### PR TITLE
IsNullable support for C# 8 nullable reference types

### DIFF
--- a/src/Roslyn/RoslynTypeMetadata.cs
+++ b/src/Roslyn/RoslynTypeMetadata.cs
@@ -104,7 +104,7 @@ namespace Typewriter.Metadata.Roslyn
                                         symbol.ToDisplayString() == "System.Collections.IEnumerable" ||
                                         symbol.AllInterfaces.Any(i =>
                                             i.ToDisplayString() == "System.Collections.IEnumerable"));
-        public bool IsNullable => isNullable;
+        public bool IsNullable => isNullable || symbol.NullableAnnotation == NullableAnnotation.Annotated;
         public bool IsTask => isTask;
 
         public static ITypeMetadata FromTypeSymbol(ITypeSymbol symbol)


### PR DESCRIPTION
In bae691d241b070cd69ada5ca267582de9b9f7064, you fixed the bug that C# 8 nullable reference types introduced. But, TypeWriter's `IsNullable` returned `false` for these types. This pull request changes `IsNullable` so that it also returns `true` for nullable reference types.

Technically, nullable reference types aren't `System.Nullable<>`, but instead have `[Nullable]` attributes that the compiler generates. However, this distinction is not relevant for Typewriter's purposes. Users of Typewriter are likely using `IsNullable` to determine if a C# property should be optional (`?`) in TypeScript, and optional properties in Typescript work for both value types and reference types. So this is why I decided to improve the existing `IsNullable` implementation instead of adding something new like "IsNullableReferenceType".