### PR TITLE
Added single file mode

### DIFF
--- a/src/CodeModel/Configuration/Settings.cs
+++ b/src/CodeModel/Configuration/Settings.cs
@@ -14,6 +14,14 @@ namespace Typewriter.Configuration
         public abstract Settings IncludeProject(string projectName);
 
         /// <summary>
+        /// Single File Mode - Template will be parsed in one file. Ignor
+        /// Note: SingleFileMode ignores the filename factory(!)
+        /// </summary>
+        /// <param name="singleFilename">The single filename.</param>
+        /// <returns></returns>
+        public abstract Settings SingleFileMode(string singleFilename);
+
+        /// <summary>
         /// Includes files in the current project when rendering the template.
         /// </summary>
         public abstract Settings IncludeCurrentProject();
@@ -60,5 +68,22 @@ namespace Typewriter.Configuration
         /// Gets or sets value indicating if generated files should not be added to project.
         /// </summary>
         public bool SkipAddingGeneratedFilesToProject { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is single file mode.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is single file mode; otherwise, <c>false</c>.
+        /// </value>
+        public abstract bool IsSingleFileMode { get; }
+
+        /// <summary>
+        /// Gets the name of the single file.
+        /// </summary>
+        /// <value>
+        /// The name of the single file.
+        /// </value>
+        public abstract string SingleFileName { get; }
+
     }
 }

--- a/src/CodeModel/Typewriter.CodeModel.XML
+++ b/src/CodeModel/Typewriter.CodeModel.XML
@@ -1398,6 +1398,14 @@
             Includes files in the specified project when rendering the template.
             </summary>
         </member>
+        <member name="M:Typewriter.Configuration.Settings.SingleFileMode(System.String)">
+            <summary>
+            Single File Mode - Template will be parsed in one file. Ignor
+            Note: SingleFileMode ignores the filename factory(!)
+            </summary>
+            <param name="singleFilename">The single filename.</param>
+            <returns></returns>
+        </member>
         <member name="M:Typewriter.Configuration.Settings.IncludeCurrentProject">
             <summary>
             Includes files in the current project when rendering the template.
@@ -1445,6 +1453,22 @@
             <summary>
             Gets or sets value indicating if generated files should not be added to project.
             </summary>
+        </member>
+        <member name="P:Typewriter.Configuration.Settings.IsSingleFileMode">
+            <summary>
+            Gets a value indicating whether this instance is single file mode.
+            </summary>
+            <value>
+              <c>true</c> if this instance is single file mode; otherwise, <c>false</c>.
+            </value>
+        </member>
+        <member name="P:Typewriter.Configuration.Settings.SingleFileName">
+            <summary>
+            Gets the name of the single file.
+            </summary>
+            <value>
+            The name of the single file.
+            </value>
         </member>
         <member name="T:Typewriter.Extensions.Types.TypeExtensions">
             <summary>

--- a/src/Tests/Render/RenderTests.cs
+++ b/src/Tests/Render/RenderTests.cs
@@ -1,6 +1,10 @@
-﻿using Microsoft.VisualStudio.Sdk.TestFramework;
+﻿using Microsoft.IO;
+using Microsoft.VisualStudio.Sdk.TestFramework;
 using Should;
+using System.Linq;
+using Typewriter.Configuration;
 using Typewriter.Generation;
+using Typewriter.Tests.Render.WebApiController;
 using Typewriter.Tests.TestInfrastructure;
 using Xunit;
 
@@ -26,7 +30,8 @@ namespace Typewriter.Tests.Render
             var nsParts = type.FullName.Remove(0, 11).Split('.');
 
             var path = string.Join(@"\", nsParts);
-
+            var tt = GetProjectItem("Tests\\Render\\WebApiController\\SingleFile.tstemplate");
+            var t2 = GetProjectItem("Tests\\Render\\WebApiController\\SingleFile.tstemplate");
             var template = new Template(GetProjectItem(path + ".tstemplate"));
             var file = GetFile(path + ".cs");
             var result = GetFileContents(path + ".result");
@@ -37,6 +42,33 @@ namespace Typewriter.Tests.Render
             output.ShouldEqual(result);
         }
 
+        [Fact]
+        public void Expect_SingleFileMode_To_Render_Correctly()
+        {
+            var ts = Path.Combine("Tests", "Render", "WebApiController", "SingleFile.tstemplate");
+            var projectItem = GetProjectItem(ts);
+           
+            var pathModels = Path.Combine("Tests","Render","WebApiController", "SingleFileModels");
+           
+            pathModels = Path.Combine(SolutionDirectory, pathModels);
+
+            string[] models = Directory.GetFiles(pathModels, "*.cs");
+
+            var files = models.Select(x => GetFile(Path.Combine(pathModels, Path.GetFileName(x)))).ToArray();
+           
+            var template = new Template(projectItem);
+
+            template.Settings.IsSingleFileMode.ShouldBeTrue();
+
+            string tpl = template.Render(files, out var success);
+
+            string resultFile = Path.Combine("Tests", "Render", "WebApiController", Path.GetFileNameWithoutExtension(ts) + ".result");
+            string content = GetFileContents(resultFile);
+            success.ShouldBeTrue();
+
+            tpl.ShouldEqual(content);
+
+        }
         //[Fact]
         //public void Expect_webapi_controller_to_angular_service_to_render_correctly()
         //{

--- a/src/Tests/Render/WebApiController/SingleFile.result
+++ b/src/Tests/Render/WebApiController/SingleFile.result
@@ -1,0 +1,10 @@
+﻿
+export class CombinedClass {
+
+public model1:string = 'Typewriter.Tests.Render.WebApiController.SingleFileModels.Model1:M1';
+
+public model2:string = 'Typewriter.Tests.Render.WebApiController.SingleFileModels.Model2:M2';
+
+public model3:string = 'Typewriter.Tests.Render.WebApiController.SingleFileModels.Model3:M3';
+
+}

--- a/src/Tests/Render/WebApiController/SingleFile.tstemplate
+++ b/src/Tests/Render/WebApiController/SingleFile.tstemplate
@@ -1,0 +1,17 @@
+﻿${
+    Template(Settings settings) {
+        
+        settings.SingleFileMode("index.d.ts");
+    
+    }
+
+    string NameAndProperties(Class cls) {
+    
+        return $"{cls.FullName}:{string.Join(",", cls.Properties.Select(x => x.Name))}";
+    }
+}
+export class CombinedClass {
+$Classes(x => x.Namespace.StartsWith("Typewriter.Tests.Render.WebApiController.SingleFileModels"))[
+public $name:string = '$NameAndProperties';
+]
+}

--- a/src/Tests/Render/WebApiController/SingleFileModels/Model1.cs
+++ b/src/Tests/Render/WebApiController/SingleFileModels/Model1.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Typewriter.Tests.Render.WebApiController.SingleFileModels
+{
+    public class Model1
+    {
+        public int M1 { get; set; }
+    }
+}

--- a/src/Tests/Render/WebApiController/SingleFileModels/Model2.cs
+++ b/src/Tests/Render/WebApiController/SingleFileModels/Model2.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Typewriter.Tests.Render.WebApiController.SingleFileModels
+{
+    public class Model2
+    {
+        public int M2 { get; set; } 
+    }
+}

--- a/src/Tests/Render/WebApiController/SingleFileModels/Model3.cs
+++ b/src/Tests/Render/WebApiController/SingleFileModels/Model3.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Typewriter.Tests.Render.WebApiController.SingleFileModels
+{
+    public class Model3
+    {
+        public int M3 { get; set; }
+    }
+}

--- a/src/Tests/Typewriter.Tests.csproj
+++ b/src/Tests/Typewriter.Tests.csproj
@@ -84,6 +84,9 @@
     <Compile Include="Metadata\Roslyn\RoslynClassMetadataTests.cs" />
     <Compile Include="Metadata\Support\GeneratedClass.cs" />
     <Compile Include="Metadata\Support\GeneratedClass.Additional.cs" />
+    <Compile Include="Render\WebApiController\SingleFileModels\Model1.cs" />
+    <Compile Include="Render\WebApiController\SingleFileModels\Model2.cs" />
+    <Compile Include="Render\WebApiController\SingleFileModels\Model3.cs" />
     <Compile Include="Support\AcceptVerbsAttribute.cs" />
     <Compile Include="TestInfrastructure\RoslynFixture.cs" />
     <Compile Include="TestInfrastructure\Dte.cs" />
@@ -109,6 +112,8 @@
   <ItemGroup>
     <None Include="Render\RoutedApiController\BooksController.result" />
     <None Include="Render\RoutedApiController\BooksController.tstemplate" />
+    <None Include="Render\WebApiController\SingleFile.result" />
+    <None Include="Render\WebApiController\SingleFile.tstemplate" />
     <None Include="Render\WebApiController\WebApiController.result" />
     <None Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Typewriter/CodeModel/Configuration/SettingsImpl.cs
+++ b/src/Typewriter/CodeModel/Configuration/SettingsImpl.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using EnvDTE;
+using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Typewriter.Configuration;
 
@@ -8,6 +9,9 @@ namespace Typewriter.CodeModel.Configuration
     public class SettingsImpl : Settings
     {
         private readonly ProjectItem _projectItem;
+
+        private bool _isSingleFileMode = false;
+        private string _singleFileName = null;
 
         public SettingsImpl(ProjectItem projectItem)
         {
@@ -24,7 +28,15 @@ namespace Typewriter.CodeModel.Configuration
             ProjectHelpers.AddProject(_projectItem, _includedProjects, projectName);
             return this;
         }
-        
+
+        public override Settings SingleFileMode(string singleFilename)
+        {
+            this._isSingleFileMode= true;
+            this._singleFileName= singleFilename;
+
+            return this;
+        }
+
         public override Settings IncludeReferencedProjects()
         {
             if (_includedProjects == null)
@@ -87,5 +99,21 @@ namespace Typewriter.CodeModel.Configuration
                 return fullName;
             }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether this instance is single file mode.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is single file mode; otherwise, <c>false</c>.
+        /// </value>
+        public override bool IsSingleFileMode => this._isSingleFileMode;
+
+        /// <summary>
+        /// Gets the name of the single file.
+        /// </summary>
+        /// <value>
+        /// The name of the single file.
+        /// </value>
+        public override string SingleFileName => this._singleFileName;
     }
 }

--- a/src/Typewriter/Generation/SingleFileParser.cs
+++ b/src/Typewriter/Generation/SingleFileParser.cs
@@ -1,0 +1,352 @@
+﻿using EnvDTE;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Remoting.Contexts;
+using System.Text;
+using System.Threading.Tasks;
+using Typewriter.CodeModel;
+using Typewriter.TemplateEditor.Lexing;
+using Typewriter.VisualStudio;
+using Type = System.Type;
+
+namespace Typewriter.Generation
+{
+    public class SingleFileParser
+    {
+        public static string Parse(ProjectItem projectItem, File[] files, string template, List<Type> extensions, out bool success)
+        {
+            var instance = new SingleFileParser(extensions);
+            var output = instance.ParseTemplate(projectItem, template, files);
+            success = instance.hasError == false;
+
+            return instance.matchFound ? output : null;
+        }
+
+        private readonly List<Type> extensions;
+        private bool matchFound;
+        private bool hasError;
+
+        private SingleFileParser(List<Type> extensions)
+        {
+            this.extensions = extensions;
+        }
+
+        private string ParseTemplate(ProjectItem projectItem, string template, File[] files, object context = null)
+        {
+            if (string.IsNullOrEmpty(template)) return null;
+
+            var output = string.Empty;
+            var stream = new Stream(template);
+
+            while (stream.Advance())
+            {
+                if (ParseDollar(projectItem, template, files, stream, context, ref output)) continue;
+                output += stream.Current;
+            }
+
+            return output;
+        }
+
+        private bool ParseDollar(ProjectItem projectItem, string template, File[] files, Stream stream, object context, ref string output)
+        {
+            if (stream.Current == '$')
+            {
+                var identifier = stream.PeekWord(1);
+
+                var blockStream  = 
+
+                stream.Advance(identifier.Length);
+                int advance = 0;
+                int offset = stream.Position + 1;
+                foreach (var f in files)
+                {
+
+                    // Create new stream for each file
+                    var innerStream = new Stream(template);
+                    innerStream.Advance(offset);
+                   
+
+                    string sourcePath = f.FullName;
+                    context = f;
+
+                    if (TryGetIdentifier(projectItem, sourcePath, identifier, context, out var value))
+                    {
+                         
+                        if (value is IEnumerable<Item> collection)
+                        {
+                            var filter = ParseBlock(innerStream, '(', ')');
+                            var block = ParseBlock(innerStream, '[', ']');
+                            var separator = ParseBlock(innerStream, '[', ']');
+
+                            if (filter == null && block == null && separator == null)
+                            {
+                                var stringValue = value.ToString();
+
+                                if (stringValue != value.GetType().FullName)
+                                    output += stringValue;
+                                else
+                                    output += "$" + identifier;
+                            }
+                            else
+                            {
+                                IEnumerable<Item> items;
+                                if (filter != null && filter.StartsWith("$", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    var predicate = filter.Remove(0, 1);
+                                    if (extensions != null)
+                                    {
+                                        // Lambda filters are always defined in the first extension type
+                                        var c = extensions.FirstOrDefault()?.GetMethod(predicate);
+                                        if (c != null)
+                                        {
+                                            try
+                                            {
+                                                items = collection.Where(x => (bool)c.Invoke(null, new object[] { x })).ToList();
+                                                matchFound = matchFound || items.Any();
+                                            }
+                                            catch (Exception e)
+                                            {
+                                                items = Array.Empty<Item>();
+                                                hasError = true;
+
+                                                var message = $"Error rendering template. Cannot apply filter to identifier '{identifier}'.";
+                                                LogException(e, message, projectItem, sourcePath);
+                                            }
+                                        }
+                                        else
+                                        {
+                                            items = Array.Empty<Item>();
+                                        }
+                                    }
+                                    else
+                                    {
+                                        items = Array.Empty<Item>();
+                                    }
+                                }
+                                else
+                                {
+                                    items = ItemFilter.Apply(collection, filter, ref matchFound);
+                                }
+                                output += string.Join(ParseTemplate(projectItem, sourcePath, separator, context), items.Select(item => ParseTemplate(projectItem, sourcePath, block, item)));
+                            }
+                        }
+                        else if (value is bool)
+                        {
+                            var trueBlock = ParseBlock(innerStream, '[', ']');
+                            var falseBlock = ParseBlock(innerStream, '[', ']');
+
+                            output += ParseTemplate(projectItem, sourcePath, (bool)value ? trueBlock : falseBlock, context);
+                        }
+                        else
+                        {
+                            var block = ParseBlock(innerStream, '[', ']');
+                            if (value != null)
+                            {
+                                if (block != null)
+                                {
+                                    output += ParseTemplate(projectItem, sourcePath, block, value);
+                                }
+                                else
+                                {
+                                    output += value.ToString();
+                                }
+                            }
+                        } 
+                    }
+
+                    advance = innerStream.Position+1;
+                }
+
+                bool canAdvance = stream.Advance(advance - offset);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static string ParseBlock(Stream stream, char open, char close)
+        {
+            if (stream.Peek() == open)
+            {
+                var block = stream.PeekBlock(2, open, close);
+
+                stream.Advance(block.Length);
+                stream.Advance(stream.Peek(2) == close ? 2 : 1);
+
+                return block;
+            }
+
+            return null;
+        }
+
+        private bool TryGetIdentifier(ProjectItem projectItem, string sourcePath, string identifier, object context, out object value)
+        {
+            value = null;
+
+            if (identifier == null) return false;
+
+            var type = context.GetType();
+
+            try
+            {
+                var property = type.GetProperty(identifier);
+                if (property != null)
+                {
+                    value = property.GetValue(context);
+                    return true;
+                }
+
+                var extension = extensions.Select(e => e.GetMethod(identifier, new[] { type })).FirstOrDefault(m => m != null);
+                if (extension != null)
+                {
+                    value = extension.Invoke(null, new[] { context });
+                    return true;
+                }
+            }
+            catch (Exception e)
+            {
+                hasError = true;
+
+                var message = $"Error rendering template. Cannot get identifier '{identifier}'.";
+                LogException(e, message, projectItem, sourcePath);
+            }
+
+            return false;
+        }
+
+        private void LogException(Exception exception, string message, ProjectItem projectItem, string sourcePath)
+        {
+            // skip the target invokation exception, get the real exception instead.
+            if (exception is TargetInvocationException && exception.InnerException != null)
+            {
+                exception = exception.InnerException;
+            }
+
+            var studioMessage = $"{message} Error: {exception.Message}. Source path: {sourcePath}. See Typewriter output for more detail.";
+            var logMessage = $"{message} Source path: {sourcePath}{Environment.NewLine}{exception}";
+
+            Log.Error(logMessage);
+            ErrorList.AddError(projectItem, studioMessage);
+            ErrorList.Show();
+        }
+
+
+        private string ParseTemplate(ProjectItem projectItem, string sourcePath, string template, object context)
+        {
+            if (string.IsNullOrEmpty(template)) return null;
+
+            var output = string.Empty;
+            var stream = new Stream(template);
+
+            while (stream.Advance())
+            {
+                if (ParseDollar(projectItem, sourcePath, stream, context, ref output)) continue;
+                output += stream.Current;
+            }
+
+            return output;
+        }
+
+        private bool ParseDollar(ProjectItem projectItem, string sourcePath, Stream stream, object context, ref string output)
+        {
+            if (stream.Current == '$')
+            {
+                var identifier = stream.PeekWord(1);
+
+                if (TryGetIdentifier(projectItem, sourcePath, identifier, context, out var value))
+                {
+                    stream.Advance(identifier.Length);
+
+                    if (value is IEnumerable<Item> collection)
+                    {
+                        var filter = ParseBlock(stream, '(', ')');
+                        var block = ParseBlock(stream, '[', ']');
+                        var separator = ParseBlock(stream, '[', ']');
+
+                        if (filter == null && block == null && separator == null)
+                        {
+                            var stringValue = value.ToString();
+
+                            if (stringValue != value.GetType().FullName)
+                                output += stringValue;
+                            else
+                                output += "$" + identifier;
+                        }
+                        else
+                        {
+                            IEnumerable<Item> items;
+                            if (filter != null && filter.StartsWith("$", StringComparison.OrdinalIgnoreCase))
+                            {
+                                var predicate = filter.Remove(0, 1);
+                                if (extensions != null)
+                                {
+                                    // Lambda filters are always defined in the first extension type
+                                    var c = extensions.FirstOrDefault()?.GetMethod(predicate);
+                                    if (c != null)
+                                    {
+                                        try
+                                        {
+                                            items = collection.Where(x => (bool)c.Invoke(null, new object[] { x })).ToList();
+                                            matchFound = matchFound || items.Any();
+                                        }
+                                        catch (Exception e)
+                                        {
+                                            items = Array.Empty<Item>();
+                                            hasError = true;
+
+                                            var message = $"Error rendering template. Cannot apply filter to identifier '{identifier}'.";
+                                            LogException(e, message, projectItem, sourcePath);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        items = Array.Empty<Item>();
+                                    }
+                                }
+                                else
+                                {
+                                    items = Array.Empty<Item>();
+                                }
+                            }
+                            else
+                            {
+                                items = ItemFilter.Apply(collection, filter, ref matchFound);
+                            }
+                            output += string.Join(ParseTemplate(projectItem, sourcePath, separator, context), items.Select(item => ParseTemplate(projectItem, sourcePath, block, item)));
+                        }
+                    }
+                    else if (value is bool)
+                    {
+                        var trueBlock = ParseBlock(stream, '[', ']');
+                        var falseBlock = ParseBlock(stream, '[', ']');
+
+                        output += ParseTemplate(projectItem, sourcePath, (bool)value ? trueBlock : falseBlock, context);
+                    }
+                    else
+                    {
+                        var block = ParseBlock(stream, '[', ']');
+                        if (value != null)
+                        {
+                            if (block != null)
+                            {
+                                output += ParseTemplate(projectItem, sourcePath, block, value);
+                            }
+                            else
+                            {
+                                output += value.ToString();
+                            }
+                        }
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/src/Typewriter/Generation/Template.cs
+++ b/src/Typewriter/Generation/Template.cs
@@ -119,6 +119,21 @@ namespace Typewriter.Generation
             }
         }
 
+        public string Render(File[] files, out bool success)
+        {
+            try
+            {
+                return SingleFileParser.Parse(_projectItem, files, _template.Value, _customExtensions, out success);
+
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex.Message + " Template: " + _templatePath);
+                success = false;
+                return null;
+            }
+        }
+
         public bool RenderFile(File file)
         {
             var output = Render(file, out var success);
@@ -133,6 +148,23 @@ namespace Typewriter.Generation
                 {
                     SaveFile(file, output, ref success);
                 }
+            }
+
+            return success;
+        }
+
+
+        public bool RenderFile(File[] files)
+        {
+            var output = Render(files, out var success);
+
+            if (success)
+            {
+                string outputdir = GetOutputDirectory();
+
+                string singleFileName = this.Settings.SingleFileName;
+
+                WriteFile(Path.Combine(outputdir, singleFileName), output);
             }
 
             return success;

--- a/src/Typewriter/Typewriter.csproj
+++ b/src/Typewriter/Typewriter.csproj
@@ -66,6 +66,7 @@
     <Compile Include="CodeModel\Implementation\RecordImpl.cs" />
     <Compile Include="CodeModel\Implementation\TypeParameterImpl.cs" />
     <Compile Include="Generation\Controllers\BlockingQueue.cs" />
+    <Compile Include="Generation\SingleFileParser.cs" />
     <Compile Include="Generation\SolutionFilesHelper.cs" />
     <Compile Include="Properties\SharedAssemblyInfo.cs" />
     <Compile Include="CodeModel\Collections\AttributeCollectionImpl.cs" />


### PR DESCRIPTION
Added single file mode as option to generate files like Modules or index files. Here are a few example of use cases:

**Example 1:** 
I want to generate an NG Module out of my generated files. I use the same helper functions to  generate the class names etc.

The TST File looks like this:
```typescript
${
    Template(Settings settings) {
        
        settings.SingleFileMode("api.module.ts");
    
    }

    string GenerateServiceNameOutOfControllerClass(Class cls) {
            
            string name = cls.Name.Substring(0, cls.Name.IndexOf("Controller"));

            return name;
    
    }
}
import { NgModule } from '@angular/core';
import { CommonModule } from '@angular/common';

@NgModule({
  imports: [
    CommonModule
  ],
  declarations: [],
  providers: [
    $Classes(x => x.Namespace.StartsWith("TypewriterTestApp.Controllers"))[
        $GenerateServiceNameOutOfControllerClass][,]  
  ]
})
export class CustomerDashboardModule { }   
```

Please note: Single File Mode is activated by `Settings.SingleFileMode("filename")`

Given I have 2 Controllers in the Namespace `TypewriterTestApp.Controllers` the file results as "api.module.ts" like:

```typescript
import { NgModule } from '@angular/core';
import { CommonModule } from '@angular/common';

@NgModule({
  imports: [
    CommonModule
  ],
  declarations: [],
  providers: [
    
        Settings,
        UserApi  
  ]
})
export class CustomerDashboardModule { }   
```


**Example 2**
I want to create an index.d.ts. I use the same path helper and name helper

The Template looking like this:

```typescript
${
    Template(Settings settings) {
        
        settings.SingleFileMode("index.ts");
    
    }

    string GenerateServiceNameOutOfControllerClass(Class cls) {
            
            string name = cls.Name.Substring(0, cls.Name.IndexOf("Controller"));

            return name;
    
    }

    string GetTsPath(Class cls) {
        return $"./clients/{cls.name}.client.ts";
    }
}
// Index TS for all api clients
$Classes(x => x.Namespace.StartsWith("TypewriterTestApp.Controllers"))[
export *  from '$GetTsPath';
]
```

Will result in index.ts like:
```typescript

// Index TS for all api clients

export *  from './clients/settingsController.client.ts';

export *  from './clients/userApiController.client.ts';

```


Please note: Single File Usage can demand more RAM depending on the filter set.

The SingleFileParser is fully tested.