### PR TITLE
Fixed IsDate property for nullable DateTime and DateTimeOffset

### DIFF
--- a/src/Typewriter/CodeModel/Implementation/TypeImpl.cs
+++ b/src/Typewriter/CodeModel/Implementation/TypeImpl.cs
@@ -47,7 +47,7 @@ namespace Typewriter.CodeModel.Implementation
 
         public override bool IsPrimitive => IsPrimitive(_metadata);
 
-        public override bool IsDate => string.Equals(Name, "Date", StringComparison.OrdinalIgnoreCase);
+        public override bool IsDate => string.Equals(Name, "Date", StringComparison.OrdinalIgnoreCase) || string.Equals(Name, "Date | null", StringComparison.OrdinalIgnoreCase);
 
         public override bool IsDefined => _metadata.IsDefined;
 


### PR DESCRIPTION
This fix is ​​needed to make the following code work again:
```cs
if (p.Type.IsDate) {
    if (p.Type.IsNullable) {
        ...
    }
}
```
Also, instead of `encodeURIComponent({name})`, `encodeURIComponent(String({name}))` will now be generated again for `DateTime?`.