### PR TITLE
Add FileLocation property to Type class

### DIFF
--- a/src/CodeModel/CodeModel/Type.cs
+++ b/src/CodeModel/CodeModel/Type.cs
@@ -16,6 +16,11 @@ namespace Typewriter.CodeModel
         public abstract string AssemblyName { get; }
 
         /// <summary>
+        /// The file paths this type is defined in.  There may be more than one if the type is a partial class.
+        /// </summary>
+        public abstract IEnumerable<string> FileLocations { get; }
+
+        /// <summary>
         /// All attributes defined on the type.
         /// </summary>
         public abstract IAttributeCollection Attributes { get; }

--- a/src/Metadata/Interfaces/ITypeMetadata.cs
+++ b/src/Metadata/Interfaces/ITypeMetadata.cs
@@ -22,6 +22,8 @@ namespace Typewriter.Metadata.Interfaces
 
         IEnumerable<IFieldMetadata> TupleElements { get; }
 
+        IEnumerable<string> FileLocations { get; }
+
         string DefaultValue { get; }
     }
 }

--- a/src/Roslyn/RoslynClassMetadata.cs
+++ b/src/Roslyn/RoslynClassMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/Roslyn/RoslynTypeMetadata.cs
+++ b/src/Roslyn/RoslynTypeMetadata.cs
@@ -47,6 +47,8 @@ namespace Typewriter.Metadata.Roslyn
 
         public string DefaultValue { get; set; }
 
+        public IEnumerable<string> FileLocations => _symbol.Locations.Select(l => l.SourceTree.FilePath);
+
         public IEnumerable<IAttributeMetadata> Attributes => RoslynAttributeMetadata.FromAttributeData(_symbol.GetAttributes(), Settings);
 
         public IClassMetadata BaseClass => RoslynClassMetadata.FromNamedTypeSymbol(_symbol.BaseType, Settings);

--- a/src/Roslyn/RoslynVoidTaskMetadata.cs
+++ b/src/Roslyn/RoslynVoidTaskMetadata.cs
@@ -74,5 +74,7 @@ namespace Typewriter.Metadata.Roslyn
         public IEnumerable<ITypeParameterMetadata> TypeParameters => Array.Empty<ITypeParameterMetadata>();
 
         public IEnumerable<IFieldMetadata> TupleElements => Array.Empty<IFieldMetadata>();
+
+        public IEnumerable<string> FileLocations => Type.FileLocations;
     }
 }

--- a/src/Typewriter/CodeModel/Implementation/TypeImpl.cs
+++ b/src/Typewriter/CodeModel/Implementation/TypeImpl.cs
@@ -145,6 +145,8 @@ namespace Typewriter.CodeModel.Implementation
 
         public override IInterfaceCollection NestedInterfaces => _nestedInterfaces ?? (_nestedInterfaces = InterfaceImpl.FromMetadata(_metadata.NestedInterfaces, this, Settings));
 
+        public override IEnumerable<string> FileLocations => _metadata.FileLocations;
+
         public override Settings Settings { get; }
 
         public override string ToString()


### PR DESCRIPTION
This will allow users to generate accurate import paths, even for files containing multiple classes.