### PR TITLE
Expose Interface.Type

### DIFF
--- a/src/CodeModel/CodeModel/Interface.cs
+++ b/src/CodeModel/CodeModel/Interface.cs
@@ -101,7 +101,7 @@ namespace Typewriter.CodeModel
         /// <summary>
         /// Represents a <see cref="Typewriter.CodeModel.Type"/>.
         /// </summary>
-        protected abstract Type Type { get; }
+        public abstract Type Type { get; }
 
         /// <summary>
         /// Converts the current instance to string.

--- a/src/Typewriter/CodeModel/Implementation/InterfaceImpl.cs
+++ b/src/Typewriter/CodeModel/Implementation/InterfaceImpl.cs
@@ -36,7 +36,7 @@ namespace Typewriter.CodeModel.Implementation
 
         private Type _type;
 
-        protected override Type Type => _type ?? (_type = TypeImpl.FromMetadata(_metadata.Type, Parent, Settings));
+        public override Type Type => _type ?? (_type = TypeImpl.FromMetadata(_metadata.Type, Parent, Settings));
 
         private IAttributeCollection _attributes;
 


### PR DESCRIPTION
I'm really curious, why was this protected instead of public?