### PR TITLE
Fix attribute parsing crash when handling value with non-string first parameter

### DIFF
--- a/src/Roslyn/RoslynAttributeMetadata.cs
+++ b/src/Roslyn/RoslynAttributeMetadata.cs
@@ -27,17 +27,11 @@ namespace Typewriter.Metadata.Roslyn
                 _value = declaration.Substring(index + 1, declaration.Length - index - 2);
 
                 // Trim {} from params
-                if (_value.EndsWith("\"}", StringComparison.OrdinalIgnoreCase))
-                {
-                    _value = _value.Remove(_value.LastIndexOf("{\"", StringComparison.Ordinal), 1);
-                    _value = _value.TrimEnd('}');
-                }
-                else if (_value.EndsWith("}", StringComparison.OrdinalIgnoreCase))
+                if (_value.EndsWith("\"}", StringComparison.OrdinalIgnoreCase) || _value.EndsWith("}", StringComparison.OrdinalIgnoreCase))
                 {
                     _value = _value.Remove(_value.LastIndexOf("{", StringComparison.Ordinal), 1);
                     _value = _value.TrimEnd('}');
                 }
-            }
 
             if (_name.EndsWith("Attribute", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Roslyn/RoslynAttributeMetadata.cs
+++ b/src/Roslyn/RoslynAttributeMetadata.cs
@@ -32,7 +32,7 @@ namespace Typewriter.Metadata.Roslyn
                     _value = _value.Remove(_value.LastIndexOf("{", StringComparison.Ordinal), 1);
                     _value = _value.TrimEnd('}');
                 }
-
+            }
             if (_name.EndsWith("Attribute", StringComparison.OrdinalIgnoreCase))
             {
                 _name = _name.Substring(0, _name.Length - 9);


### PR DESCRIPTION
This PR fixes a crash in `RoslynAttributeMetadata` when parsing attributes such as `AllowedValuesAttribute` whose parameter list starts with a non-string value (e.g. `null`).

Previously, the code assumed that the attribute parameter list would look like `{"Foo"}` and searched for the substring `{"` before trimming braces. When the parameter list instead looks like `{null, "Foo"}`, this assumption no longer holds and the code throws an `ArgumentOutOfRangeException` from `String.Remove`.

The logic is updated to look for the opening { regardless of whether the first parameter is a string literal.

**Notes**:
I'm unable to run tests locally (#48), so I'm not sure this PR isn't breaking.

Closes #55