### PR TITLE
fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,22 +94,18 @@ jobs:
 
           npm --prefix vscode version $env:VERSION --no-git-tag-version --allow-same-version
 
-          foreach ($projectPath in @(
-            "src/Typewriter.Cli/Typewriter.Cli.csproj",
-            "src/Typewriter.LanguageServer/Typewriter.LanguageServer.csproj"
-          )) {
-            $resolvedPath = (Resolve-Path -LiteralPath $projectPath).Path
-            $project = New-Object System.Xml.XmlDocument
-            $project.PreserveWhitespace = $true
-            $project.Load($resolvedPath)
-            $versionNode = $project.SelectSingleNode("/*[local-name()='Project']/*[local-name()='PropertyGroup']/*[local-name()='Version']")
-            if ($null -eq $versionNode) {
-              throw "Unable to find Version in $projectPath."
-            }
-
-            $versionNode.InnerText = $env:VERSION
-            $project.Save($resolvedPath)
+          $directoryBuildPropsPath = "Directory.Build.props"
+          $resolvedDirectoryBuildPropsPath = (Resolve-Path -LiteralPath $directoryBuildPropsPath).Path
+          $directoryBuildProps = New-Object System.Xml.XmlDocument
+          $directoryBuildProps.PreserveWhitespace = $true
+          $directoryBuildProps.Load($resolvedDirectoryBuildPropsPath)
+          $versionNode = $directoryBuildProps.SelectSingleNode("/*[local-name()='Project']/*[local-name()='PropertyGroup']/*[local-name()='Version']")
+          if ($null -eq $versionNode) {
+            throw "Unable to find Version in $directoryBuildPropsPath."
           }
+
+          $versionNode.InnerText = $env:VERSION
+          $directoryBuildProps.Save($resolvedDirectoryBuildPropsPath)
 
           $manifestPath = "src/Typewriter.VisualStudio/source.extension.vsixmanifest"
           $resolvedManifestPath = (Resolve-Path -LiteralPath $manifestPath).Path


### PR DESCRIPTION
This pull request updates the release workflow to simplify how the version number is set for .NET projects. Instead of updating the version in each individual `.csproj` file, the workflow now updates the version in the central `Directory.Build.props` file, which is a more maintainable approach.

**Release workflow improvements:**

* The script in `.github/workflows/release.yml` was refactored to update the version in `Directory.Build.props` instead of iterating over each project file, reducing redundancy and making version management easier.