### PR TITLE
added structs and indexers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ErrorLog>$(MSBuildThisFileDirectory).sarif\$(MSBuildProjectName).json</ErrorLog>
-    <Version>4.0.0</Version>
+    <Version>4.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ choose a tag, expand **Assets**, then install the matching package.
 The CLI and language server are also published to NuGet as dotnet tools:
 
 ```bash
-dotnet tool install --global AdaskoTheBeAsT.Typewriter.Cli --prerelease
-dotnet tool install --global AdaskoTheBeAsT.Typewriter.LanguageServer --prerelease
+dotnet tool install --global AdaskoTheBeAsT.Typewriter.Cli
+dotnet tool install --global AdaskoTheBeAsT.Typewriter.LanguageServer
 typewriter --help
 ```
 
@@ -352,6 +352,7 @@ Templates are `.tst` files using the original Typewriter dialect — existing te
 | `$Classes(filter)[...]`                              | Render block for every matching class (also `$Records`, `$Structs`, `$Interfaces`, `$Enums`, `$Delegates`)          |
 | `$Properties[...][separator]`                        | Iterate members, including indexers (also `$Methods`, `$Parameters`, `$Fields`, `$Constants`, `$Events`, `$Values`) |
 | `$Name`, `$name`, `$FullName`, `$Namespace`, `$Type` | Scalar substitutions (lowercase first letter via `$name`)                                                           |
+| `$$`                                                 | Render one literal `$`, for example `$$type` outputs `$type` without treating it as a template member               |
 | `(*Model)`, `([Attribute])`, `(c => c.IsPublic)`     | Wildcard, attribute, and lambda filters                                                                             |
 | `$IsNullable[yes][no]`                               | Conditional true/false blocks                                                                                       |
 | `${ ... }`                                           | Compiled C# helper block — write real C# methods used by the template                                               |
@@ -828,6 +829,7 @@ dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj --config
 
 - Added struct metadata and template rendering through `$Structs[...]`, `$Types(Struct)[...]`, CodeModel `Struct`, and LSP/editor completions.
 - Added indexer metadata through `Property.IsIndexer` and property-level `$Parameters[...]`, intended for lookup-style API generation rather than JSON DTO payloads.
+- Added literal dollar escaping with `$$`, so templates can emit `$type`, `${...}`, and other TypeScript dollar syntax without triggering template member lookup.
 - Added tests that cover Roslyn extraction, template rendering, CodeModel parity, and language-server completions for structs and indexers.
 
 ---

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
     - [🌱 Environment variables](#-environment-variables)
   - [📝 Template Authoring](#-template-authoring)
     - [Core syntax](#core-syntax)
+    - [Struct and indexer templates](#struct-and-indexer-templates)
     - [Sharing logic between templates: `#load` vs `#r`](#sharing-logic-between-templates-load-vs-r)
     - [Compiled C# helpers](#compiled-c-helpers)
     - [Shared helpers and render completion hooks](#shared-helpers-and-render-completion-hooks)
@@ -62,6 +63,8 @@
   - [🏗️ Architecture](#️-architecture)
   - [🔨 Building from Source](#-building-from-source)
   - [🗺 Project Status and Roadmap](#-project-status-and-roadmap)
+  - [Changelog](#changelog)
+    - [4.1.0](#410)
   - [🤝 Contributing](#-contributing)
   - [🐛 Issues and Support](#-issues-and-support)
   - [🙏 Acknowledgments](#-acknowledgments)
@@ -344,16 +347,84 @@ Templates are `.tst` files using the original Typewriter dialect — existing te
 
 ### Core syntax
 
-| Construct                                            | Meaning                                                                                          |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `$Classes(filter)[...]`                              | Render block for every matching class (also `$Records`, `$Interfaces`, `$Enums`, `$Delegates`)   |
-| `$Properties[...][separator]`                        | Iterate members (also `$Methods`, `$Parameters`, `$Fields`, `$Constants`, `$Events`, `$Values`)  |
-| `$Name`, `$name`, `$FullName`, `$Namespace`, `$Type` | Scalar substitutions (lowercase first letter via `$name`)                                        |
-| `(*Model)`, `([Attribute])`, `(c => c.IsPublic)`     | Wildcard, attribute, and lambda filters                                                          |
-| `$IsNullable[yes][no]`                               | Conditional true/false blocks                                                                    |
-| `${ ... }`                                           | Compiled C# helper block — write real C# methods used by the template                            |
-| `#r "nuget: PackageId, 1.2.3"`                       | Reference DLLs or NuGet packages (restored automatically) from helper code                       |
-| `#load "shared-helpers.cs"`                          | Include shared C# source helper members from a file relative to the current template/helper file |
+| Construct                                            | Meaning                                                                                                             |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `$Classes(filter)[...]`                              | Render block for every matching class (also `$Records`, `$Structs`, `$Interfaces`, `$Enums`, `$Delegates`)          |
+| `$Properties[...][separator]`                        | Iterate members, including indexers (also `$Methods`, `$Parameters`, `$Fields`, `$Constants`, `$Events`, `$Values`) |
+| `$Name`, `$name`, `$FullName`, `$Namespace`, `$Type` | Scalar substitutions (lowercase first letter via `$name`)                                                           |
+| `(*Model)`, `([Attribute])`, `(c => c.IsPublic)`     | Wildcard, attribute, and lambda filters                                                                             |
+| `$IsNullable[yes][no]`                               | Conditional true/false blocks                                                                                       |
+| `${ ... }`                                           | Compiled C# helper block — write real C# methods used by the template                                               |
+| `#r "nuget: PackageId, 1.2.3"`                       | Reference DLLs or NuGet packages (restored automatically) from helper code                                          |
+| `#load "shared-helpers.cs"`                          | Include shared C# source helper members from a file relative to the current template/helper file                    |
+
+### Struct and indexer templates
+
+Version `4.1.0` adds first-class struct and indexer support. Structs are useful for DTO generation when your serializer can read and write them. Indexers are exposed for template completeness and lookup-style TypeScript APIs, but they are not JSON payload properties.
+
+Use `$Structs[...]` when value types should be generated separately from classes and records:
+
+```typescript
+$Structs[
+export interface $Name {
+$Properties[
+    $name: $Type;]
+}
+]
+```
+
+You can also filter all available types to structs:
+
+```typescript
+$Types(Struct)[
+export type $NameValue = $Properties[$Type][ | ];
+]
+```
+
+Indexer properties are included in `$Properties[...]`. Use `$IsIndexer` to distinguish them from normal properties, and render indexer parameters through `$Parameters[...]`:
+
+```typescript
+$Classes[
+export interface $NameLookup {
+$Properties[
+    $IsIndexer[
+    get($Parameters[$name: $Type][, ]): $Type;
+    ][
+    $name: $Type;
+    ]]
+}
+]
+```
+
+For this C# type:
+
+```csharp
+public sealed class LocalizedText
+{
+    public string Default { get; init; } = string.Empty;
+
+    public string this[string culture] => Default;
+}
+
+public readonly struct Money
+{
+    public decimal Amount { get; init; }
+    public string Currency { get; init; }
+}
+```
+
+Templates can now generate both the `Money` value shape and a typed lookup signature for `LocalizedText`.
+
+> Indexer note: `System.Text.Json` and Newtonsoft.Json do not deserialize indexers as normal object properties. If the lookup values must round-trip through JSON, expose a real property and generate from that instead:
+
+```csharp
+public sealed class LocalizedTextDto
+{
+    public Dictionary<string, string> Values { get; init; } = [];
+}
+```
+
+Then generate the TypeScript dictionary shape from `Values`, for example `Record<string, string>`.
 
 ### Sharing logic between templates: `#load` vs `#r`
 
@@ -748,6 +819,16 @@ dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj --config
 - 📗 [`implemented.md`](implemented.md) — everything that is done, in detail
 - 📙 [`to_implement.md`](to_implement.md) — roadmap and backlog
 - 📕 [`compatibility.md`](compatibility.md) — original-Typewriter parity status
+
+---
+
+## Changelog
+
+### 4.1.0
+
+- Added struct metadata and template rendering through `$Structs[...]`, `$Types(Struct)[...]`, CodeModel `Struct`, and LSP/editor completions.
+- Added indexer metadata through `Property.IsIndexer` and property-level `$Parameters[...]`, intended for lookup-style API generation rather than JSON DTO payloads.
+- Added tests that cover Roslyn extraction, template rendering, CodeModel parity, and language-server completions for structs and indexers.
 
 ---
 

--- a/samples/SignalRHubs/SignalRHubs.tst
+++ b/samples/SignalRHubs/SignalRHubs.tst
@@ -100,7 +100,7 @@ $Classes($IncludeClass)[
 export class $ServiceName {
   readonly url = '$GetHubRouteValue';
 $Methods($IncludeHubMethod)[
-  $MethodName($SkipParameters[$name: $Type][, ]): $IsStreamingMethod[Observable<$StreamReturnType>]$IsInvokeMethod[Promise<$InvokeReturnType>] {
+  $MethodName$IsStreamingMethod[$$]($SkipParameters[$name: $Type][, ]): $IsStreamingMethod[Observable<$StreamReturnType>]$IsInvokeMethod[Promise<$InvokeReturnType>] {
     return '$SignalRMethodName'$InvocationArguments;
   }]
 }]

--- a/samples/SignalRHubs/generated/signalr-chat.service.ts
+++ b/samples/SignalRHubs/generated/signalr-chat.service.ts
@@ -8,7 +8,7 @@ export class SignalRChatService {
   invokeSendAsync(message: string): Promise<void> {
     return 'SendMessage', message;
   }
-  streamStreamMessages(room: string): Observable<ChatMessage> {
+  streamStreamMessages$(room: string): Observable<ChatMessage> {
     return 'StreamMessages', room;
   }
 }

--- a/src/Typewriter.Abstractions/ParameterMetadata.cs
+++ b/src/Typewriter.Abstractions/ParameterMetadata.cs
@@ -16,4 +16,6 @@ public sealed record ParameterMetadata(
     public string? Documentation { get; init; }
 
     public DocCommentMetadata? DocComment { get; init; }
+
+    public string ParentPropertyFullName { get; init; } = string.Empty;
 }

--- a/src/Typewriter.Abstractions/PropertyMetadata.cs
+++ b/src/Typewriter.Abstractions/PropertyMetadata.cs
@@ -22,5 +22,9 @@ public sealed record PropertyMetadata(
 
     public bool IsAbstract { get; init; }
 
+    public bool IsIndexer { get; init; }
+
     public bool IsVirtual { get; init; }
+
+    public IReadOnlyList<ParameterMetadata> Parameters { get; init; } = [];
 }

--- a/src/Typewriter.Abstractions/TypeMetadata.cs
+++ b/src/Typewriter.Abstractions/TypeMetadata.cs
@@ -48,6 +48,8 @@ public sealed record TypeMetadata(
 
     public IReadOnlyList<TypeMetadata> NestedRecords { get; init; } = [];
 
+    public IReadOnlyList<TypeMetadata> NestedStructs { get; init; } = [];
+
     public IReadOnlyList<TypeMetadata> NestedEnums { get; init; } = [];
 
     public IReadOnlyList<TypeMetadata> NestedInterfaces { get; init; } = [];

--- a/src/Typewriter.Abstractions/TypeMetadataKind.cs
+++ b/src/Typewriter.Abstractions/TypeMetadataKind.cs
@@ -4,6 +4,7 @@ public enum TypeMetadataKind
 {
     Class,
     Record,
+    Struct,
     Interface,
     Enum,
 }

--- a/src/Typewriter.Engine/CodeModel/Class.cs
+++ b/src/Typewriter.Engine/CodeModel/Class.cs
@@ -38,6 +38,8 @@ public class Class : Item
 
     public virtual IRecordCollection NestedRecords { get; init; } = new RecordCollection();
 
+    public virtual IStructCollection NestedStructs { get; init; } = new StructCollection();
+
     public virtual IPropertyCollection Properties { get; init; } = new PropertyCollection();
 
     public virtual IStaticReadOnlyFieldCollection StaticReadOnlyFields { get; init; } = new StaticReadOnlyFieldCollection();

--- a/src/Typewriter.Engine/CodeModel/File.cs
+++ b/src/Typewriter.Engine/CodeModel/File.cs
@@ -14,5 +14,7 @@ public class File : Item
 
     public virtual IRecordCollection Records { get; init; } = new RecordCollection();
 
+    public virtual IStructCollection Structs { get; init; } = new StructCollection();
+
     public virtual ITypeCollection Types { get; init; } = new TypeCollection();
 }

--- a/src/Typewriter.Engine/CodeModel/IStructCollection.cs
+++ b/src/Typewriter.Engine/CodeModel/IStructCollection.cs
@@ -1,0 +1,5 @@
+namespace Typewriter.CodeModel;
+
+public interface IStructCollection : IItemCollection<Struct>
+{
+}

--- a/src/Typewriter.Engine/CodeModel/Interface.cs
+++ b/src/Typewriter.Engine/CodeModel/Interface.cs
@@ -18,6 +18,8 @@ public class Interface : Item
 
     public virtual string Namespace { get; init; } = string.Empty;
 
+    public virtual IStructCollection NestedStructs { get; init; } = new StructCollection();
+
     public virtual IPropertyCollection Properties { get; init; } = new PropertyCollection();
 
     public virtual Type Type { get; init; } = new();

--- a/src/Typewriter.Engine/CodeModel/Property.cs
+++ b/src/Typewriter.Engine/CodeModel/Property.cs
@@ -12,9 +12,13 @@ public class Property : Item
 
     public virtual bool IsAbstract { get; init; }
 
+    public virtual bool IsIndexer { get; init; }
+
     public virtual bool IsRequired { get; init; }
 
     public virtual bool IsVirtual { get; init; }
+
+    public virtual IParameterCollection Parameters { get; init; } = new ParameterCollection();
 
     public virtual Type Type { get; init; } = new();
 

--- a/src/Typewriter.Engine/CodeModel/Struct.cs
+++ b/src/Typewriter.Engine/CodeModel/Struct.cs
@@ -1,14 +1,14 @@
 namespace Typewriter.CodeModel;
 
-public class Record : Item
+public class Struct : Item
 {
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
-    public virtual Record? BaseRecord { get; init; }
-
     public virtual IConstantCollection Constants { get; init; } = new ConstantCollection();
 
-    public virtual Record? ContainingRecord { get; init; }
+    public virtual Class? ContainingClass { get; init; }
+
+    public virtual Struct? ContainingStruct { get; init; }
 
     public virtual IDelegateCollection Delegates { get; init; } = new DelegateCollection();
 
@@ -20,9 +20,9 @@ public class Record : Item
 
     public virtual IInterfaceCollection Interfaces { get; init; } = new InterfaceCollection();
 
-    public virtual bool IsAbstract { get; init; }
-
     public virtual bool IsGeneric { get; init; }
+
+    public virtual bool IsStatic { get; init; }
 
     public virtual IMethodCollection Methods { get; init; } = new MethodCollection();
 
@@ -48,7 +48,7 @@ public class Record : Item
 
     public virtual ITypeParameterCollection TypeParameters { get; init; } = new TypeParameterCollection();
 
-    public static implicit operator string(Record? instance) => instance?.ToString() ?? string.Empty;
+    public static implicit operator string(Struct? instance) => instance?.ToString() ?? string.Empty;
 
-    public static implicit operator Type?(Record? instance) => instance?.Type;
+    public static implicit operator Type?(Struct? instance) => instance?.Type;
 }

--- a/src/Typewriter.Engine/CodeModel/StructCollection.cs
+++ b/src/Typewriter.Engine/CodeModel/StructCollection.cs
@@ -1,0 +1,26 @@
+namespace Typewriter.CodeModel;
+
+public sealed class StructCollection : ItemCollection<Struct>, IStructCollection
+{
+    public StructCollection()
+    {
+    }
+
+    public StructCollection(IEnumerable<Struct> items)
+        : base(items: items)
+    {
+    }
+
+    protected override IEnumerable<string> GetAttributeFilter(Struct item) => GetAttributeNames(attributes: item.Attributes);
+
+    protected override IEnumerable<string> GetInheritanceFilter(Struct item)
+    {
+        foreach (var implementedInterface in item.Interfaces)
+        {
+            yield return implementedInterface.Name;
+            yield return implementedInterface.FullName;
+        }
+    }
+
+    protected override IEnumerable<string> GetItemFilter(Struct item) => [item.Name, item.FullName, item.Namespace];
+}

--- a/src/Typewriter.Engine/CodeModel/Type.cs
+++ b/src/Typewriter.Engine/CodeModel/Type.cs
@@ -44,6 +44,8 @@ public class Type : Item
 
     public virtual bool IsPrimitive { get; init; }
 
+    public virtual bool IsStruct { get; init; }
+
     public virtual bool IsTask { get; init; }
 
     public virtual bool IsTimeSpan { get; init; }
@@ -61,6 +63,8 @@ public class Type : Item
     public virtual IInterfaceCollection NestedInterfaces { get; init; } = new InterfaceCollection();
 
     public virtual IRecordCollection NestedRecords { get; init; } = new RecordCollection();
+
+    public virtual IStructCollection NestedStructs { get; init; } = new StructCollection();
 
     public virtual string OriginalName { get; init; } = string.Empty;
 

--- a/src/Typewriter.Engine/TemplateCodeModelAdapterFactory.cs
+++ b/src/Typewriter.Engine/TemplateCodeModelAdapterFactory.cs
@@ -12,6 +12,7 @@ using CodeMethod = Typewriter.CodeModel.Method;
 using CodeParameter = Typewriter.CodeModel.Parameter;
 using CodeRecord = Typewriter.CodeModel.Record;
 using CodeStaticReadOnlyField = Typewriter.CodeModel.StaticReadOnlyField;
+using CodeStruct = Typewriter.CodeModel.Struct;
 using CodeType = Typewriter.CodeModel.Type;
 
 namespace Typewriter.Engine;
@@ -21,6 +22,7 @@ internal sealed class TemplateCodeModelAdapterFactory
     private readonly Typewriter.Configuration.Settings _settings;
     private readonly string _assemblyName;
     private readonly IReadOnlyDictionary<string, MethodMetadata> _methodsByFullName;
+    private readonly IReadOnlyDictionary<string, PropertyMetadata> _propertiesByFullName;
     private readonly IReadOnlyDictionary<string, TypeMetadata> _typesByFullName;
     private readonly TypeScriptTypeMapper _typeMapper = new();
 
@@ -48,6 +50,10 @@ internal sealed class TemplateCodeModelAdapterFactory
         _methodsByFullName = metadata.Types
             .SelectMany(selector: type => type.Methods)
             .GroupBy(keySelector: method => method.FullName, comparer: StringComparer.Ordinal)
+            .ToDictionary(keySelector: group => group.Key, elementSelector: group => group.First(), comparer: StringComparer.Ordinal);
+        _propertiesByFullName = metadata.Types
+            .SelectMany(selector: type => type.Properties)
+            .GroupBy(keySelector: property => property.FullName, comparer: StringComparer.Ordinal)
             .ToDictionary(keySelector: group => group.Key, elementSelector: group => group.First(), comparer: StringComparer.Ordinal);
     }
 
@@ -209,6 +215,10 @@ internal sealed class TemplateCodeModelAdapterFactory
                 items: rootTypes
                     .Where(predicate: type => type.Kind == TypeMetadataKind.Record)
                     .Select(selector: CreateRecord)),
+            Structs = new Typewriter.CodeModel.StructCollection(
+                items: rootTypes
+                    .Where(predicate: type => type.Kind == TypeMetadataKind.Struct)
+                    .Select(selector: CreateStruct)),
             Delegates = new Typewriter.CodeModel.DelegateCollection(items: project.Delegates.Select(selector: @delegate => CreateDelegate(@delegate: @delegate, parent: null))),
             Interfaces = new Typewriter.CodeModel.InterfaceCollection(
                 items: rootTypes
@@ -234,6 +244,11 @@ internal sealed class TemplateCodeModelAdapterFactory
         if (type.Kind == TypeMetadataKind.Record && targetType.IsAssignableFrom(c: typeof(CodeRecord)))
         {
             return CreateRecord(type: type);
+        }
+
+        if (type.Kind == TypeMetadataKind.Struct && targetType.IsAssignableFrom(c: typeof(CodeStruct)))
+        {
+            return CreateStruct(type: type);
         }
 
         if (type.Kind == TypeMetadataKind.Interface && targetType.IsAssignableFrom(c: typeof(CodeInterface)))
@@ -284,6 +299,7 @@ internal sealed class TemplateCodeModelAdapterFactory
             NestedEnums = new Typewriter.CodeModel.EnumCollection(items: type.NestedEnums.Select(selector: CreateEnum)),
             NestedInterfaces = new Typewriter.CodeModel.InterfaceCollection(items: type.NestedInterfaces.Select(selector: CreateInterface)),
             NestedRecords = new Typewriter.CodeModel.RecordCollection(items: type.NestedRecords.Select(selector: CreateRecord)),
+            NestedStructs = new Typewriter.CodeModel.StructCollection(items: type.NestedStructs.Select(selector: CreateStruct)),
             Properties = new Typewriter.CodeModel.PropertyCollection(items: type.Properties.Select(selector: property => CreateProperty(property: property, parent: null))),
             StaticReadOnlyFields = new Typewriter.CodeModel.StaticReadOnlyFieldCollection(
                 items: type.StaticReadOnlyFields.Select(selector: field => CreateStaticReadOnlyField(field: field, parent: null))),
@@ -325,6 +341,7 @@ internal sealed class TemplateCodeModelAdapterFactory
             NestedEnums = new Typewriter.CodeModel.EnumCollection(items: type.NestedEnums.Select(selector: CreateEnum)),
             NestedInterfaces = new Typewriter.CodeModel.InterfaceCollection(items: type.NestedInterfaces.Select(selector: CreateInterface)),
             NestedRecords = new Typewriter.CodeModel.RecordCollection(items: type.NestedRecords.Select(selector: CreateRecord)),
+            NestedStructs = new Typewriter.CodeModel.StructCollection(items: type.NestedStructs.Select(selector: CreateStruct)),
             Properties = new Typewriter.CodeModel.PropertyCollection(items: type.Properties.Select(selector: property => CreateProperty(property: property, parent: null))),
             StaticReadOnlyFields = new Typewriter.CodeModel.StaticReadOnlyFieldCollection(
                 items: type.StaticReadOnlyFields.Select(selector: field => CreateStaticReadOnlyField(field: field, parent: null))),
@@ -357,9 +374,52 @@ internal sealed class TemplateCodeModelAdapterFactory
             IsGeneric = interfaceType.IsGeneric,
             Interfaces = CreateInterfaces(type: type),
             Methods = new Typewriter.CodeModel.MethodCollection(items: type.Methods.Select(selector: method => CreateMethod(method: method, parent: null))),
+            NestedStructs = new Typewriter.CodeModel.StructCollection(items: type.NestedStructs.Select(selector: CreateStruct)),
             Properties = new Typewriter.CodeModel.PropertyCollection(items: type.Properties.Select(selector: property => CreateProperty(property: property, parent: null))),
             Type = interfaceType,
             TypeArguments = interfaceType.TypeArguments,
+            TypeParameters = CreateTypeParameters(typeParameters: type.TypeParameters, parent: null),
+        };
+    }
+
+    private CodeStruct CreateStruct(TypeMetadata type)
+    {
+        return CreateStruct(type: type, reference: null);
+    }
+
+    private CodeStruct CreateStruct(
+        TypeMetadata type,
+        TypeMetadataReference? reference)
+    {
+        var structType = reference is null ? CreateType(type: type) : CreateType(type: reference);
+        return new CodeStruct
+        {
+            AssemblyName = ResolveAssemblyName(assemblyName: type.AssemblyName),
+            Name = type.Name,
+            FullName = type.FullName,
+            Namespace = type.Namespace,
+            Attributes = CreateAttributes(attributes: type.Attributes, parent: null),
+            ContainingClass = CreateContainingClass(type: type),
+            ContainingStruct = CreateContainingStruct(type: type),
+            DocComment = CreateDocComment(docComment: type.DocComment, parent: null),
+            Interfaces = CreateInterfaces(type: type),
+            IsGeneric = structType.IsGeneric,
+            IsStatic = type.IsStatic,
+            Constants = new Typewriter.CodeModel.ConstantCollection(items: type.Constants.Select(selector: constant => CreateConstant(constant: constant, parent: null))),
+            Delegates = new Typewriter.CodeModel.DelegateCollection(items: type.Delegates.Select(selector: @delegate => CreateDelegate(@delegate: @delegate, parent: null))),
+            Events = new Typewriter.CodeModel.EventCollection(items: type.Events.Select(selector: @event => CreateEvent(@event: @event, parent: null))),
+            Fields = new Typewriter.CodeModel.FieldCollection(items: type.Fields.Select(selector: field => CreateField(field: field, parent: null))),
+            Methods = new Typewriter.CodeModel.MethodCollection(items: type.Methods.Select(selector: method => CreateMethod(method: method, parent: null))),
+            NestedClasses = new Typewriter.CodeModel.ClassCollection(items: type.NestedClasses.Select(selector: CreateClass)),
+            NestedEnums = new Typewriter.CodeModel.EnumCollection(items: type.NestedEnums.Select(selector: CreateEnum)),
+            NestedInterfaces = new Typewriter.CodeModel.InterfaceCollection(items: type.NestedInterfaces.Select(selector: CreateInterface)),
+            NestedRecords = new Typewriter.CodeModel.RecordCollection(items: type.NestedRecords.Select(selector: CreateRecord)),
+            NestedStructs = new Typewriter.CodeModel.StructCollection(items: type.NestedStructs.Select(selector: CreateStruct)),
+            Properties = new Typewriter.CodeModel.PropertyCollection(items: type.Properties.Select(selector: property => CreateProperty(property: property, parent: null))),
+            StaticReadOnlyFields = new Typewriter.CodeModel.StaticReadOnlyFieldCollection(
+                items: type.StaticReadOnlyFields.Select(selector: field => CreateStaticReadOnlyField(field: field, parent: null))),
+            Type = structType,
+            TypeArguments = structType.TypeArguments,
             TypeParameters = CreateTypeParameters(typeParameters: type.TypeParameters, parent: null),
         };
     }
@@ -398,6 +458,7 @@ internal sealed class TemplateCodeModelAdapterFactory
             IsDefined = true,
             IsEnum = type.Kind == TypeMetadataKind.Enum,
             IsGeneric = type.TypeParameters.Count > 0 || type.TypeArguments.Count > 0,
+            IsStruct = type.Kind == TypeMetadataKind.Struct,
             Interfaces = CreateInterfaces(type: type),
             Constants = new Typewriter.CodeModel.ConstantCollection(items: type.Constants.Select(selector: constant => CreateConstant(constant: constant, parent: null))),
             Delegates = new Typewriter.CodeModel.DelegateCollection(items: type.Delegates.Select(selector: @delegate => CreateDelegate(@delegate: @delegate, parent: null))),
@@ -407,6 +468,7 @@ internal sealed class TemplateCodeModelAdapterFactory
             NestedEnums = new Typewriter.CodeModel.EnumCollection(items: type.NestedEnums.Select(selector: CreateEnum)),
             NestedInterfaces = new Typewriter.CodeModel.InterfaceCollection(items: type.NestedInterfaces.Select(selector: CreateInterface)),
             NestedRecords = new Typewriter.CodeModel.RecordCollection(items: type.NestedRecords.Select(selector: CreateRecord)),
+            NestedStructs = new Typewriter.CodeModel.StructCollection(items: type.NestedStructs.Select(selector: CreateStruct)),
             Properties = new Typewriter.CodeModel.PropertyCollection(items: type.Properties.Select(selector: property => CreateProperty(property: property, parent: null))),
             StaticReadOnlyFields = new Typewriter.CodeModel.StaticReadOnlyFieldCollection(
                 items: type.StaticReadOnlyFields.Select(selector: field => CreateStaticReadOnlyField(field: field, parent: null))),
@@ -421,6 +483,8 @@ internal sealed class TemplateCodeModelAdapterFactory
     {
         var typeArguments = new Typewriter.CodeModel.TypeCollection(items: type.TypeArguments.Select(selector: CreateType));
         var mappedName = _typeMapper.Map(type: type, strictNull: _settings.StrictNullGeneration);
+        var isStruct = _typesByFullName.TryGetValue(key: type.FullName, value: out var metadata)
+                       && metadata.Kind == TypeMetadataKind.Struct;
         return new CodeType
         {
             AssemblyName = ResolveAssemblyName(assemblyName: type.AssemblyName),
@@ -439,6 +503,7 @@ internal sealed class TemplateCodeModelAdapterFactory
             IsPrimitive = type.IsPrimitive
                 || type.IsDateLike
                 || type.FullName.Equals(value: "System.Guid", comparisonType: StringComparison.Ordinal),
+            IsStruct = isStruct,
             IsTask = IsTaskLike(fullName: type.FullName),
             IsTimeSpan = type.FullName.Equals(value: "System.TimeSpan", comparisonType: StringComparison.Ordinal),
             IsValueTuple = type.IsValueTuple,
@@ -454,6 +519,14 @@ internal sealed class TemplateCodeModelAdapterFactory
         PropertyMetadata property,
         Typewriter.CodeModel.Item? parent)
     {
+        return CreateProperty(property: property, parent: parent, includeParameters: true);
+    }
+
+    private Typewriter.CodeModel.Property CreateProperty(
+        PropertyMetadata property,
+        Typewriter.CodeModel.Item? parent,
+        bool includeParameters)
+    {
         return new Typewriter.CodeModel.Property
         {
             AssemblyName = ResolveAssemblyName(assemblyName: property.AssemblyName),
@@ -465,8 +538,12 @@ internal sealed class TemplateCodeModelAdapterFactory
             HasGetter = property.HasGetter,
             HasSetter = property.HasSetter,
             IsAbstract = property.IsAbstract,
+            IsIndexer = property.IsIndexer,
             IsRequired = property.IsRequired,
             IsVirtual = property.IsVirtual,
+            Parameters = includeParameters
+                ? new Typewriter.CodeModel.ParameterCollection(items: property.Parameters.Select(selector: parameter => CreateParameter(parameter: parameter, parent: null)))
+                : new Typewriter.CodeModel.ParameterCollection(),
             Type = CreateType(type: property.Type),
         };
     }
@@ -510,7 +587,9 @@ internal sealed class TemplateCodeModelAdapterFactory
             AssemblyName = ResolveAssemblyName(assemblyName: parameter.AssemblyName),
             Name = parameter.Name,
             FullName = parameter.FullName,
-            Parent = parent ?? CreateParentMethod(fullName: parameter.ParentMethodFullName),
+            Parent = parent
+                ?? (Typewriter.CodeModel.Item?)CreateParentMethod(fullName: parameter.ParentMethodFullName)
+                ?? CreateParentProperty(fullName: parameter.ParentPropertyFullName),
             Attributes = CreateAttributes(attributes: parameter.Attributes, parent: null),
             DefaultValue = parameter.DefaultValue ?? string.Empty,
             HasDefaultValue = parameter.HasDefaultValue,
@@ -710,6 +789,7 @@ internal sealed class TemplateCodeModelAdapterFactory
         {
             TypeMetadataKind.Class => CreateShallowClass(type: type),
             TypeMetadataKind.Record => CreateShallowRecord(type: type),
+            TypeMetadataKind.Struct => CreateShallowStruct(type: type),
             TypeMetadataKind.Interface => CreateShallowInterface(type: type),
             TypeMetadataKind.Enum => CreateShallowEnum(type: type),
             _ => null,
@@ -721,6 +801,14 @@ internal sealed class TemplateCodeModelAdapterFactory
         return !string.IsNullOrWhiteSpace(value: fullName)
             && _methodsByFullName.TryGetValue(key: fullName, value: out var method)
                 ? CreateMethod(method: method, parent: CreateParentTypeItem(fullName: method.ParentTypeFullName), includeParameters: false)
+                : null;
+    }
+
+    private Typewriter.CodeModel.Property? CreateParentProperty(string fullName)
+    {
+        return !string.IsNullOrWhiteSpace(value: fullName)
+            && _propertiesByFullName.TryGetValue(key: fullName, value: out var property)
+                ? CreateProperty(property: property, parent: CreateParentTypeItem(fullName: property.ParentTypeFullName), includeParameters: false)
                 : null;
     }
 
@@ -748,6 +836,15 @@ internal sealed class TemplateCodeModelAdapterFactory
             && _typesByFullName.TryGetValue(key: type.ContainingTypeFullName, value: out var containingType)
             && containingType.Kind == TypeMetadataKind.Record
                 ? CreateShallowRecord(type: containingType)
+                : null;
+    }
+
+    private CodeStruct? CreateContainingStruct(TypeMetadata type)
+    {
+        return !string.IsNullOrWhiteSpace(value: type.ContainingTypeFullName)
+            && _typesByFullName.TryGetValue(key: type.ContainingTypeFullName, value: out var containingType)
+            && containingType.Kind == TypeMetadataKind.Struct
+                ? CreateShallowStruct(type: containingType)
                 : null;
     }
 
@@ -780,6 +877,23 @@ internal sealed class TemplateCodeModelAdapterFactory
             Attributes = CreateAttributes(attributes: type.Attributes, parent: null),
             IsAbstract = type.IsAbstract,
             IsGeneric = type.TypeParameters.Count > 0 || type.TypeArguments.Count > 0,
+            Type = CreateTypeShell(type: type),
+            TypeArguments = new Typewriter.CodeModel.TypeCollection(items: type.TypeArguments.Select(selector: CreateType)),
+            TypeParameters = CreateTypeParameters(typeParameters: type.TypeParameters, parent: null),
+        };
+    }
+
+    private CodeStruct CreateShallowStruct(TypeMetadata type)
+    {
+        return new CodeStruct
+        {
+            AssemblyName = ResolveAssemblyName(assemblyName: type.AssemblyName),
+            Name = type.Name,
+            FullName = type.FullName,
+            Namespace = type.Namespace,
+            Attributes = CreateAttributes(attributes: type.Attributes, parent: null),
+            IsGeneric = type.TypeParameters.Count > 0 || type.TypeArguments.Count > 0,
+            IsStatic = type.IsStatic,
             Type = CreateTypeShell(type: type),
             TypeArguments = new Typewriter.CodeModel.TypeCollection(items: type.TypeArguments.Select(selector: CreateType)),
             TypeParameters = CreateTypeParameters(typeParameters: type.TypeParameters, parent: null),
@@ -829,6 +943,7 @@ internal sealed class TemplateCodeModelAdapterFactory
             IsDefined = true,
             IsEnum = type.Kind == TypeMetadataKind.Enum,
             IsGeneric = type.TypeParameters.Count > 0 || type.TypeArguments.Count > 0,
+            IsStruct = type.Kind == TypeMetadataKind.Struct,
             DefaultValue = GetDefaultValue(type: type),
             Settings = _settings,
             TypeArguments = new Typewriter.CodeModel.TypeCollection(items: type.TypeArguments.Select(selector: CreateType)),

--- a/src/Typewriter.Engine/TemplateRenderer.cs
+++ b/src/Typewriter.Engine/TemplateRenderer.cs
@@ -20,6 +20,7 @@ using CodeModelParameterComment = Typewriter.CodeModel.ParameterComment;
 using CodeModelProperty = Typewriter.CodeModel.Property;
 using CodeModelRecord = Typewriter.CodeModel.Record;
 using CodeModelStaticReadOnlyField = Typewriter.CodeModel.StaticReadOnlyField;
+using CodeModelStruct = Typewriter.CodeModel.Struct;
 using CodeModelType = Typewriter.CodeModel.Type;
 using CodeModelTypeParameter = Typewriter.CodeModel.TypeParameter;
 using NameCase = Typewriter.CodeModel.NameCase;
@@ -105,6 +106,7 @@ public sealed class TemplateRenderer
         return identifier is "Types"
             or "Classes"
             or "Records"
+            or "Structs"
             or "Delegates"
             or "Interfaces"
             or "Enums";
@@ -825,6 +827,7 @@ public sealed class TemplateRenderer
             "NestedClasses" => @class.NestedClasses,
             "NestedEnums" => @class.NestedEnums,
             "NestedInterfaces" => @class.NestedInterfaces,
+            "NestedStructs" => @class.NestedStructs,
             "Parent" => @class.Parent,
             "Properties" => @class.Properties,
             "StaticReadOnlyFields" => @class.StaticReadOnlyFields,
@@ -859,6 +862,7 @@ public sealed class TemplateRenderer
             "Fields" => record.Fields,
             "Interfaces" => record.Interfaces,
             "Methods" => record.Methods,
+            "NestedStructs" => record.NestedStructs,
             "Parent" => record.Parent,
             "Properties" => record.Properties,
             "StaticReadOnlyFields" => record.StaticReadOnlyFields,
@@ -867,6 +871,44 @@ public sealed class TemplateRenderer
             "TypeParameters" => record.TypeParameters,
             "IsAbstract" => record.IsAbstract,
             "IsGeneric" => record.IsGeneric,
+            _ => Unresolved.Value,
+        };
+    }
+
+    private static object? ResolveCodeModelStruct(
+        CodeModelStruct @struct,
+        string identifier)
+    {
+        return identifier switch
+        {
+            "Name" => @struct.Name,
+            "name" => @struct.name,
+            "FullName" => @struct.FullName,
+            "AssemblyName" => @struct.AssemblyName,
+            "Namespace" => @struct.Namespace,
+            "Attributes" => @struct.Attributes,
+            "ContainingClass" => @struct.ContainingClass,
+            "ContainingStruct" => @struct.ContainingStruct,
+            "Constants" => @struct.Constants,
+            "Delegates" => @struct.Delegates,
+            "DocComment" => @struct.DocComment,
+            "Events" => @struct.Events,
+            "Fields" => @struct.Fields,
+            "Interfaces" => @struct.Interfaces,
+            "Methods" => @struct.Methods,
+            "NestedClasses" => @struct.NestedClasses,
+            "NestedEnums" => @struct.NestedEnums,
+            "NestedInterfaces" => @struct.NestedInterfaces,
+            "NestedRecords" => @struct.NestedRecords,
+            "NestedStructs" => @struct.NestedStructs,
+            "Parent" => @struct.Parent,
+            "Properties" => @struct.Properties,
+            "StaticReadOnlyFields" => @struct.StaticReadOnlyFields,
+            "Type" => @struct.Type,
+            "TypeArguments" => @struct.TypeArguments,
+            "TypeParameters" => @struct.TypeParameters,
+            "IsGeneric" => @struct.IsGeneric,
+            "IsStatic" => @struct.IsStatic,
             _ => Unresolved.Value,
         };
     }
@@ -888,6 +930,7 @@ public sealed class TemplateRenderer
             "Events" => @interface.Events,
             "Interfaces" => @interface.Interfaces,
             "Methods" => @interface.Methods,
+            "NestedStructs" => @interface.NestedStructs,
             "Parent" => @interface.Parent,
             "Properties" => @interface.Properties,
             "Type" => @interface.Type,
@@ -1055,8 +1098,10 @@ public sealed class TemplateRenderer
             "HasGetter" => property.HasGetter,
             "HasSetter" => property.HasSetter,
             "IsAbstract" => property.IsAbstract,
+            "IsIndexer" => property.IsIndexer,
             "IsVirtual" => property.IsVirtual,
             "IsRequired" => property.IsRequired,
+            "Parameters" => property.Parameters,
             "Attributes" => property.Attributes,
             _ => Unresolved.Value,
         };
@@ -1124,6 +1169,7 @@ public sealed class TemplateRenderer
             "NestedClasses" => type.NestedClasses,
             "NestedEnums" => type.NestedEnums,
             "NestedInterfaces" => type.NestedInterfaces,
+            "NestedStructs" => type.NestedStructs,
             "Parent" => type.Parent,
             "Properties" => type.Properties,
             "StaticReadOnlyFields" => type.StaticReadOnlyFields,
@@ -1144,6 +1190,7 @@ public sealed class TemplateRenderer
             "IsNullable" => type.IsNullable,
             "IsDynamic" => type.IsDynamic,
             "IsPrimitive" => type.IsPrimitive,
+            "IsStruct" => type.IsStruct,
             "IsTask" => type.IsTask,
             "IsTimeSpan" => type.IsTimeSpan,
             "IsValueTuple" => type.IsValueTuple,
@@ -1646,6 +1693,7 @@ public sealed class TemplateRenderer
         {
             "Class" => items.OfType<TypeMetadata>().Where(predicate: type => type.Kind == TypeMetadataKind.Class),
             "Record" => items.OfType<TypeMetadata>().Where(predicate: type => type.Kind == TypeMetadataKind.Record),
+            "Struct" => items.OfType<TypeMetadata>().Where(predicate: type => type.Kind == TypeMetadataKind.Struct),
             "Interface" => items.OfType<TypeMetadata>().Where(predicate: type => type.Kind == TypeMetadataKind.Interface),
             "Enum" => items.OfType<TypeMetadata>().Where(predicate: type => type.Kind == TypeMetadataKind.Enum),
             "HasProperties" => items.OfType<TypeMetadata>().Where(predicate: type => type.Properties.Count > 0),
@@ -1857,6 +1905,8 @@ public sealed class TemplateRenderer
             "IncludeInterface" => context is TypeMetadata { Kind: TypeMetadataKind.Interface } type
                 && MatchesRecipeTypePredicate(type: type, body: body),
             "IncludeRecord" => context is TypeMetadata { Kind: TypeMetadataKind.Record } type
+                && MatchesRecipeTypePredicate(type: type, body: body),
+            "IncludeStruct" => context is TypeMetadata { Kind: TypeMetadataKind.Struct } type
                 && MatchesRecipeTypePredicate(type: type, body: body),
             "IsEnumAsNumber" => context is TypeMetadata type
                 && !HasAttribute(attributes: type.Attributes, name: "AsString"),
@@ -2196,6 +2246,7 @@ public sealed class TemplateRenderer
             TypeParameterMetadata typeParameter => ResolveTypeParameter(typeParameter: typeParameter, identifier: identifier),
             CodeModelClass codeClass => ResolveCodeModelClass(@class: codeClass, identifier: identifier),
             CodeModelRecord codeRecord => ResolveCodeModelRecord(record: codeRecord, identifier: identifier),
+            CodeModelStruct codeStruct => ResolveCodeModelStruct(@struct: codeStruct, identifier: identifier),
             CodeModelInterface codeInterface => ResolveCodeModelInterface(@interface: codeInterface, identifier: identifier),
             CodeModelEnum codeEnum => ResolveCodeModelEnum(@enum: codeEnum, identifier: identifier),
             CodeModelDelegate codeDelegate => ResolveCodeModelDelegate(@delegate: codeDelegate, identifier: identifier),
@@ -2238,6 +2289,7 @@ public sealed class TemplateRenderer
             "Types" => metadata.Types,
             "Classes" => metadata.Types.Where(predicate: type => type.Kind is TypeMetadataKind.Class or TypeMetadataKind.Record),
             "Records" => metadata.Types.Where(predicate: type => type.Kind == TypeMetadataKind.Record),
+            "Structs" => metadata.Types.Where(predicate: type => type.Kind == TypeMetadataKind.Struct),
             "Delegates" => metadata.Delegates,
             "Interfaces" => metadata.Types.Where(predicate: type => type.Kind == TypeMetadataKind.Interface),
             "Enums" => metadata.Types.Where(predicate: type => type.Kind == TypeMetadataKind.Enum),
@@ -2282,8 +2334,12 @@ public sealed class TemplateRenderer
             "ContainingRecord" => string.IsNullOrWhiteSpace(value: type.ContainingTypeFullName)
                 ? null
                 : state?.ResolveParentType(fullName: type.ContainingTypeFullName) ?? Unresolved.Value,
+            "ContainingStruct" => string.IsNullOrWhiteSpace(value: type.ContainingTypeFullName)
+                ? null
+                : state?.ResolveParentType(fullName: type.ContainingTypeFullName) ?? Unresolved.Value,
             "NestedClasses" => type.NestedClasses,
             "NestedRecords" => type.NestedRecords,
+            "NestedStructs" => type.NestedStructs,
             "NestedEnums" => type.NestedEnums,
             "NestedInterfaces" => type.NestedInterfaces,
             "FileLocations" => type.FileLocations,
@@ -2291,6 +2347,7 @@ public sealed class TemplateRenderer
             "EnumValues" => type.EnumValues,
             "IsClass" => type.Kind == TypeMetadataKind.Class,
             "IsRecord" => type.Kind == TypeMetadataKind.Record,
+            "IsStruct" => type.Kind == TypeMetadataKind.Struct,
             "IsInterface" => type.Kind == TypeMetadataKind.Interface,
             "IsEnum" => type.Kind == TypeMetadataKind.Enum,
             "IsNullableAware" => type.IsNullableAware,
@@ -2322,8 +2379,10 @@ public sealed class TemplateRenderer
             "HasGetter" => property.HasGetter,
             "HasSetter" => property.HasSetter,
             "IsRequired" => property.IsRequired,
+            "IsIndexer" => property.IsIndexer,
             "IsAbstract" => property.IsAbstract,
             "IsVirtual" => property.IsVirtual,
+            "Parameters" => property.Parameters,
             "DocComment" => property.DocComment,
             "Attributes" => property.Attributes,
             _ => Unresolved.Value,
@@ -2367,7 +2426,9 @@ public sealed class TemplateRenderer
             "Name" => parameter.Name,
             "name" => ToCamelCase(value: parameter.Name),
             "FullName" => parameter.FullName,
-            "Parent" => state?.ResolveParentMethod(fullName: parameter.ParentMethodFullName) ?? Unresolved.Value,
+            "Parent" => !string.IsNullOrWhiteSpace(value: parameter.ParentMethodFullName)
+                ? state?.ResolveParentMethod(fullName: parameter.ParentMethodFullName) ?? Unresolved.Value
+                : state?.ResolveParentProperty(fullName: parameter.ParentPropertyFullName) ?? state?.CurrentParentContext ?? Unresolved.Value,
             "Type" => CreateTypeTemplateValue(type: parameter.Type, state: state),
             "CSharpType" => parameter.Type.Name,
             "TypeScriptType" => MapType(type: parameter.Type, state: state),
@@ -2376,6 +2437,7 @@ public sealed class TemplateRenderer
             "DocComment" => parameter.DocComment,
             "Attributes" => parameter.Attributes,
             "ParentMethodFullName" => parameter.ParentMethodFullName,
+            "ParentPropertyFullName" => parameter.ParentPropertyFullName,
             _ => Unresolved.Value,
         };
     }
@@ -2532,6 +2594,9 @@ public sealed class TemplateRenderer
             "IsDynamic" => IsDynamicType(type: type),
             "IsEnum" => type.IsEnum,
             "IsPrimitive" => IsPrimitiveType(type: type),
+            "IsStruct" => state is not null
+                && state.TryResolveType(fullName: type.FullName, type: out var metadata)
+                && metadata.Kind == TypeMetadataKind.Struct,
             "IsDate" => type.IsDateLike,
             "IsGuid" => type.FullName.Equals(value: "System.Guid", comparisonType: StringComparison.Ordinal),
             "IsTimeSpan" => type.FullName.Equals(value: "System.TimeSpan", comparisonType: StringComparison.Ordinal),
@@ -2608,6 +2673,7 @@ public sealed class TemplateRenderer
         private readonly CompiledTemplateHelper? _compiledTemplateHelper;
         private readonly ProjectMetadata _metadata;
         private readonly IReadOnlyDictionary<string, MethodMetadata> _methodsByFullName;
+        private readonly IReadOnlyDictionary<string, PropertyMetadata> _propertiesByFullName;
         private readonly IReadOnlyDictionary<string, TypeMetadata> _typesByFullName;
         private readonly Stack<object> _parentContexts = new();
         private readonly HashSet<string> _reportedCompiledInvocationErrors = [];
@@ -2635,6 +2701,10 @@ public sealed class TemplateRenderer
             _methodsByFullName = metadata.Types
                 .SelectMany(selector: type => type.Methods)
                 .GroupBy(keySelector: method => method.FullName, comparer: StringComparer.Ordinal)
+                .ToDictionary(keySelector: group => group.Key, elementSelector: group => group.First(), comparer: StringComparer.Ordinal);
+            _propertiesByFullName = metadata.Types
+                .SelectMany(selector: type => type.Properties)
+                .GroupBy(keySelector: property => property.FullName, comparer: StringComparer.Ordinal)
                 .ToDictionary(keySelector: group => group.Key, elementSelector: group => group.First(), comparer: StringComparer.Ordinal);
             _compiledTemplateHelper = template.CodeBlocks.Count == 0
                 ? null
@@ -2701,6 +2771,14 @@ public sealed class TemplateRenderer
         {
             return !string.IsNullOrWhiteSpace(value: fullName)
                 && _methodsByFullName.TryGetValue(key: fullName, value: out var parent)
+                    ? parent
+                    : Unresolved.Value;
+        }
+
+        public object ResolveParentProperty(string fullName)
+        {
+            return !string.IsNullOrWhiteSpace(value: fullName)
+                && _propertiesByFullName.TryGetValue(key: fullName, value: out var parent)
                     ? parent
                     : Unresolved.Value;
         }

--- a/src/Typewriter.Engine/TemplateRenderer.cs
+++ b/src/Typewriter.Engine/TemplateRenderer.cs
@@ -1488,6 +1488,25 @@ public sealed class TemplateRenderer
         return string.Join(separator: '\n', values: output);
     }
 
+    private static object? ResolveContainingType(
+        TypeMetadata type,
+        TypeMetadataKind kind,
+        RenderState? state)
+    {
+        if (string.IsNullOrWhiteSpace(value: type.ContainingTypeFullName))
+        {
+            return null;
+        }
+
+        if (state is null
+            || !state.TryResolveType(fullName: type.ContainingTypeFullName, type: out var containingType))
+        {
+            return Unresolved.Value;
+        }
+
+        return containingType.Kind == kind ? containingType : null;
+    }
+
     private string RenderCore(
         string template,
         object context,
@@ -1499,6 +1518,16 @@ public sealed class TemplateRenderer
             if (template[index: index] != '$')
             {
                 output.Append(value: template[index: index]);
+                continue;
+            }
+
+            if (index + 1 < template.Length
+                && template[index: index + 1] == '$')
+            {
+                output.Append(value: '$');
+#pragma warning disable S127 // "for" loop stop conditions should be invariant
+                index++;
+#pragma warning restore S127 // "for" loop stop conditions should be invariant
                 continue;
             }
 
@@ -2328,15 +2357,9 @@ public sealed class TemplateRenderer
             "BaseClass" => type.BaseTypes.FirstOrDefault(),
             "BaseRecord" => type.BaseTypes.FirstOrDefault(),
             "BaseTypes" => type.BaseTypes,
-            "ContainingClass" => string.IsNullOrWhiteSpace(value: type.ContainingTypeFullName)
-                ? null
-                : state?.ResolveParentType(fullName: type.ContainingTypeFullName) ?? Unresolved.Value,
-            "ContainingRecord" => string.IsNullOrWhiteSpace(value: type.ContainingTypeFullName)
-                ? null
-                : state?.ResolveParentType(fullName: type.ContainingTypeFullName) ?? Unresolved.Value,
-            "ContainingStruct" => string.IsNullOrWhiteSpace(value: type.ContainingTypeFullName)
-                ? null
-                : state?.ResolveParentType(fullName: type.ContainingTypeFullName) ?? Unresolved.Value,
+            "ContainingClass" => ResolveContainingType(type: type, kind: TypeMetadataKind.Class, state: state),
+            "ContainingRecord" => ResolveContainingType(type: type, kind: TypeMetadataKind.Record, state: state),
+            "ContainingStruct" => ResolveContainingType(type: type, kind: TypeMetadataKind.Struct, state: state),
             "NestedClasses" => type.NestedClasses,
             "NestedRecords" => type.NestedRecords,
             "NestedStructs" => type.NestedStructs,

--- a/src/Typewriter.Engine/TemplateRuntimeCompiler.cs
+++ b/src/Typewriter.Engine/TemplateRuntimeCompiler.cs
@@ -171,6 +171,7 @@ internal static class TemplateRuntimeCompiler
             "using Parameter = Typewriter.CodeModel.Parameter;",
             "using Property = Typewriter.CodeModel.Property;",
             "using Record = Typewriter.CodeModel.Record;",
+            "using Struct = Typewriter.CodeModel.Struct;",
             "using Type = Typewriter.CodeModel.Type;",
         };
         var references = new List<string>();

--- a/src/Typewriter.LanguageServer/TemplateFeatureService.cs
+++ b/src/Typewriter.LanguageServer/TemplateFeatureService.cs
@@ -31,6 +31,7 @@ internal sealed class TemplateFeatureService : IDisposable
         "public",
         "return",
         "static",
+        "struct",
         "string",
         "switch",
         "true",
@@ -57,6 +58,7 @@ internal sealed class TemplateFeatureService : IDisposable
         "Property",
         "Record",
         "Settings",
+        "Struct",
         "Type",
     ];
 
@@ -292,6 +294,7 @@ internal sealed class TemplateFeatureService : IDisposable
             insertText: "Types[$0]");
         AddTemplateMember(items: items, label: "Classes", detail: "Collection", documentation: "C# classes.", insertText: "Classes[$0]");
         AddTemplateMember(items: items, label: "Records", detail: "Collection", documentation: "C# records.", insertText: "Records[$0]");
+        AddTemplateMember(items: items, label: "Structs", detail: "Collection", documentation: "C# structs.", insertText: "Structs[$0]");
         AddTemplateMember(items: items, label: "Interfaces", detail: "Collection", documentation: "C# interfaces.", insertText: "Interfaces[$0]");
         AddTemplateMember(items: items, label: "Enums", detail: "Collection", documentation: "C# enums.", insertText: "Enums[$0]");
         AddTemplateMember(items: items, label: "Properties", detail: "Collection", documentation: "Properties on the current type.", insertText: "Properties[$0]");
@@ -330,6 +333,8 @@ internal sealed class TemplateFeatureService : IDisposable
         yield return Scalar(label: "IsStatic", documentation: "Whether the current type/member is static.");
         yield return Scalar(label: "IsAbstract", documentation: "Whether the current method is abstract.");
         yield return Scalar(label: "IsGeneric", documentation: "Whether the current method or type reference is generic.");
+        yield return Scalar(label: "IsStruct", documentation: "Whether the current type is a struct.");
+        yield return Scalar(label: "IsIndexer", documentation: "Whether the current property is an indexer.");
         yield return Scalar(label: "HasGetter", documentation: "Whether the current property has a getter.");
         yield return Scalar(label: "HasSetter", documentation: "Whether the current property has a setter.");
         yield return Scalar(label: "IsRequired", documentation: "Whether the current property is required.");
@@ -349,6 +354,7 @@ internal sealed class TemplateFeatureService : IDisposable
     {
         yield return Filter(label: "Class", documentation: "Keep only classes.");
         yield return Filter(label: "Record", documentation: "Keep only records.");
+        yield return Filter(label: "Struct", documentation: "Keep only structs.");
         yield return Filter(label: "Interface", documentation: "Keep only interfaces.");
         yield return Filter(label: "Enum", documentation: "Keep only enums.");
         yield return Filter(label: "HasProperties", documentation: "Keep types with properties.");
@@ -545,6 +551,7 @@ internal sealed class TemplateFeatureService : IDisposable
             documentation: "All public/internal C# types available to this template.");
         AddTypewriterSnippet(items: items, label: "$Classes", insertText: "Classes[$0]", documentation: "C# classes.");
         AddTypewriterSnippet(items: items, label: "$Records", insertText: "Records[$0]", documentation: "C# records.");
+        AddTypewriterSnippet(items: items, label: "$Structs", insertText: "Structs[$0]", documentation: "C# structs.");
         AddTypewriterSnippet(items: items, label: "$Interfaces", insertText: "Interfaces[$0]", documentation: "C# interfaces.");
         AddTypewriterSnippet(items: items, label: "$Enums", insertText: "Enums[$0]", documentation: "C# enums.");
         AddTypewriterSnippet(items: items, label: "$Properties", insertText: "Properties[$0]", documentation: "Properties on the current type.");
@@ -616,6 +623,18 @@ internal sealed class TemplateFeatureService : IDisposable
                     documentation: property.Documentation ?? $"C# property {property.FullName}.",
                     location: property.Location,
                     targetKind: TemplateAnalysisTargetKind.Property);
+
+                foreach (var parameter in property.Parameters)
+                {
+                    AddMember(
+                        items: items,
+                        label: parameter.Name,
+                        completionKind: CompletionKind.Variable,
+                        detail: $"Indexer parameter {property.Name}.{parameter.Name}: {parameter.Type.Name}",
+                        documentation: parameter.Documentation ?? $"C# indexer parameter {parameter.FullName}.",
+                        location: parameter.Location,
+                        targetKind: TemplateAnalysisTargetKind.Parameter);
+                }
             }
 
             foreach (var method in type.Methods)
@@ -899,6 +918,7 @@ internal sealed class TemplateFeatureService : IDisposable
             "Types" => item.TargetKind == TemplateAnalysisTargetKind.Type,
             "Classes" => item.TargetKind == TemplateAnalysisTargetKind.Type && item.Detail.StartsWith(value: "Class", comparisonType: StringComparison.OrdinalIgnoreCase),
             "Records" => item.TargetKind == TemplateAnalysisTargetKind.Type && item.Detail.StartsWith(value: "Record", comparisonType: StringComparison.OrdinalIgnoreCase),
+            "Structs" => item.TargetKind == TemplateAnalysisTargetKind.Type && item.Detail.StartsWith(value: "Struct", comparisonType: StringComparison.OrdinalIgnoreCase),
             "Interfaces" => item.TargetKind == TemplateAnalysisTargetKind.Type && item.Detail.StartsWith(value: "Interface", comparisonType: StringComparison.OrdinalIgnoreCase),
             "Enums" => item.TargetKind == TemplateAnalysisTargetKind.Type && item.Detail.StartsWith(value: "Enum", comparisonType: StringComparison.OrdinalIgnoreCase),
             "Properties" => item.TargetKind == TemplateAnalysisTargetKind.Property,
@@ -987,6 +1007,7 @@ internal sealed class TemplateFeatureService : IDisposable
         {
             TypeMetadataKind.Interface => CompletionKind.Interface,
             TypeMetadataKind.Enum => CompletionKind.Enum,
+            TypeMetadataKind.Struct => CompletionKind.Struct,
             _ => CompletionKind.Class,
         };
 
@@ -1104,6 +1125,7 @@ internal sealed class TemplateFeatureService : IDisposable
         public const int Snippet = 15;
         public const int EnumMember = 20;
         public const int Constant = 21;
+        public const int Struct = 22;
     }
 
     private static class InsertTextFormat

--- a/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
+++ b/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
@@ -289,6 +289,7 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         {
             Microsoft.CodeAnalysis.TypeKind.Class when symbol.IsRecord => TypeMetadataKind.Record,
             Microsoft.CodeAnalysis.TypeKind.Class => TypeMetadataKind.Class,
+            Microsoft.CodeAnalysis.TypeKind.Struct => TypeMetadataKind.Struct,
             Microsoft.CodeAnalysis.TypeKind.Interface => TypeMetadataKind.Interface,
             Microsoft.CodeAnalysis.TypeKind.Enum => TypeMetadataKind.Enum,
             _ => (TypeMetadataKind?)null,
@@ -340,6 +341,7 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                 .ToArray(),
             NestedClasses = GetNestedTypes(symbol: symbol, kind: TypeMetadataKind.Class, compilation: compilation).ToArray(),
             NestedRecords = GetNestedTypes(symbol: symbol, kind: TypeMetadataKind.Record, compilation: compilation).ToArray(),
+            NestedStructs = GetNestedTypes(symbol: symbol, kind: TypeMetadataKind.Struct, compilation: compilation).ToArray(),
             NestedEnums = GetNestedTypes(symbol: symbol, kind: TypeMetadataKind.Enum, compilation: compilation).ToArray(),
             NestedInterfaces = GetNestedTypes(symbol: symbol, kind: TypeMetadataKind.Interface, compilation: compilation).ToArray(),
         };
@@ -356,10 +358,11 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
             .Select(
                 selector: property =>
                 {
+                    var fullName = property.ToDisplayString(format: SymbolDisplayFormat.CSharpErrorMessageFormat);
                     var docComment = GetDocComment(symbol: property);
                     return new PropertyMetadata(
                         Name: property.Name,
-                        FullName: property.ToDisplayString(format: SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        FullName: fullName,
                         Type: CreateTypeReference(symbol: property.Type, nullableAnnotation: property.NullableAnnotation),
                         Accessibility: MapAccessibility(accessibility: property.DeclaredAccessibility),
                         HasGetter: property.GetMethod is not null,
@@ -373,7 +376,9 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                         Documentation = docComment?.Summary,
                         DocComment = docComment,
                         IsAbstract = property.IsAbstract,
+                        IsIndexer = property.IsIndexer,
                         IsVirtual = property.IsVirtual,
+                        Parameters = GetParameters(parameters: property.Parameters, parentFullName: fullName, parentPropertyFullName: fullName).ToArray(),
                     };
                 });
     }
@@ -413,9 +418,16 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
 
     private static IEnumerable<ParameterMetadata> GetParameters(
         IMethodSymbol method,
-        string methodFullName)
+        string methodFullName) =>
+        GetParameters(parameters: method.Parameters, parentFullName: methodFullName, parentMethodFullName: methodFullName);
+
+    private static IEnumerable<ParameterMetadata> GetParameters(
+        IEnumerable<IParameterSymbol> parameters,
+        string parentFullName,
+        string parentMethodFullName = "",
+        string parentPropertyFullName = "")
     {
-        return method.Parameters.Select(
+        return parameters.Select(
             selector: parameter =>
             {
                 var defaultValue = parameter.HasExplicitDefaultValue
@@ -425,17 +437,18 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
 
                 return new ParameterMetadata(
                     Name: parameter.Name,
-                    FullName: methodFullName + "." + parameter.Name,
+                    FullName: parentFullName + "." + parameter.Name,
                     Type: CreateTypeReference(symbol: parameter.Type, nullableAnnotation: parameter.NullableAnnotation),
                     HasDefaultValue: parameter.HasExplicitDefaultValue,
                     DefaultValue: defaultValue,
                     Attributes: GetAttributes(attributes: parameter.GetAttributes()).ToArray(),
-                    ParentMethodFullName: methodFullName)
+                    ParentMethodFullName: parentMethodFullName)
                 {
                     AssemblyName = GetAssemblyName(symbol: parameter),
                     Location = GetSourceLocation(symbol: parameter),
                     Documentation = docComment?.Summary,
                     DocComment = docComment,
+                    ParentPropertyFullName = parentPropertyFullName,
                 };
             });
     }
@@ -639,7 +652,9 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
     private static IEnumerable<TypeMetadataReference> GetBaseTypes(INamedTypeSymbol symbol)
     {
         if (symbol.BaseType is not null
-            && !symbol.BaseType.SpecialType.Equals(obj: SpecialType.System_Object))
+            && symbol.BaseType.SpecialType is not SpecialType.System_Object
+                and not SpecialType.System_ValueType
+                and not SpecialType.System_Enum)
         {
             yield return CreateTypeReference(symbol: symbol.BaseType, nullableAnnotation: NullableAnnotation.NotAnnotated);
         }

--- a/src/Typewriter.VisualStudio/TypewriterCompletion.cs
+++ b/src/Typewriter.VisualStudio/TypewriterCompletion.cs
@@ -25,6 +25,7 @@ internal sealed class TypewriterCompletionSource : ICompletionSource
         "Types",
         "Classes",
         "Records",
+        "Structs",
         "Interfaces",
         "Enums",
         "Properties",
@@ -48,6 +49,8 @@ internal sealed class TypewriterCompletionSource : ICompletionSource
         "IsStatic",
         "IsAbstract",
         "IsGeneric",
+        "IsStruct",
+        "IsIndexer",
         "IsCollection",
         "IsDictionary",
         "IsEnum",
@@ -77,6 +80,7 @@ internal sealed class TypewriterCompletionSource : ICompletionSource
         "public",
         "return",
         "static",
+        "struct",
         "string",
         "switch",
         "true",
@@ -103,6 +107,7 @@ internal sealed class TypewriterCompletionSource : ICompletionSource
         "Property",
         "Record",
         "Settings",
+        "Struct",
         "Type",
     ];
 

--- a/src/Typewriter.VisualStudio/TypewriterEditorClassification.cs
+++ b/src/Typewriter.VisualStudio/TypewriterEditorClassification.cs
@@ -130,6 +130,7 @@ internal sealed class TypewriterClassifier : IClassifier
     {
         "Classes",
         "Records",
+        "Structs",
         "Interfaces",
         "Enums",
         "Properties",
@@ -165,6 +166,7 @@ internal sealed class TypewriterClassifier : IClassifier
         "public",
         "return",
         "static",
+        "struct",
         "string",
         "switch",
         "Template",

--- a/tests/unit/Typewriter.Engine.Tests/CodeModelParityTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/CodeModelParityTests.cs
@@ -6,6 +6,7 @@ using Delegate = Typewriter.CodeModel.Delegate;
 using Enum = Typewriter.CodeModel.Enum;
 using File = Typewriter.CodeModel.File;
 using Record = Typewriter.CodeModel.Record;
+using Struct = Typewriter.CodeModel.Struct;
 using Type = Typewriter.CodeModel.Type;
 
 namespace Typewriter.Engine.Tests;
@@ -18,7 +19,7 @@ public sealed class CodeModelParityTests
         {
             { typeof(Attribute), ["Arguments", "AssemblyName", "FullName", "Name", "Parent", "Type", "Value", "name"] },
             { typeof(AttributeArgument), ["Type", "TypeValue", "Value"] },
-            { typeof(Class), ["AssemblyName", "Attributes", "BaseClass", "Constants", "ContainingClass", "Delegates", "DocComment", "Events", "Fields", "FullName", "Interfaces", "IsAbstract", "IsGeneric", "IsStatic", "Methods", "Name", "Namespace", "NestedClasses", "NestedEnums", "NestedInterfaces", "Parent", "Properties", "StaticReadOnlyFields", "TypeArguments", "TypeParameters", "name"] },
+            { typeof(Class), ["AssemblyName", "Attributes", "BaseClass", "Constants", "ContainingClass", "Delegates", "DocComment", "Events", "Fields", "FullName", "Interfaces", "IsAbstract", "IsGeneric", "IsStatic", "Methods", "Name", "Namespace", "NestedClasses", "NestedEnums", "NestedInterfaces", "NestedStructs", "Parent", "Properties", "StaticReadOnlyFields", "TypeArguments", "TypeParameters", "name"] },
             { typeof(Constant), ["AssemblyName", "Attributes", "DocComment", "FullName", "Name", "Parent", "Type", "Value", "name"] },
             { typeof(Delegate), ["AssemblyName", "Attributes", "DocComment", "FullName", "IsGeneric", "Name", "Parameters", "Parent", "Type", "TypeParameters", "name"] },
             { typeof(DocComment), ["Parameters", "Parent", "Returns", "Summary"] },
@@ -26,15 +27,16 @@ public sealed class CodeModelParityTests
             { typeof(EnumValue), ["AssemblyName", "Attributes", "DocComment", "FullName", "Name", "Parent", "Value", "name"] },
             { typeof(Event), ["AssemblyName", "Attributes", "DocComment", "FullName", "Name", "Parent", "Type", "name"] },
             { typeof(Field), ["AssemblyName", "Attributes", "DocComment", "FullName", "Name", "Parent", "Type", "name"] },
-            { typeof(File), ["Classes", "Delegates", "Enums", "FullName", "Interfaces", "Name", "Records"] },
-            { typeof(Interface), ["AssemblyName", "Attributes", "ContainingClass", "DocComment", "Events", "FullName", "Interfaces", "IsGeneric", "Methods", "Name", "Namespace", "Parent", "Properties", "Type", "TypeArguments", "TypeParameters", "name"] },
+            { typeof(File), ["Classes", "Delegates", "Enums", "FullName", "Interfaces", "Name", "Records", "Structs"] },
+            { typeof(Interface), ["AssemblyName", "Attributes", "ContainingClass", "DocComment", "Events", "FullName", "Interfaces", "IsGeneric", "Methods", "Name", "Namespace", "NestedStructs", "Parent", "Properties", "Type", "TypeArguments", "TypeParameters", "name"] },
             { typeof(Method), ["AssemblyName", "Attributes", "DocComment", "FullName", "IsAbstract", "IsGeneric", "Name", "Parameters", "Parent", "Type", "TypeParameters", "name"] },
             { typeof(Parameter), ["AssemblyName", "Attributes", "DefaultValue", "FullName", "HasDefaultValue", "Name", "Parent", "Type", "name"] },
             { typeof(ParameterComment), ["Description", "Name", "Parent"] },
-            { typeof(Property), ["AssemblyName", "Attributes", "DocComment", "FullName", "HasGetter", "HasSetter", "IsAbstract", "IsVirtual", "Name", "Parent", "Type", "name"] },
-            { typeof(Record), ["AssemblyName", "Attributes", "BaseRecord", "Constants", "ContainingRecord", "Delegates", "DocComment", "Events", "Fields", "FullName", "Interfaces", "IsAbstract", "IsGeneric", "Methods", "Name", "Namespace", "Parent", "Properties", "StaticReadOnlyFields", "TypeArguments", "TypeParameters", "name"] },
+            { typeof(Property), ["AssemblyName", "Attributes", "DocComment", "FullName", "HasGetter", "HasSetter", "IsAbstract", "IsIndexer", "IsVirtual", "Name", "Parameters", "Parent", "Type", "name"] },
+            { typeof(Record), ["AssemblyName", "Attributes", "BaseRecord", "Constants", "ContainingRecord", "Delegates", "DocComment", "Events", "Fields", "FullName", "Interfaces", "IsAbstract", "IsGeneric", "Methods", "Name", "Namespace", "NestedStructs", "Parent", "Properties", "StaticReadOnlyFields", "TypeArguments", "TypeParameters", "name"] },
             { typeof(StaticReadOnlyField), ["AssemblyName", "Attributes", "DocComment", "FullName", "Name", "Parent", "Type", "Value", "name"] },
-            { typeof(Type), ["AssemblyName", "Attributes", "BaseClass", "Constants", "ContainingClass", "DefaultValue", "Delegates", "DocComment", "ElementType", "Fields", "FileLocations", "FullName", "Interfaces", "IsDate", "IsDefined", "IsDictionary", "IsDynamic", "IsEnum", "IsEnumerable", "IsGeneric", "IsGuid", "IsNullable", "IsPrimitive", "IsTask", "IsTimeSpan", "IsValueTuple", "Methods", "Name", "Namespace", "NestedClasses", "NestedEnums", "NestedInterfaces", "OriginalName", "Parent", "Properties", "Settings", "StaticReadOnlyFields", "TupleElements", "TypeArguments", "TypeParameters", "name"] },
+            { typeof(Struct), ["AssemblyName", "Attributes", "Constants", "ContainingClass", "ContainingStruct", "Delegates", "DocComment", "Events", "Fields", "FullName", "Interfaces", "IsGeneric", "IsStatic", "Methods", "Name", "Namespace", "NestedClasses", "NestedEnums", "NestedInterfaces", "NestedRecords", "NestedStructs", "Parent", "Properties", "StaticReadOnlyFields", "Type", "TypeArguments", "TypeParameters", "name"] },
+            { typeof(Type), ["AssemblyName", "Attributes", "BaseClass", "Constants", "ContainingClass", "DefaultValue", "Delegates", "DocComment", "ElementType", "Fields", "FileLocations", "FullName", "Interfaces", "IsDate", "IsDefined", "IsDictionary", "IsDynamic", "IsEnum", "IsEnumerable", "IsGeneric", "IsGuid", "IsNullable", "IsPrimitive", "IsStruct", "IsTask", "IsTimeSpan", "IsValueTuple", "Methods", "Name", "Namespace", "NestedClasses", "NestedEnums", "NestedInterfaces", "NestedStructs", "OriginalName", "Parent", "Properties", "Settings", "StaticReadOnlyFields", "TupleElements", "TypeArguments", "TypeParameters", "name"] },
             { typeof(TypeParameter), ["Name", "Parent", "name"] },
         };
 #pragma warning restore CC0021 // Use nameof
@@ -63,6 +65,7 @@ public sealed class CodeModelParityTests
         var record = new Record { Name = "WidgetRecord", Type = type };
         var @interface = new Interface { Name = "IWidget", Type = type };
         var @enum = new Enum { Name = "WidgetKind", Type = type };
+        var @struct = new Struct { Name = "WidgetStruct", Type = type };
 
         string attributeName = new Attribute { Name = "Generate" };
         string className = @class;
@@ -84,6 +87,8 @@ public sealed class CodeModelParityTests
         string recordName = record;
         Type? recordType = record;
         string staticReadOnlyFieldName = new StaticReadOnlyField { Name = "StaticLabel" };
+        string structName = @struct;
+        Type? structType = @struct;
         string typeName = type;
 
         Assert.Equal(expected: "Generate", actual: attributeName);
@@ -106,6 +111,8 @@ public sealed class CodeModelParityTests
         Assert.Equal(expected: "WidgetRecord", actual: recordName);
         Assert.Same(expected: type, actual: recordType);
         Assert.Equal(expected: "StaticLabel", actual: staticReadOnlyFieldName);
+        Assert.Equal(expected: "WidgetStruct", actual: structName);
+        Assert.Same(expected: type, actual: structType);
         Assert.Equal(expected: "Widget", actual: typeName);
     }
 

--- a/tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs
@@ -87,6 +87,134 @@ public sealed class TemplateRendererTests
     }
 
     [Fact]
+    public void RenderExpandsStructsAndStructFilter()
+    {
+        var metadata = new ProjectMetadata(
+            ProjectPath: "Sample.csproj",
+            SourceFiles: [],
+            Types:
+            [
+                new TypeMetadata(
+                    Name: "User",
+                    FullName: "Sample.User",
+                    Namespace: "Sample",
+                    Kind: TypeMetadataKind.Class,
+                    Accessibility: MetadataAccessibility.Public,
+                    Properties: [],
+                    Attributes: [],
+                    BaseTypes: [],
+                    EnumValues: [],
+                    IsNullableAware: true),
+                new TypeMetadata(
+                    Name: "Point",
+                    FullName: "Sample.Point",
+                    Namespace: "Sample",
+                    Kind: TypeMetadataKind.Struct,
+                    Accessibility: MetadataAccessibility.Public,
+                    Properties:
+                    [
+                        new PropertyMetadata(
+                            Name: "X",
+                            FullName: "Sample.Point.X",
+                            Type: TypeReference(name: "Int32", fullName: "System.Int32", isNullable: false),
+                            Accessibility: MetadataAccessibility.Public,
+                            HasGetter: true,
+                            HasSetter: true,
+                            IsRequired: false,
+                            Attributes: []),
+                    ],
+                    Attributes: [],
+                    BaseTypes: [],
+                    EnumValues: [],
+                    IsNullableAware: true),
+            ],
+            Diagnostics: []);
+        const string template = "$Structs[struct $Name {$Properties[$name:$Type;]}] filtered:$Types(Struct)[$Name][,]";
+        var document = new TemplateDocument(Path: "models.tst", Content: template, OutputPath: "models.ts");
+        var diagnostics = new List<GenerationDiagnostic>();
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        Assert.Empty(collection: diagnostics);
+        Assert.Contains(expectedSubstring: "struct Point", actualString: output, comparisonType: StringComparison.Ordinal);
+        Assert.Contains(expectedSubstring: "x:number;", actualString: output, comparisonType: StringComparison.Ordinal);
+        Assert.Contains(expectedSubstring: "filtered:Point", actualString: output, comparisonType: StringComparison.Ordinal);
+        Assert.DoesNotContain(expectedSubstring: "filtered:User", actualString: output, comparisonType: StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderExposesIndexerPropertiesAndParameters()
+    {
+        var metadata = new ProjectMetadata(
+            ProjectPath: "Sample.csproj",
+            SourceFiles: [],
+            Types:
+            [
+                new TypeMetadata(
+                    Name: "Lookup",
+                    FullName: "Sample.Lookup",
+                    Namespace: "Sample",
+                    Kind: TypeMetadataKind.Class,
+                    Accessibility: MetadataAccessibility.Public,
+                    Properties:
+                    [
+                        new PropertyMetadata(
+                            Name: "Item",
+                            FullName: "Sample.Lookup.Item",
+                            Type: TypeReference(name: "String", fullName: "System.String", isNullable: false),
+                            Accessibility: MetadataAccessibility.Public,
+                            HasGetter: true,
+                            HasSetter: true,
+                            IsRequired: false,
+                            Attributes: [])
+                        {
+                            IsIndexer = true,
+                            Parameters =
+                            [
+                                new ParameterMetadata(
+                                    Name: "index",
+                                    FullName: "Sample.Lookup.Item.index",
+                                    Type: TypeReference(name: "Int32", fullName: "System.Int32", isNullable: false),
+                                    HasDefaultValue: false,
+                                    DefaultValue: null,
+                                    Attributes: [],
+                                    ParentMethodFullName: string.Empty)
+                                {
+                                    ParentPropertyFullName = "Sample.Lookup.Item",
+                                },
+                                new ParameterMetadata(
+                                    Name: "key",
+                                    FullName: "Sample.Lookup.Item.key",
+                                    Type: TypeReference(name: "String", fullName: "System.String", isNullable: true),
+                                    HasDefaultValue: false,
+                                    DefaultValue: null,
+                                    Attributes: [],
+                                    ParentMethodFullName: string.Empty)
+                                {
+                                    ParentPropertyFullName = "Sample.Lookup.Item",
+                                },
+                            ],
+                        },
+                    ],
+                    Attributes: [],
+                    BaseTypes: [],
+                    EnumValues: [],
+                    IsNullableAware: true),
+            ],
+            Diagnostics: []);
+        const string template = "$Classes[$Properties[$IsIndexer[$Parameters[$name:$Type][, ]->$Type;]]]";
+        var document = new TemplateDocument(Path: "models.tst", Content: template, OutputPath: "models.ts");
+        var diagnostics = new List<GenerationDiagnostic>();
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        Assert.Empty(collection: diagnostics);
+        Assert.Contains(expectedSubstring: "index:number, key:string | null->string;", actualString: output, comparisonType: StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderPreservesNullableDictionaryWhenValueTypeIsNullable()
     {
         var keyType = TypeReference(name: "String", fullName: "System.String", isNullable: false);

--- a/tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs
@@ -144,6 +144,88 @@ public sealed class TemplateRendererTests
     }
 
     [Fact]
+    public void RenderContainingTypeAccessorsAreKindFiltered()
+    {
+        var metadata = new ProjectMetadata(
+            ProjectPath: "Sample.csproj",
+            SourceFiles: [],
+            Types:
+            [
+                CreateType(name: "ClassContainer", kind: TypeMetadataKind.Class),
+                CreateType(name: "RecordContainer", kind: TypeMetadataKind.Record),
+                CreateType(name: "StructContainer", kind: TypeMetadataKind.Struct),
+                CreateType(name: "NestedInClass", kind: TypeMetadataKind.Struct, containingTypeFullName: "Sample.ClassContainer"),
+                CreateType(name: "NestedInRecord", kind: TypeMetadataKind.Struct, containingTypeFullName: "Sample.RecordContainer"),
+                CreateType(name: "NestedInStruct", kind: TypeMetadataKind.Struct, containingTypeFullName: "Sample.StructContainer"),
+            ],
+            Diagnostics: []);
+        const string template = "$Types(Struct)[$Name:C=$ContainingClass[$Name];R=$ContainingRecord[$Name];S=$ContainingStruct[$Name];]";
+        var document = new TemplateDocument(Path: "models.tst", Content: template, OutputPath: "models.ts");
+        var diagnostics = new List<GenerationDiagnostic>();
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        Assert.Empty(collection: diagnostics);
+        Assert.Contains(expectedSubstring: "NestedInClass:C=ClassContainer;R=;S=;", actualString: output, comparisonType: StringComparison.Ordinal);
+        Assert.Contains(expectedSubstring: "NestedInRecord:C=;R=RecordContainer;S=;", actualString: output, comparisonType: StringComparison.Ordinal);
+        Assert.Contains(expectedSubstring: "NestedInStruct:C=;R=;S=StructContainer;", actualString: output, comparisonType: StringComparison.Ordinal);
+
+        static TypeMetadata CreateType(
+            string name,
+            TypeMetadataKind kind,
+            string containingTypeFullName = "")
+        {
+            return new TypeMetadata(
+                Name: name,
+                FullName: "Sample." + name,
+                Namespace: "Sample",
+                Kind: kind,
+                Accessibility: MetadataAccessibility.Public,
+                Properties: [],
+                Attributes: [],
+                BaseTypes: [],
+                EnumValues: [],
+                IsNullableAware: true)
+            {
+                ContainingTypeFullName = containingTypeFullName,
+            };
+        }
+    }
+
+    [Fact]
+    public void RenderEscapedDollarSignsAsLiterals()
+    {
+        var metadata = new ProjectMetadata(
+            ProjectPath: "Sample.csproj",
+            SourceFiles: [],
+            Types:
+            [
+                new TypeMetadata(
+                    Name: "User",
+                    FullName: "Sample.User",
+                    Namespace: "Sample",
+                    Kind: TypeMetadataKind.Class,
+                    Accessibility: MetadataAccessibility.Public,
+                    Properties: [],
+                    Attributes: [],
+                    BaseTypes: [],
+                    EnumValues: [],
+                    IsNullableAware: true),
+            ],
+            Diagnostics: []);
+        const string template = "$Classes[$$type $$Name $${environment.apiBaseUrl} $$$Name]";
+        var document = new TemplateDocument(Path: "models.tst", Content: template, OutputPath: "models.ts");
+        var diagnostics = new List<GenerationDiagnostic>();
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        Assert.Empty(collection: diagnostics);
+        Assert.Equal(expected: "$type $Name ${environment.apiBaseUrl} $User", actual: output);
+    }
+
+    [Fact]
     public void RenderExposesIndexerPropertiesAndParameters()
     {
         var metadata = new ProjectMetadata(

--- a/tests/unit/Typewriter.LanguageServer.Tests/TemplateFeatureServiceTests.cs
+++ b/tests/unit/Typewriter.LanguageServer.Tests/TemplateFeatureServiceTests.cs
@@ -24,8 +24,12 @@ public sealed class TemplateFeatureServiceTests
             var completions = await service.GetCompletionsAsync(document: document, settings: settings, position: new LspPosition(Line: 3, Character: 1), cancellationToken: CancellationToken.None);
 
             Assert.Contains(collection: completions.Items, filter: item => item.Label == "Classes");
+            Assert.Contains(collection: completions.Items, filter: item => item.Label == "Structs");
             Assert.Contains(collection: completions.Items, filter: item => item.Label == "Customer");
+            Assert.Contains(collection: completions.Items, filter: item => item.Label == "Coordinate");
             Assert.Contains(collection: completions.Items, filter: item => item.Label == "DisplayName");
+            Assert.Contains(collection: completions.Items, filter: item => item.Label == "index");
+            Assert.Contains(collection: completions.Items, filter: item => item.Label == "IsIndexer");
             Assert.Contains(collection: completions.Items, filter: item => item.Label == "FormatName");
         }
         finally
@@ -99,6 +103,7 @@ public sealed class TemplateFeatureServiceTests
             Assert.Contains(collection: completions.Items, filter: item => item.Label == "string");
             Assert.Contains(collection: completions.Items, filter: item => item.Label == "Class");
             Assert.Contains(collection: completions.Items, filter: item => item.Label == "File");
+            Assert.Contains(collection: completions.Items, filter: item => item.Label == "Struct");
         }
         finally
         {
@@ -467,6 +472,13 @@ public sealed class TemplateFeatureServiceTests
                       {
                           /// <summary>Display name docs.</summary>
                           public required string DisplayName { get; init; }
+
+                              public string this[int index] => DisplayName;
+                          }
+
+                          public struct Coordinate
+                          {
+                              public int X { get; init; }
                       }
                       """).ConfigureAwait(continueOnCapturedContext: false);
         await File.WriteAllTextAsync(

--- a/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
+++ b/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
@@ -77,9 +77,25 @@ public sealed class CSharpProjectMetadataProviderTests
                               public IReadOnlyDictionary<string, User?> RelatedUsers { get; init; } = new Dictionary<string, User?>();
 
                               public OrderStatus DefaultStatus { get; init; }
+
+                              public string this[[FromRoute] int index, string? key]
+                              {
+                                  get => DisplayName;
+                                  set { }
+                              }
                           }
 
                           public sealed record Order(int Id, decimal Total);
+
+                          public struct Money
+                          {
+                              public decimal Amount { get; set; }
+
+                              public struct Token
+                              {
+                                  public int Value { get; set; }
+                              }
+                          }
 
                           [GenerateFrontendType]
                           public sealed class UsersController : ControllerBase
@@ -119,6 +135,22 @@ public sealed class CSharpProjectMetadataProviderTests
             var displayName = Assert.Single(collection: user.Properties.Where(predicate: property => property.Name == "DisplayName"));
             Assert.Equal(expected: "Name shown to users.", actual: displayName.Documentation);
             Assert.NotNull(@object: displayName.Location);
+            var indexer = Assert.Single(collection: user.Properties.Where(predicate: property => property.IsIndexer));
+            Assert.Collection(
+                collection: indexer.Parameters,
+                parameter =>
+                {
+                    Assert.Equal(expected: "index", actual: parameter.Name);
+                    Assert.Equal(expected: "Int32", actual: parameter.Type.Name);
+                    Assert.Contains(collection: parameter.Attributes, filter: attribute => attribute.Name == "FromRoute");
+                    Assert.Equal(expected: indexer.FullName, actual: parameter.ParentPropertyFullName);
+                },
+                parameter =>
+                {
+                    Assert.Equal(expected: "key", actual: parameter.Name);
+                    Assert.True(condition: parameter.Type.IsNullable);
+                    Assert.Equal(expected: indexer.FullName, actual: parameter.ParentPropertyFullName);
+                });
             var orders = Assert.Single(collection: user.Properties.Where(predicate: property => property.Name == "Orders"));
             Assert.True(condition: orders.Type.IsCollection);
             Assert.Equal(expected: "Order", actual: orders.Type.ElementType?.Name);
@@ -137,6 +169,10 @@ public sealed class CSharpProjectMetadataProviderTests
                 value => Assert.Equal(expected: (string?)"Paid", actual: (string?)value.Name));
             var order = Assert.Single(collection: metadata.Types.Where(predicate: type => type.Name == "Order"));
             Assert.Equal(expected: TypeMetadataKind.Record, actual: order.Kind);
+            var money = Assert.Single(collection: metadata.Types.Where(predicate: type => type.Name == "Money"));
+            Assert.Equal(expected: TypeMetadataKind.Struct, actual: money.Kind);
+            Assert.Contains(collection: money.Properties, filter: property => property.Name == "Amount");
+            Assert.Contains(collection: money.NestedStructs, filter: nested => nested.Name == "Token");
             var controller = Assert.Single(collection: metadata.Types.Where(predicate: type => type.Name == "UsersController"));
             Assert.False(condition: controller.IsStatic);
             var apiVersion = Assert.Single(collection: controller.Constants.Where(predicate: constant => constant.Name == "ApiVersion"));


### PR DESCRIPTION
This pull request introduces first-class support for structs and indexers in the Typewriter code generation engine and its abstractions. It adds new metadata, code model types, and template capabilities to enable struct and indexer rendering, along with documentation and tests. The changes also update the version to 4.1.0 and document the new features in the README.

**Struct and Indexer Support:**

- Added struct metadata and template rendering support, including new `Struct` code model classes, `IStructCollection`, and related collections and properties across the engine and abstractions. Structs can now be rendered in templates using `$Structs[...]` and filtered via `$Types(Struct)[...]`. [[1]](diffhunk://#diff-79f33fb17e81629a25b39c6a43f5075f8bcd4e0bd79252c46f42d589929274cbR1-R54) [[2]](diffhunk://#diff-fab136d563709e13d2fb1534d6d2ece93bc1d3aad32a8f992172abae4f5c3e7eR1-R26) [[3]](diffhunk://#diff-5328fbe0eb18e987425f396f625a343214f0ce13a2812b4218625b02e342d74bR1-R5) [[4]](diffhunk://#diff-d20885a9cfb73b876e812390607fc68d35bc4ee1018e6fe80eaf278c7a89008fR51-R52) [[5]](diffhunk://#diff-203d88d977b1487b3b23793275f6a7ee2a1a34f25cde45cad756ff67f9895649R41-R42) [[6]](diffhunk://#diff-194dda4958282c97dac3dffe72b1b58f1040e93032ec2d0c8b7217394ca6142fR17-R18) [[7]](diffhunk://#diff-061e60471bc8e2798d9b9d156208fcce3cffb74559caf23f73d4e897a68bbb3fR21-R22) [[8]](diffhunk://#diff-7a9dc4b4c58d4a867f2ed94be6073c800a34a40e811745c61f05287ef2df69bfR39-R40) [[9]](diffhunk://#diff-ec16ab974cb13fb0d40686007830a17b705bfcde436c1f44b70b01f8d90b186dR67-R68) [[10]](diffhunk://#diff-dd8c4c952537e595708e5ca27eddade78ba38ce0b6c4d1379447519c853ae898R218-R221) [[11]](diffhunk://#diff-dd8c4c952537e595708e5ca27eddade78ba38ce0b6c4d1379447519c853ae898R249-R253) [[12]](diffhunk://#diff-dd8c4c952537e595708e5ca27eddade78ba38ce0b6c4d1379447519c853ae898R302)
- Introduced the `Struct` kind to `TypeMetadataKind` and the `IsStruct` property to the `Type` code model for accurate struct identification. [[1]](diffhunk://#diff-d239eca266b14db3c006364b0ac3e608fb6b726c27b5a3752d08b407228d6729R7) [[2]](diffhunk://#diff-ec16ab974cb13fb0d40686007830a17b705bfcde436c1f44b70b01f8d90b186dR47-R48)
- Enhanced the `Property` code model and metadata to support indexers via the `IsIndexer` property and a `Parameters` collection, enabling template rendering for indexer properties. [[1]](diffhunk://#diff-c6b125376954742e1795f04eaf3e7b2b57836f17bb0d881f56f9d7cbde81584aR25-R29) [[2]](diffhunk://#diff-be9bed3fc8d869ed58f31c10d1999bb0bcf5774a32600bf8be65f425e44a9749R15-R22) [[3]](diffhunk://#diff-e8a6711c0e06fec098255dbfec5c18fd59210ba408e4718b84ee215a1165ec47R19-R20)

**Template Engine and Adapter Updates:**

- Updated the `TemplateCodeModelAdapterFactory` to handle struct and indexer metadata, including mapping, adaptation, and collection initialization for structs and properties with parameters. [[1]](diffhunk://#diff-dd8c4c952537e595708e5ca27eddade78ba38ce0b6c4d1379447519c853ae898R15) [[2]](diffhunk://#diff-dd8c4c952537e595708e5ca27eddade78ba38ce0b6c4d1379447519c853ae898R25) [[3]](diffhunk://#diff-dd8c4c952537e595708e5ca27eddade78ba38ce0b6c4d1379447519c853ae898R54-R57)

**Documentation and Versioning:**

- Updated the `README.md` with new sections and examples for struct and indexer templates, and added a changelog describing the 4.1.0 release features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R66-R67) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L348-R428) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R825-R834)
- Bumped the project version to 4.1.0 in `Directory.Build.props`.