### PR TITLE
Fixes #80. Missing right click commands.

### DIFF
--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -54,5 +54,29 @@
                 text="Validate Current Template"
                 description="Validate the current Typewriter template without writing generated files" />
         </group>
+        <group id="Typewriter.ContextMenu" text="Typewriter" popup="true">
+            <add-to-group group-id="SolutionExplorerPopupMenu" anchor="last" />
+            <action
+                id="Typewriter.RenderTemplate"
+                class="com.adaskothebeast.typewriter.rider.TypewriterGenerateCurrentAction"
+                text="Render Template"
+                description="Generate TypeScript from the selected Typewriter template" />
+            <action
+                id="Typewriter.RenderAllTemplates"
+                class="com.adaskothebeast.typewriter.rider.TypewriterGenerateAllAction"
+                text="Render All Templates"
+                description="Generate TypeScript from all discovered Typewriter templates" />
+            <action
+                id="Typewriter.ValidateTemplate"
+                class="com.adaskothebeast.typewriter.rider.TypewriterValidateCurrentAction"
+                text="Validate Template"
+                description="Validate the selected Typewriter template without writing generated files" />
+        </group>
+        <group id="Typewriter.EditorContextMenu" text="Typewriter" popup="true">
+            <add-to-group group-id="EditorLangPopupMenu" anchor="last" />
+            <reference ref="Typewriter.RenderTemplate" />
+            <reference ref="Typewriter.RenderAllTemplates" />
+            <reference ref="Typewriter.ValidateTemplate" />
+        </group>
     </actions>
 </idea-plugin>

--- a/src/Typewriter.VisualStudio/TypewriterCommandService.cs
+++ b/src/Typewriter.VisualStudio/TypewriterCommandService.cs
@@ -598,16 +598,19 @@ internal sealed class TypewriterCommandService
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         var dte = GetGlobalDte();
-        return IsTemplatePath(path: ResolveSelectedTemplatePath(dte: dte))
-            || IsTemplatePath(path: dte?.ActiveDocument?.FullName);
+        return IsSolutionExplorerActive(dte: dte)
+            ? IsTemplatePath(path: ResolveSelectedTemplatePath(dte: dte))
+            : IsTemplatePath(path: dte?.ActiveDocument?.FullName);
     }
 
     private static bool HasRenderAllContext()
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         var dte = GetGlobalDte();
-        return GetSelectedProjectNodePath(dte: dte) is not null
-            || HasTemplateContext();
+        return IsSolutionExplorerActive(dte: dte)
+            ? GetSelectedProjectNodePath(dte: dte) is not null
+              || IsTemplatePath(path: ResolveSelectedTemplatePath(dte: dte))
+            : IsTemplatePath(path: dte?.ActiveDocument?.FullName);
     }
 
     private static DTE2? GetGlobalDte()

--- a/src/Typewriter.VisualStudio/TypewriterCommandService.cs
+++ b/src/Typewriter.VisualStudio/TypewriterCommandService.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,24 +41,33 @@ internal sealed class TypewriterCommandService
             return;
         }
 
-        commandService.AddCommand(
-            command: new OleMenuCommand(
-                invokeHandler: (_, _) => RunAsync(action: () => GenerateCurrentTemplateAsync(templatePathOverride: null, cancellationToken: CancellationToken.None)),
-                id: new CommandID(
-                    menuGroup: TypewriterVisualStudioConstants.CommandSetGuid,
-                    commandID: TypewriterVisualStudioConstants.GenerateCurrentTemplateCommandId)));
-        commandService.AddCommand(
-            command: new OleMenuCommand(
-                invokeHandler: (_, _) => RunAsync(action: () => GenerateAllTemplatesAsync(cancellationToken: CancellationToken.None)),
-                id: new CommandID(
-                    menuGroup: TypewriterVisualStudioConstants.CommandSetGuid,
-                    commandID: TypewriterVisualStudioConstants.GenerateAllTemplatesCommandId)));
-        commandService.AddCommand(
-            command: new OleMenuCommand(
-                invokeHandler: (_, _) => RunAsync(action: () => ValidateCurrentTemplateAsync(cancellationToken: CancellationToken.None)),
-                id: new CommandID(
-                    menuGroup: TypewriterVisualStudioConstants.CommandSetGuid,
-                    commandID: TypewriterVisualStudioConstants.ValidateCurrentTemplateCommandId)));
+        AddCommand(
+            commandService: commandService,
+            commandId: TypewriterVisualStudioConstants.GenerateCurrentTemplateCommandId,
+            action: () => GenerateCurrentTemplateAsync(templatePathOverride: null, cancellationToken: CancellationToken.None));
+        AddCommand(
+            commandService: commandService,
+            commandId: TypewriterVisualStudioConstants.GenerateAllTemplatesCommandId,
+            action: () => GenerateAllTemplatesAsync(cancellationToken: CancellationToken.None));
+        AddCommand(
+            commandService: commandService,
+            commandId: TypewriterVisualStudioConstants.ValidateCurrentTemplateCommandId,
+            action: () => ValidateCurrentTemplateAsync(cancellationToken: CancellationToken.None));
+        AddContextCommand(
+            commandService: commandService,
+            commandId: TypewriterVisualStudioConstants.RenderTemplateCommandId,
+            action: () => GenerateCurrentTemplateAsync(templatePathOverride: null, cancellationToken: CancellationToken.None),
+            isVisible: HasTemplateContext);
+        AddContextCommand(
+            commandService: commandService,
+            commandId: TypewriterVisualStudioConstants.RenderAllTemplatesCommandId,
+            action: () => GenerateAllTemplatesAsync(cancellationToken: CancellationToken.None),
+            isVisible: HasRenderAllContext);
+        AddContextCommand(
+            commandService: commandService,
+            commandId: TypewriterVisualStudioConstants.ValidateTemplateCommandId,
+            action: () => ValidateCurrentTemplateAsync(cancellationToken: CancellationToken.None),
+            isVisible: HasTemplateContext);
     }
 
     public Task GenerateSavedTemplateAsync(
@@ -67,6 +77,41 @@ internal sealed class TypewriterCommandService
             message: "Typewriter generate-on-save failed.",
             action: () => GenerateCurrentTemplateAsync(templatePathOverride: templatePath, cancellationToken: cancellationToken),
             cancellationToken: cancellationToken);
+
+    private void AddCommand(
+        OleMenuCommandService commandService,
+        int commandId,
+        Func<Task> action)
+    {
+        commandService.AddCommand(
+            command: new OleMenuCommand(
+                invokeHandler: (_, _) => RunAsync(action: action),
+                id: CreateCommandId(commandId: commandId)));
+    }
+
+    private void AddContextCommand(
+        OleMenuCommandService commandService,
+        int commandId,
+        Func<Task> action,
+        Func<bool> isVisible)
+    {
+        var command = new OleMenuCommand(
+            invokeHandler: (_, _) => RunAsync(action: action),
+            id: CreateCommandId(commandId: commandId));
+        command.BeforeQueryStatus += (_, _) =>
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            var visible = isVisible();
+            command.Visible = visible;
+            command.Enabled = visible;
+        };
+        commandService.AddCommand(command: command);
+    }
+
+    private static CommandID CreateCommandId(int commandId) =>
+        new(
+            menuGroup: TypewriterVisualStudioConstants.CommandSetGuid,
+            commandID: commandId);
 
     private void RunAsync(Func<Task> action)
     {
@@ -176,8 +221,10 @@ internal sealed class TypewriterCommandService
             return null;
         }
 
+        var selectedProjectPath = IsSolutionExplorerActive(dte: dte) ? GetSelectedProjectPath(dte: dte) : null;
         var projectPath = ResolveConfiguredPath(value: options.ProjectPath)
-            ?? FindProjectPathForTemplate(dte: dte, templatePath: templatePath)
+            ?? (templatePath is not null ? FindProjectPathForTemplate(dte: dte, templatePath: templatePath) : selectedProjectPath)
+            ?? selectedProjectPath
             ?? GetActiveProjectPath(dte: dte);
         var workspacePath = ResolveConfiguredPath(value: options.WorkspacePath)
             ?? GetSolutionPath(dte: dte)
@@ -360,13 +407,14 @@ internal sealed class TypewriterCommandService
         var candidate = templatePathOverride;
         if (string.IsNullOrWhiteSpace(value: candidate))
         {
-            candidate = dte?.ActiveDocument?.FullName;
+            var selectedTemplatePath = ResolveSelectedTemplatePath(dte: dte);
+            var activeTemplatePath = dte?.ActiveDocument?.FullName;
+            candidate = IsSolutionExplorerActive(dte: dte)
+                ? selectedTemplatePath ?? activeTemplatePath
+                : activeTemplatePath ?? selectedTemplatePath;
         }
 
-        return !string.IsNullOrWhiteSpace(value: candidate)
-            && Path.GetExtension(path: candidate).Equals(value: ".tst", comparisonType: StringComparison.OrdinalIgnoreCase)
-                ? candidate
-                : null;
+        return IsTemplatePath(path: candidate) ? candidate : null;
     }
 
     private static string? GetSolutionPath(DTE2? dte)
@@ -379,6 +427,213 @@ internal sealed class TypewriterCommandService
     {
         ThreadHelper.ThrowIfNotOnUIThread();
         return dte?.ActiveDocument?.ProjectItem?.ContainingProject?.FullName;
+    }
+
+    private static string? ResolveSelectedTemplatePath(DTE2? dte)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        return GetSelectedItems(dte: dte)
+            .Select(selector: selectedItem => GetProjectItemPath(projectItem: GetSelectedProjectItem(selectedItem: selectedItem)))
+            .FirstOrDefault(predicate: IsTemplatePath);
+    }
+
+    private static string? GetSelectedProjectPath(DTE2? dte)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        foreach (var selectedItem in GetSelectedItems(dte: dte))
+        {
+            var projectItem = GetSelectedProjectItem(selectedItem: selectedItem);
+            var projectPath = GetProjectPath(project: GetSelectedProject(selectedItem: selectedItem))
+                ?? GetProjectPath(project: projectItem?.ContainingProject);
+            if (!string.IsNullOrWhiteSpace(value: projectPath))
+            {
+                return projectPath;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? GetSelectedProjectNodePath(DTE2? dte)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        return GetSelectedItems(dte: dte)
+            .Select(selector: selectedItem => GetProjectPath(project: GetSelectedProject(selectedItem: selectedItem)))
+            .FirstOrDefault(predicate: path => !string.IsNullOrWhiteSpace(value: path));
+    }
+
+    private static IReadOnlyList<SelectedItem> GetSelectedItems(DTE2? dte)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var selectedItems = dte?.SelectedItems;
+        if (selectedItems is null)
+        {
+            return [];
+        }
+
+        int count;
+        try
+        {
+            count = selectedItems.Count;
+        }
+        catch (COMException)
+        {
+            return [];
+        }
+
+        var items = new List<SelectedItem>();
+        for (var index = 1; index <= count; index++)
+        {
+            try
+            {
+                if (selectedItems.Item(index) is SelectedItem selectedItem)
+                {
+                    items.Add(item: selectedItem);
+                }
+            }
+            catch (COMException)
+            {
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        return items;
+    }
+
+    private static ProjectItem? GetSelectedProjectItem(SelectedItem selectedItem)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            return selectedItem.ProjectItem;
+        }
+        catch (COMException)
+        {
+            return null;
+        }
+        catch (NotImplementedException)
+        {
+            return null;
+        }
+    }
+
+    private static Project? GetSelectedProject(SelectedItem selectedItem)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            return selectedItem.Project;
+        }
+        catch (COMException)
+        {
+            return null;
+        }
+        catch (NotImplementedException)
+        {
+            return null;
+        }
+    }
+
+    private static string? GetProjectItemPath(ProjectItem? projectItem)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (projectItem is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            for (var index = 1; index <= projectItem.FileCount; index++)
+            {
+                var path = projectItem.FileNames[(short)index];
+                if (!string.IsNullOrWhiteSpace(value: path))
+                {
+                    return path;
+                }
+            }
+        }
+        catch (COMException)
+        {
+        }
+        catch (ArgumentException)
+        {
+        }
+        catch (NotImplementedException)
+        {
+        }
+
+        return null;
+    }
+
+    private static string? GetProjectPath(Project? project)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (project is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return string.IsNullOrWhiteSpace(value: project.FullName) ? null : project.FullName;
+        }
+        catch (COMException)
+        {
+            return null;
+        }
+        catch (NotImplementedException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsTemplatePath(string? path) =>
+        !string.IsNullOrWhiteSpace(value: path)
+        && Path.GetExtension(path: path).Equals(value: ".tst", comparisonType: StringComparison.OrdinalIgnoreCase);
+
+    private static bool HasTemplateContext()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var dte = GetGlobalDte();
+        return IsTemplatePath(path: ResolveSelectedTemplatePath(dte: dte))
+            || IsTemplatePath(path: dte?.ActiveDocument?.FullName);
+    }
+
+    private static bool HasRenderAllContext()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var dte = GetGlobalDte();
+        return GetSelectedProjectNodePath(dte: dte) is not null
+            || HasTemplateContext();
+    }
+
+    private static DTE2? GetGlobalDte()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        return Package.GetGlobalService(typeof(DTE)) as DTE2;
+    }
+
+    private static bool IsSolutionExplorerActive(DTE2? dte)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            return string.Equals(
+                a: dte?.ActiveWindow?.Kind,
+                b: Constants.vsWindowKindSolutionExplorer,
+                comparisonType: StringComparison.OrdinalIgnoreCase);
+        }
+        catch (COMException)
+        {
+            return false;
+        }
+        catch (NotImplementedException)
+        {
+            return false;
+        }
     }
 
     private static string? FindProjectPathForTemplate(

--- a/src/Typewriter.VisualStudio/TypewriterPackage.vsct
+++ b/src/Typewriter.VisualStudio/TypewriterPackage.vsct
@@ -8,6 +8,15 @@
       <Group guid="guidTypewriterCommandSet" id="TypewriterMenuGroup" priority="0x0600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_TOOLS" />
       </Group>
+      <Group guid="guidTypewriterCommandSet" id="TypewriterEditorContextMenuGroup" priority="0x0600">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN" />
+      </Group>
+      <Group guid="guidTypewriterCommandSet" id="TypewriterItemContextMenuGroup" priority="0x0600">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />
+      </Group>
+      <Group guid="guidTypewriterCommandSet" id="TypewriterProjectContextMenuGroup" priority="0x0600">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PROJNODE" />
+      </Group>
     </Groups>
 
     <Buttons>
@@ -29,16 +38,58 @@
           <ButtonText>Typewriter: Validate Current Template</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidTypewriterCommandSet" id="cmdidRenderTemplate" priority="0x0200" type="Button">
+        <Parent guid="guidTypewriterCommandSet" id="TypewriterItemContextMenuGroup" />
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Render Template</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidTypewriterCommandSet" id="cmdidRenderAllTemplates" priority="0x0201" type="Button">
+        <Parent guid="guidTypewriterCommandSet" id="TypewriterItemContextMenuGroup" />
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Render All Templates</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidTypewriterCommandSet" id="cmdidValidateTemplate" priority="0x0202" type="Button">
+        <Parent guid="guidTypewriterCommandSet" id="TypewriterItemContextMenuGroup" />
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Validate Template</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
   </Commands>
+
+  <CommandPlacements>
+    <CommandPlacement guid="guidTypewriterCommandSet" id="cmdidRenderTemplate" priority="0x0200">
+      <Parent guid="guidTypewriterCommandSet" id="TypewriterEditorContextMenuGroup" />
+    </CommandPlacement>
+    <CommandPlacement guid="guidTypewriterCommandSet" id="cmdidRenderAllTemplates" priority="0x0201">
+      <Parent guid="guidTypewriterCommandSet" id="TypewriterEditorContextMenuGroup" />
+    </CommandPlacement>
+    <CommandPlacement guid="guidTypewriterCommandSet" id="cmdidRenderAllTemplates" priority="0x0201">
+      <Parent guid="guidTypewriterCommandSet" id="TypewriterProjectContextMenuGroup" />
+    </CommandPlacement>
+    <CommandPlacement guid="guidTypewriterCommandSet" id="cmdidValidateTemplate" priority="0x0202">
+      <Parent guid="guidTypewriterCommandSet" id="TypewriterEditorContextMenuGroup" />
+    </CommandPlacement>
+  </CommandPlacements>
 
   <Symbols>
     <GuidSymbol name="guidTypewriterPackage" value="{0f42254e-a1f3-45bb-9209-b7a4d5c30791}" />
     <GuidSymbol name="guidTypewriterCommandSet" value="{70f36224-b7ab-491c-9f9c-b241ebafde9a}">
       <IDSymbol name="TypewriterMenuGroup" value="0x1020" />
+      <IDSymbol name="TypewriterEditorContextMenuGroup" value="0x1021" />
+      <IDSymbol name="TypewriterItemContextMenuGroup" value="0x1022" />
+      <IDSymbol name="TypewriterProjectContextMenuGroup" value="0x1023" />
       <IDSymbol name="cmdidGenerateCurrentTemplate" value="0x0100" />
       <IDSymbol name="cmdidGenerateAllTemplates" value="0x0101" />
       <IDSymbol name="cmdidValidateCurrentTemplate" value="0x0102" />
+      <IDSymbol name="cmdidRenderTemplate" value="0x0200" />
+      <IDSymbol name="cmdidRenderAllTemplates" value="0x0201" />
+      <IDSymbol name="cmdidValidateTemplate" value="0x0202" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/src/Typewriter.VisualStudio/TypewriterVisualStudioConstants.cs
+++ b/src/Typewriter.VisualStudio/TypewriterVisualStudioConstants.cs
@@ -11,4 +11,7 @@ internal static class TypewriterVisualStudioConstants
     public const int GenerateCurrentTemplateCommandId = 0x0100;
     public const int GenerateAllTemplatesCommandId = 0x0101;
     public const int ValidateCurrentTemplateCommandId = 0x0102;
+    public const int RenderTemplateCommandId = 0x0200;
+    public const int RenderAllTemplatesCommandId = 0x0201;
+    public const int ValidateTemplateCommandId = 0x0202;
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -55,21 +55,60 @@
     "commands": [
       {
         "command": "typewriter.generate",
-        "title": "Typewriter: Generate Current Template"
+        "title": "Typewriter: Generate Current Template",
+        "shortTitle": "Render Template"
       },
       {
         "command": "typewriter.generateAll",
-        "title": "Typewriter: Generate All Templates"
+        "title": "Typewriter: Generate All Templates",
+        "shortTitle": "Render All Templates"
       },
       {
         "command": "typewriter.validate",
-        "title": "Typewriter: Validate Current Template"
+        "title": "Typewriter: Validate Current Template",
+        "shortTitle": "Validate Template"
       },
       {
         "command": "typewriter.restartServer",
         "title": "Typewriter: Restart Language Server"
       }
     ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "typewriter.generate",
+          "when": "resourceScheme == file && resourceExtname == .tst",
+          "group": "typewriter@1"
+        },
+        {
+          "command": "typewriter.generateAll",
+          "when": "resourceScheme == file && resourceExtname == .tst",
+          "group": "typewriter@2"
+        },
+        {
+          "command": "typewriter.validate",
+          "when": "resourceScheme == file && resourceExtname == .tst",
+          "group": "typewriter@3"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "typewriter.generate",
+          "when": "resourceScheme == file && resourceExtname == .tst",
+          "group": "typewriter@1"
+        },
+        {
+          "command": "typewriter.generateAll",
+          "when": "resourceScheme == file && resourceExtname == .tst",
+          "group": "typewriter@2"
+        },
+        {
+          "command": "typewriter.validate",
+          "when": "resourceScheme == file && resourceExtname == .tst",
+          "group": "typewriter@3"
+        }
+      ]
+    },
     "configuration": {
       "title": "Typewriter",
       "properties": {

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -15,9 +15,9 @@ async function activate(context) {
 
     context.subscriptions.push(outputChannel, diagnostics);
     context.subscriptions.push(
-        vscode.commands.registerCommand("typewriter.generate", () => executeCurrentTemplate(context, "generate")),
-        vscode.commands.registerCommand("typewriter.generateAll", () => executeGenerateAll(context)),
-        vscode.commands.registerCommand("typewriter.validate", () => executeCurrentTemplate(context, "validate")),
+        vscode.commands.registerCommand("typewriter.generate", uri => executeCurrentTemplate(context, "generate", undefined, toFileUri(uri))),
+        vscode.commands.registerCommand("typewriter.generateAll", uri => executeGenerateAll(context, toFileUri(uri))),
+        vscode.commands.registerCommand("typewriter.validate", uri => executeCurrentTemplate(context, "validate", undefined, toFileUri(uri))),
         vscode.commands.registerCommand("typewriter.restartServer", () => restartLanguageServer(context)),
         createFallbackCompletionProvider(),
         vscode.workspace.onDidSaveTextDocument(document => handleDocumentSaved(context, document)));
@@ -123,28 +123,28 @@ async function stopLanguageServer() {
     await client.stop();
 }
 
-async function executeCurrentTemplate(context, command, document) {
-    const templatePath = await resolveCurrentTemplatePath(document);
+async function executeCurrentTemplate(context, command, document, resourceUri) {
+    const templatePath = await resolveCurrentTemplatePath(document, resourceUri);
     if (!templatePath) {
         return;
     }
 
-    await executeCliCommand(context, command, templatePath);
+    await executeCliCommand(context, command, templatePath, { resourceUri });
 }
 
-async function executeGenerateAll(context) {
-    await executeCliCommand(context, "generate", undefined, { allTemplates: true });
+async function executeGenerateAll(context, resourceUri) {
+    await executeCliCommand(context, "generate", undefined, { allTemplates: true, resourceUri });
 }
 
 async function executeCliCommand(context, command, templatePath, options = {}) {
-    const workspacePath = resolveWorkspacePath(templatePath);
+    const workspacePath = resolveWorkspacePath(templatePath, options.resourceUri);
     if (!workspacePath) {
         vscode.window.showErrorMessage("Typewriter requires an open workspace or configured typewriter.workspacePath.");
         return;
     }
 
     const workingDirectory = getWorkingDirectory(workspacePath);
-    const configuration = getConfiguration(templatePath ? vscode.Uri.file(templatePath) : undefined);
+    const configuration = getConfiguration(templatePath ? vscode.Uri.file(templatePath) : options.resourceUri);
     const args = buildTypewriterArguments(command, workspacePath, templatePath, configuration, options);
     const invocation = resolveCliInvocation(context, workingDirectory, configuration);
 
@@ -359,11 +359,13 @@ function buildLanguageServerInitializationOptions(workspacePath, configuration) 
     };
 }
 
-function resolveWorkspacePath(templatePath) {
-    const uri = templatePath ? vscode.Uri.file(templatePath) : vscode.window.activeTextEditor?.document.uri;
+function resolveWorkspacePath(templatePath, resourceUri) {
+    const uri = resourceUri ?? (templatePath ? vscode.Uri.file(templatePath) : vscode.window.activeTextEditor?.document.uri);
     const workspaceFolder = uri ? vscode.workspace.getWorkspaceFolder(uri) : undefined;
     const fallbackFolder = workspaceFolder ?? vscode.workspace.workspaceFolders?.[0];
-    const basePath = fallbackFolder?.uri.fsPath ?? (templatePath ? path.dirname(templatePath) : undefined);
+    const basePath = fallbackFolder?.uri.fsPath
+        ?? (templatePath ? path.dirname(templatePath) : undefined)
+        ?? (resourceUri ? path.dirname(resourceUri.fsPath) : undefined);
     const configuration = getConfiguration(uri);
     const configuredWorkspace = configuration.get("workspacePath");
 
@@ -374,7 +376,11 @@ function resolveWorkspacePath(templatePath) {
     return basePath;
 }
 
-async function resolveCurrentTemplatePath(document) {
+async function resolveCurrentTemplatePath(document, resourceUri) {
+    if (isTypewriterUri(resourceUri)) {
+        return resourceUri.fsPath;
+    }
+
     const targetDocument = document ?? vscode.window.activeTextEditor?.document;
     if (targetDocument && isTypewriterDocument(targetDocument)) {
         return targetDocument.uri.fsPath;
@@ -404,6 +410,15 @@ async function resolveCurrentTemplatePath(document) {
 function isTypewriterDocument(document) {
     return document.languageId === "typewriter"
         || document.uri.fsPath.toLowerCase().endsWith(".tst");
+}
+
+function isTypewriterUri(uri) {
+    return uri?.scheme === "file"
+        && uri.fsPath.toLowerCase().endsWith(".tst");
+}
+
+function toFileUri(value) {
+    return value?.scheme === "file" ? value : undefined;
 }
 
 function createFallbackCompletionProvider() {


### PR DESCRIPTION
This pull request adds context menu support for Typewriter commands in Visual Studio, Rider, and VS Code, making it easier to access template-related actions directly from file and editor context menus. It introduces new command groups, dynamic visibility for context-sensitive commands, and improves the logic for detecting selected templates and projects. The changes also unify and clarify command naming across environments.

**Context menu integration and command enhancements:**

* Visual Studio:  
  - Added new command groups and placements for context menus in Solution Explorer, editor, item, and project nodes in `TypewriterPackage.vsct`, allowing "Render Template", "Render All Templates", and "Validate Template" to appear contextually. Dynamic visibility is handled so commands only show when relevant (e.g., `.tst` files or project nodes). [[1]](diffhunk://#diff-b7664c12ba25d8a4b0a78a7c70ab1029a9f4725c18ca5172ca7fec8812a9fb21R11-R19) [[2]](diffhunk://#diff-b7664c12ba25d8a4b0a78a7c70ab1029a9f4725c18ca5172ca7fec8812a9fb21R41-R92)
  - Updated `TypewriterVisualStudioConstants` with new command IDs for the added context menu actions.
  - Refactored `TypewriterCommandService` to add helper methods for registering context commands, determining visibility, and resolving selected templates/projects robustly. This includes logic to check active windows, selected items, and file types, ensuring context menus behave as expected. [[1]](diffhunk://#diff-e81f26f8841db4b82f45969e56ff7fd2cfc20ff3d31e60224f447b5019266a08L43-R70) [[2]](diffhunk://#diff-e81f26f8841db4b82f45969e56ff7fd2cfc20ff3d31e60224f447b5019266a08R81-R115) [[3]](diffhunk://#diff-e81f26f8841db4b82f45969e56ff7fd2cfc20ff3d31e60224f447b5019266a08L363-R417) [[4]](diffhunk://#diff-e81f26f8841db4b82f45969e56ff7fd2cfc20ff3d31e60224f447b5019266a08R432-R638) [[5]](diffhunk://#diff-e81f26f8841db4b82f45969e56ff7fd2cfc20ff3d31e60224f447b5019266a08R224-R227) [[6]](diffhunk://#diff-e81f26f8841db4b82f45969e56ff7fd2cfc20ff3d31e60224f447b5019266a08R9)

* Rider:  
  - Added context menu groups and actions for Typewriter commands in `plugin.xml`, integrating with the Solution Explorer and editor context menus.

* VS Code:  
  - Updated `package.json` to add short titles for commands and register them in the file explorer and editor context menus, only for `.tst` files.
  - Modified command registrations in `extension.js` to accept a URI parameter, enabling commands to act on the selected file from the context menu.

These changes collectively improve user experience by making Typewriter's template actions more discoverable and accessible across supported IDEs.