### PR TITLE
new value for property and field initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@
   - [🔨 Building from Source](#-building-from-source)
   - [🗺 Project Status and Roadmap](#-project-status-and-roadmap)
   - [Changelog](#changelog)
+    - [4.3.0](#430)
+    - [4.2.0](#420)
+    - [4.1.1](#411)
     - [4.1.0](#410)
+    - [4.0.0](#400)
+    - [4.0.0-beta.1](#400-beta1)
   - [🤝 Contributing](#-contributing)
   - [🐛 Issues and Support](#-issues-and-support)
   - [🙏 Acknowledgments](#-acknowledgments)
@@ -825,12 +830,45 @@ dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj --config
 
 ## Changelog
 
+### 4.3.0
+
+- Added property and instance-field initializer values to the metadata model, exposed to templates as `$Value` (for example `$Properties[$Value]` and `$Fields[$Value]`).
+- Initializer values come from the source declaration: literals render as their text value, non-literal initializers (such as `Guid.NewGuid()`) render as the expression text, and members without an initializer render empty.
+- Added Roslyn extraction and renderer support plus language-server completion documentation for the new `$Value` member, covered by engine and Roslyn tests.
+
+### 4.2.0
+
+- Restored the editor right-click commands **Render Template** and **Generate Current Template** so a template can be regenerated on demand from the context menu.
+- Fixed a stack overflow that occurred while extracting metadata for types with cyclic references.
+
+### 4.1.1
+
+- Fixed resolution of types that come from transitively referenced projects.
+- Fixed remaining metadata-loading issues for older full .NET Framework projects.
+- Fixed handling of satellite (localized) assemblies during project loading.
+
 ### 4.1.0
 
 - Added struct metadata and template rendering through `$Structs[...]`, `$Types(Struct)[...]`, CodeModel `Struct`, and LSP/editor completions.
 - Added indexer metadata through `Property.IsIndexer` and property-level `$Parameters[...]`, intended for lookup-style API generation rather than JSON DTO payloads.
 - Added literal dollar escaping with `$$`, so templates can emit `$type`, `${...}`, and other TypeScript dollar syntax without triggering template member lookup.
+- Fixed processing of full .NET Framework projects.
+- Fixed implicit `using` resolution for referenced projects.
+- Fixed loading of projects that use source generators.
+- Fixed conflicts when two projects reference different versions of the same package.
 - Added tests that cover Roslyn extraction, template rendering, CodeModel parity, and language-server completions for structs and indexers.
+
+### 4.0.0
+
+- First stable release of the ground-up, cross-platform reimplementation: a shared Roslyn-powered engine with a CLI, Language Server, VS Code extension, Visual Studio 2026 VSIX, and JetBrains Rider plugin.
+- Documentation and packaging refinements over `4.0.0-beta.1`.
+
+### 4.0.0-beta.1
+
+- Initial public preview of the new toolchain: `typewriter init`, `generate`, `validate`, `watch`, and `list-templates`, with `typewriter.json` configuration and discovery.
+- Editor-independent engine running the original `.tst` dialect, plus compiled C# helpers, shared `#load` source helpers, and NuGet `#r` references.
+- Safe output planning (`TW0005`/`TW0006`/`TW0008`), template logging (`TW0007`), and deterministic CLI exit codes with text/JSON output.
+- Language Server features: live diagnostics, completion, hover, go-to-definition, and semantic tokens.
 
 ---
 

--- a/src/Typewriter.Abstractions/FieldMetadata.cs
+++ b/src/Typewriter.Abstractions/FieldMetadata.cs
@@ -15,4 +15,6 @@ public sealed record FieldMetadata(
     public string? Documentation { get; init; }
 
     public DocCommentMetadata? DocComment { get; init; }
+
+    public string? Value { get; init; }
 }

--- a/src/Typewriter.Abstractions/PropertyMetadata.cs
+++ b/src/Typewriter.Abstractions/PropertyMetadata.cs
@@ -27,4 +27,6 @@ public sealed record PropertyMetadata(
     public bool IsVirtual { get; init; }
 
     public IReadOnlyList<ParameterMetadata> Parameters { get; init; } = [];
+
+    public string? Value { get; init; }
 }

--- a/src/Typewriter.Engine/CodeModel/Field.cs
+++ b/src/Typewriter.Engine/CodeModel/Field.cs
@@ -8,5 +8,7 @@ public class Field : Item
 
     public virtual Type? Type { get; init; }
 
+    public virtual string Value { get; init; } = string.Empty;
+
     public static implicit operator string(Field? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/Property.cs
+++ b/src/Typewriter.Engine/CodeModel/Property.cs
@@ -22,5 +22,7 @@ public class Property : Item
 
     public virtual Type Type { get; init; } = new();
 
+    public virtual string Value { get; init; } = string.Empty;
+
     public static implicit operator string(Property? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/TemplateCodeModelAdapterFactory.cs
+++ b/src/Typewriter.Engine/TemplateCodeModelAdapterFactory.cs
@@ -545,6 +545,7 @@ internal sealed class TemplateCodeModelAdapterFactory
                 ? new Typewriter.CodeModel.ParameterCollection(items: property.Parameters.Select(selector: parameter => CreateParameter(parameter: parameter, parent: null)))
                 : new Typewriter.CodeModel.ParameterCollection(),
             Type = CreateType(type: property.Type),
+            Value = property.Value ?? string.Empty,
         };
     }
 
@@ -627,6 +628,7 @@ internal sealed class TemplateCodeModelAdapterFactory
             Attributes = CreateAttributes(attributes: field.Attributes, parent: null),
             DocComment = CreateDocComment(docComment: field.DocComment, parent: null),
             Type = CreateType(type: field.Type),
+            Value = field.Value ?? string.Empty,
         };
     }
 

--- a/src/Typewriter.Engine/TemplateRenderer.cs
+++ b/src/Typewriter.Engine/TemplateRenderer.cs
@@ -999,6 +999,7 @@ public sealed class TemplateRenderer
             "DocComment" => field.DocComment,
             "Parent" => field.Parent,
             "Type" => field.Type,
+            "Value" => field.Value,
             _ => Unresolved.Value,
         };
     }
@@ -1103,6 +1104,7 @@ public sealed class TemplateRenderer
             "IsRequired" => property.IsRequired,
             "Parameters" => property.Parameters,
             "Attributes" => property.Attributes,
+            "Value" => property.Value,
             _ => Unresolved.Value,
         };
     }
@@ -2408,6 +2410,7 @@ public sealed class TemplateRenderer
             "Parameters" => property.Parameters,
             "DocComment" => property.DocComment,
             "Attributes" => property.Attributes,
+            "Value" => property.Value,
             _ => Unresolved.Value,
         };
     }
@@ -2505,6 +2508,7 @@ public sealed class TemplateRenderer
             "DocComment" => field.DocComment,
             "Attributes" => field.Attributes,
             "ParentTypeFullName" => field.ParentTypeFullName,
+            "Value" => field.Value,
             _ => Unresolved.Value,
         };
     }

--- a/src/Typewriter.LanguageServer/TemplateFeatureService.cs
+++ b/src/Typewriter.LanguageServer/TemplateFeatureService.cs
@@ -326,7 +326,7 @@ internal sealed class TemplateFeatureService : IDisposable
         yield return Scalar(label: "Namespace", documentation: "Containing namespace.");
         yield return Scalar(label: "Type", documentation: "TypeScript rendering of the current item's type.");
         yield return Scalar(label: "ReturnType", documentation: "Method return type.");
-        yield return Scalar(label: "Value", documentation: "Constant, enum, or attribute argument value.");
+        yield return Scalar(label: "Value", documentation: "Constant, enum, attribute argument, or property/field initializer value.");
         yield return Scalar(label: "DefaultValue", documentation: "Parameter default value.");
         yield return Scalar(label: "Parent", documentation: "Parent metadata object.");
         yield return Scalar(label: "IsNullable", documentation: "Whether the current type reference or property is nullable.");

--- a/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
+++ b/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
@@ -1585,7 +1585,7 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         return value switch
         {
             null => null,
-            LiteralExpressionSyntax literal when literal.IsKind(kind: SyntaxKind.NullLiteralExpression) => string.Empty,
+            LiteralExpressionSyntax literal when literal.IsKind(kind: SyntaxKind.NullLiteralExpression) => "null",
             LiteralExpressionSyntax literal => literal.Token.ValueText,
             _ => value.ToString(),
         };

--- a/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
+++ b/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
@@ -737,6 +737,7 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                         IsIndexer = property.IsIndexer,
                         IsVirtual = property.IsVirtual,
                         Parameters = GetParameters(parameters: property.Parameters, parentFullName: fullName, parentPropertyFullName: fullName).ToArray(),
+                        Value = GetPropertyInitializerValue(property: property),
                     };
                 });
     }
@@ -872,6 +873,7 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                         Location = GetSourceLocation(symbol: field),
                         Documentation = docComment?.Summary,
                         DocComment = docComment,
+                        Value = GetFieldInitializerValue(field: field),
                     };
                 });
     }
@@ -1556,6 +1558,36 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
             LiteralExpressionSyntax literal when literal.IsKind(kind: SyntaxKind.NullLiteralExpression) => string.Empty,
             LiteralExpressionSyntax literal => literal.Token.ValueText,
             _ => initializer.ToString(),
+        };
+    }
+
+    private static string? GetPropertyInitializerValue(IPropertySymbol property)
+    {
+        var syntax = property.DeclaringSyntaxReferences
+            .Select(selector: reference => reference.GetSyntax())
+            .OfType<PropertyDeclarationSyntax>()
+            .FirstOrDefault();
+        return GetInitializerValueText(initializer: syntax?.Initializer);
+    }
+
+    private static string? GetFieldInitializerValue(IFieldSymbol field)
+    {
+        var syntax = field.DeclaringSyntaxReferences
+            .Select(selector: reference => reference.GetSyntax())
+            .OfType<VariableDeclaratorSyntax>()
+            .FirstOrDefault();
+        return GetInitializerValueText(initializer: syntax?.Initializer);
+    }
+
+    private static string? GetInitializerValueText(EqualsValueClauseSyntax? initializer)
+    {
+        var value = initializer?.Value;
+        return value switch
+        {
+            null => null,
+            LiteralExpressionSyntax literal when literal.IsKind(kind: SyntaxKind.NullLiteralExpression) => string.Empty,
+            LiteralExpressionSyntax literal => literal.Token.ValueText,
+            _ => value.ToString(),
         };
     }
 

--- a/tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs
@@ -297,6 +297,69 @@ public sealed class TemplateRendererTests
     }
 
     [Fact]
+    public void RenderResolvesPropertyAndFieldInitializerValue()
+    {
+        var stringType = TypeReference(name: "String", fullName: "System.String", isNullable: false);
+        var metadata = new ProjectMetadata(
+            ProjectPath: "Sample.csproj",
+            SourceFiles: [],
+            Types:
+            [
+                new TypeMetadata(
+                    Name: "Holder",
+                    FullName: "Sample.Holder",
+                    Namespace: "Sample",
+                    Kind: TypeMetadataKind.Class,
+                    Accessibility: MetadataAccessibility.Public,
+                    Properties:
+                    [
+                        new PropertyMetadata(
+                            Name: "Type",
+                            FullName: "Sample.Holder.Type",
+                            Type: stringType,
+                            Accessibility: MetadataAccessibility.Public,
+                            HasGetter: true,
+                            HasSetter: false,
+                            IsRequired: false,
+                            Attributes: [])
+                        {
+                            Value = "myTestType",
+                        },
+                    ],
+                    Attributes: [],
+                    BaseTypes: [],
+                    EnumValues: [],
+                    IsNullableAware: true)
+                {
+                    Fields =
+                    [
+                        new FieldMetadata(
+                            Name: "Label",
+                            FullName: "Sample.Holder.Label",
+                            Accessibility: MetadataAccessibility.Public,
+                            Type: stringType,
+                            Attributes: [],
+                            ParentTypeFullName: "Sample.Holder")
+                        {
+                            Value = "instance",
+                        },
+                    ],
+                },
+            ],
+            Diagnostics: []);
+        const string template = "$Classes[$Properties[$Name=$Value;]$Fields[$Name=$Value;]]";
+        var document = new TemplateDocument(Path: "models.tst", Content: template, OutputPath: "models.ts");
+        var diagnostics = new List<GenerationDiagnostic>();
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        diagnostics.Should().BeEmpty();
+        output.Should().Contain("Type=myTestType;");
+        output.Should().Contain("Label=instance;");
+    }
+
+    [Fact]
     public void RenderPreservesNullableDictionaryWhenValueTypeIsNullable()
     {
         var keyType = TypeReference(name: "String", fullName: "System.String", isNullable: false);

--- a/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
+++ b/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
@@ -1034,6 +1034,59 @@ public sealed class CSharpProjectMetadataProviderTests
         }
     }
 
+    [Fact]
+    public async Task GetMetadataExtractsPropertyAndFieldInitializerValues()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var projectPath = Path.Combine(path1: directory, path2: "Sample.csproj");
+            await File.WriteAllTextAsync(
+                path: projectPath,
+                contents: """
+                          <Project Sdk="Microsoft.NET.Sdk">
+                            <PropertyGroup>
+                              <TargetFramework>net10.0</TargetFramework>
+                              <Nullable>enable</Nullable>
+                              <ImplicitUsings>enable</ImplicitUsings>
+                            </PropertyGroup>
+                          </Project>
+                          """);
+            await File.WriteAllTextAsync(
+                path: Path.Combine(path1: directory, path2: "Models.cs"),
+                contents: """
+                          namespace Sample;
+
+                          public class Holder
+                          {
+                              public string Type { get; } = "myTestType";
+
+                              public int Count { get; set; } = 5;
+
+                              public string Label = "instance";
+
+                              public string? NoInitializer { get; set; }
+                          }
+                          """);
+            var provider = new CSharpProjectMetadataProvider();
+
+            var metadata = await provider.GetMetadataAsync(
+                project: new ProjectContext(ProjectPath: projectPath, WorkspacePath: directory),
+                cancellationToken: CancellationToken.None);
+
+            metadata.Diagnostics.Should().BeEmpty();
+            var holder = metadata.Types.Should().ContainSingle(type => type.Name == "Holder").Which;
+            holder.Properties.Should().ContainSingle(property => property.Name == "Type").Which.Value.Should().Be("myTestType");
+            holder.Properties.Should().ContainSingle(property => property.Name == "Count").Which.Value.Should().Be("5");
+            holder.Properties.Should().ContainSingle(property => property.Name == "NoInitializer").Which.Value.Should().BeNull();
+            holder.Fields.Should().ContainSingle(field => field.Name == "Label").Which.Value.Should().Be("instance");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
     private static string CreateProjectDirectory()
     {
         var directory = Path.Combine(

--- a/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
+++ b/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
@@ -1066,6 +1066,10 @@ public sealed class CSharpProjectMetadataProviderTests
                               public string Label = "instance";
 
                               public string? NoInitializer { get; set; }
+
+                              public string? NullInitializer { get; set; } = null;
+
+                              public string? NullField = null;
                           }
                           """);
             var provider = new CSharpProjectMetadataProvider();
@@ -1079,7 +1083,9 @@ public sealed class CSharpProjectMetadataProviderTests
             holder.Properties.Should().ContainSingle(property => property.Name == "Type").Which.Value.Should().Be("myTestType");
             holder.Properties.Should().ContainSingle(property => property.Name == "Count").Which.Value.Should().Be("5");
             holder.Properties.Should().ContainSingle(property => property.Name == "NoInitializer").Which.Value.Should().BeNull();
+            holder.Properties.Should().ContainSingle(property => property.Name == "NullInitializer").Which.Value.Should().Be("null");
             holder.Fields.Should().ContainSingle(field => field.Name == "Label").Which.Value.Should().Be("instance");
+            holder.Fields.Should().ContainSingle(field => field.Name == "NullField").Which.Value.Should().Be("null");
         }
         finally
         {


### PR DESCRIPTION
This pull request adds support for exposing property and instance-field initializer values in the metadata model, making them accessible in templates as `$Value`. It updates the Roslyn extraction, engine, and template rendering pipeline to include these values, and adds documentation and tests to cover the new feature.

**New metadata and template features:**

* Added a `Value` property to both `PropertyMetadata` and `FieldMetadata` records, as well as to the corresponding `Property` and `Field` code model classes, to hold the initializer value if present (`src/Typewriter.Abstractions/PropertyMetadata.cs` [[1]](diffhunk://#diff-c6b125376954742e1795f04eaf3e7b2b57836f17bb0d881f56f9d7cbde81584aR30-R31) `src/Typewriter.Abstractions/FieldMetadata.cs` [[2]](diffhunk://#diff-11aec0c540ebeba11a738b497cd26d26d964f15056ad87d44df1b88917168295R18-R19) `src/Typewriter.Engine/CodeModel/Property.cs` [[3]](diffhunk://#diff-be9bed3fc8d869ed58f31c10d1999bb0bcf5774a32600bf8be65f425e44a9749R25-R26) `src/Typewriter.Engine/CodeModel/Field.cs` [[4]](diffhunk://#diff-7a7727c7bbce58c92b7f9cedcf910658e31a044809d26a0b0a7dff6bffe922fcR11-R12).
* Updated the Roslyn metadata provider to extract initializer values for properties and fields, handling both literal and non-literal initializers, and returning the expression text for non-literals (`src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs` [[1]](diffhunk://#diff-131fd96b68788b0eb8457106af1bffe0cd099b9171832fb11bc7fd1a3be4390dR740) [[2]](diffhunk://#diff-131fd96b68788b0eb8457106af1bffe0cd099b9171832fb11bc7fd1a3be4390dR876) [[3]](diffhunk://#diff-131fd96b68788b0eb8457106af1bffe0cd099b9171832fb11bc7fd1a3be4390dR1564-R1593).
* Modified the template rendering pipeline to expose the new `Value` property for fields and properties, making it accessible in templates as `$Value` (`src/Typewriter.Engine/TemplateRenderer.cs` [[1]](diffhunk://#diff-a286a475ccbdfba72ce872a9498f8dc7d6af97cd329b81ad2963ec434dc9af3bR1002) [[2]](diffhunk://#diff-a286a475ccbdfba72ce872a9498f8dc7d6af97cd329b81ad2963ec434dc9af3bR1107) [[3]](diffhunk://#diff-a286a475ccbdfba72ce872a9498f8dc7d6af97cd329b81ad2963ec434dc9af3bR2413) [[4]](diffhunk://#diff-a286a475ccbdfba72ce872a9498f8dc7d6af97cd329b81ad2963ec434dc9af3bR2511).
* Updated the language server's completion documentation for `$Value` to include property/field initializer values (`src/Typewriter.LanguageServer/TemplateFeatureService.cs` [src/Typewriter.LanguageServer/TemplateFeatureService.csL329-R329](diffhunk://#diff-06fbc374c741511f2800d3090e427f505c9abdad01594868ae4c156cc42c62a6L329-R329)).

**Documentation and testing:**

* Added changelog entries for versions 4.3.0 through 4.0.0-beta.1, highlighting the new feature and other recent changes (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R72) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R833-R872).
* Introduced new engine and Roslyn tests to verify extraction and rendering of property and field initializer values (`tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs` [[1]](diffhunk://#diff-b58e1bf1a7a270b0dbb475d3ebc325f221c97f339ba127afdc51a57e26300fd3R299-R361) `tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs` [[2]](diffhunk://#diff-94881705b1c8fbffa9dfdd9c776db95c165bf8e200ad1cba0c36964f57b6831bR1037-R1089).

These changes ensure that templates can now access and render the initializer values of properties and fields, improving the expressiveness and utility of generated code.