### PR TITLE
jsdoc helpers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ErrorLog>$(MSBuildThisFileDirectory).sarif\$(MSBuildProjectName).json</ErrorLog>
-    <Version>4.1.0</Version>
+    <Version>4.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
     <PackageReference Include="AdaskoTheBeAsT.Puma.Security.Rules.2022" Version="2.3.1.50" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="AdaskoTheBeAsT.ReflectionAnalyzer" Version="0.3.1.50" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="AdaskoTheBeAsT.SecurityCodeScan.VS2022" Version="5.6.7.50" PrivateAssets="all" ExcludeAssets="runtime" />
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.104" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.105" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" ExcludeAssets="runtime" />

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
   - [🔨 Building from Source](#-building-from-source)
   - [🗺 Project Status and Roadmap](#-project-status-and-roadmap)
   - [Changelog](#changelog)
+    - [4.4.0](#440)
     - [4.3.0](#430)
     - [4.2.0](#420)
     - [4.1.1](#411)
@@ -829,6 +830,11 @@ dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj --config
 ---
 
 ## Changelog
+
+### 4.4.0
+
+- Fixed XML doc-comment extraction so inline elements (such as `<see cref="..."/>`) are preserved in `$DocComment[$Summary]` and `$DocComment[$Returns]` instead of being stripped to their text content, so referenced type names are no longer lost in generated comments.
+- Added an opt-in `Typewriter.Extensions.Documentation` formatter with `DocComment.ToJsDoc()`, `ToJsDocSummary()`, and `ToJsDocReturns()` helpers that convert C# XML doc tags to TypeScript JSDoc (for example `<see cref="GeometryFieldType"/>` becomes `{@link GeometryFieldType}`, and `<c>`/`<see langword>`/`<paramref>` become backtick code). The metadata stays raw; conversion is applied only when a template calls these helpers.
 
 ### 4.3.0
 

--- a/src/Typewriter.Engine/Extensions/Documentation/DocCommentExtensions.cs
+++ b/src/Typewriter.Engine/Extensions/Documentation/DocCommentExtensions.cs
@@ -1,0 +1,167 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Typewriter.CodeModel;
+
+namespace Typewriter.Extensions.Documentation;
+
+public static class DocCommentExtensions
+{
+    private const string SeeSelfClosingPattern = "<see\\s+(?<attr>cref|langword|href)\\s*=\\s*\"(?<val>[^\"]*)\"\\s*/>";
+    private const string SeeWithContentPattern = "<see\\s+(?<attr>cref|href)\\s*=\\s*\"(?<val>[^\"]*)\"\\s*>(?<text>.*?)</see>";
+    private const string ReferencePattern = "<(?:paramref|typeparamref)\\s+name\\s*=\\s*\"(?<val>[^\"]*)\"\\s*/>";
+    private const string CodePattern = "<c>(?<val>.*?)</c>";
+    private const string ParaPattern = "</?para\\s*/?>";
+    private const string MultiSpacePattern = "[ \\t]{2,}";
+
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(value: 1);
+
+    public static string ToJsDoc(this DocComment docComment)
+    {
+        ArgumentNullException.ThrowIfNull(argument: docComment);
+
+        var lines = new List<string>();
+
+        var summary = ConvertInlineTags(text: docComment.Summary);
+        if (!string.IsNullOrWhiteSpace(value: summary))
+        {
+            lines.Add(item: summary);
+        }
+
+        foreach (var parameter in docComment.Parameters)
+        {
+            var description = ConvertInlineTags(text: parameter.Description);
+            lines.Add(item: $"@param {parameter.Name} {description}".TrimEnd());
+        }
+
+        var returns = ConvertInlineTags(text: docComment.Returns);
+        if (!string.IsNullOrWhiteSpace(value: returns))
+        {
+            lines.Add(item: $"@returns {returns}");
+        }
+
+        if (lines.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        builder.Append(value: "/**\n");
+        foreach (var line in lines)
+        {
+            builder.Append(value: " * ").Append(value: line).Append(value: '\n');
+        }
+
+        builder.Append(value: " */");
+        return builder.ToString();
+    }
+
+    public static string ToJsDocSummary(this DocComment docComment)
+    {
+        ArgumentNullException.ThrowIfNull(argument: docComment);
+
+        return ConvertInlineTags(text: docComment.Summary);
+    }
+
+    public static string ToJsDocReturns(this DocComment docComment)
+    {
+        ArgumentNullException.ThrowIfNull(argument: docComment);
+
+        return ConvertInlineTags(text: docComment.Returns);
+    }
+
+    private static string ConvertInlineTags(string? text)
+    {
+        if (string.IsNullOrEmpty(value: text))
+        {
+            return string.Empty;
+        }
+
+        var result = Regex.Replace(
+            input: text,
+            pattern: SeeWithContentPattern,
+            evaluator: ReplaceSeeWithContent,
+            options: RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Singleline,
+            matchTimeout: RegexTimeout);
+        result = Regex.Replace(
+            input: result,
+            pattern: SeeSelfClosingPattern,
+            evaluator: ReplaceSeeSelfClosing,
+            options: RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+            matchTimeout: RegexTimeout);
+        result = Regex.Replace(
+            input: result,
+            pattern: ReferencePattern,
+            evaluator: static match => $"`{match.Groups[groupname: "val"].Value}`",
+            options: RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+            matchTimeout: RegexTimeout);
+        result = Regex.Replace(
+            input: result,
+            pattern: CodePattern,
+            evaluator: static match => $"`{match.Groups[groupname: "val"].Value}`",
+            options: RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Singleline,
+            matchTimeout: RegexTimeout);
+        result = Regex.Replace(
+            input: result,
+            pattern: ParaPattern,
+            replacement: " ",
+            options: RegexOptions.IgnoreCase | RegexOptions.CultureInvariant,
+            matchTimeout: RegexTimeout);
+        result = Regex.Replace(
+            input: result,
+            pattern: MultiSpacePattern,
+            replacement: " ",
+            options: RegexOptions.CultureInvariant,
+            matchTimeout: RegexTimeout);
+        return result.Trim();
+    }
+
+    private static string ReplaceSeeSelfClosing(Match match)
+    {
+        var attribute = match.Groups[groupname: "attr"].Value;
+        var value = match.Groups[groupname: "val"].Value;
+        if (attribute.Equals(value: "cref", comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            return $"{{@link {SimpleCrefName(cref: value)}}}";
+        }
+
+        return attribute.Equals(value: "href", comparisonType: StringComparison.OrdinalIgnoreCase)
+            ? $"{{@link {value}}}"
+            : $"`{value}`";
+    }
+
+    private static string ReplaceSeeWithContent(Match match)
+    {
+        var attribute = match.Groups[groupname: "attr"].Value;
+        var value = match.Groups[groupname: "val"].Value;
+        var inner = match.Groups[groupname: "text"].Value.Trim();
+        var target = attribute.Equals(value: "cref", comparisonType: StringComparison.OrdinalIgnoreCase)
+            ? SimpleCrefName(cref: value)
+            : value;
+        return string.IsNullOrEmpty(value: inner)
+            ? $"{{@link {target}}}"
+            : $"{{@link {target} | {inner}}}";
+    }
+
+    private static string SimpleCrefName(string cref)
+    {
+        var value = cref;
+        if (value.Length > 2 && value[1] == ':')
+        {
+            value = value[2..];
+        }
+
+        var parenIndex = value.IndexOf(value: '(');
+        if (parenIndex >= 0)
+        {
+            value = value[..parenIndex];
+        }
+
+        var dotIndex = value.LastIndexOf(value: '.');
+        if (dotIndex >= 0 && dotIndex < value.Length - 1)
+        {
+            value = value[(dotIndex + 1)..];
+        }
+
+        return value;
+    }
+}

--- a/src/Typewriter.Engine/TemplateRuntimeCompiler.cs
+++ b/src/Typewriter.Engine/TemplateRuntimeCompiler.cs
@@ -156,6 +156,7 @@ internal static class TemplateRuntimeCompiler
             "using System.Text.RegularExpressions;",
             "using Typewriter.CodeModel;",
             "using Typewriter.Configuration;",
+            "using Typewriter.Extensions.Documentation;",
             "using Typewriter.Extensions.Types;",
             "using Typewriter.Extensions.WebApi;",
             "using Typewriter.VisualStudio;",

--- a/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
+++ b/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
@@ -1515,8 +1515,8 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         {
             var document = XDocument.Parse(text: "<doc>" + documentation + "</doc>");
             return new DocCommentMetadata(
-                Summary: NormalizeDocumentation(documentation: document.Descendants(name: "summary").FirstOrDefault()?.Value) ?? string.Empty,
-                Returns: NormalizeDocumentation(documentation: document.Descendants(name: "returns").FirstOrDefault()?.Value) ?? string.Empty,
+                Summary: NormalizeDocumentation(documentation: GetDocCommentElementContent(element: document.Descendants(name: "summary").FirstOrDefault())) ?? string.Empty,
+                Returns: NormalizeDocumentation(documentation: GetDocCommentElementContent(element: document.Descendants(name: "returns").FirstOrDefault())) ?? string.Empty,
                 Parameters: document.Descendants(name: "param")
                     .Select(
                         selector: element => new ParameterCommentMetadata(
@@ -1589,6 +1589,13 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
             LiteralExpressionSyntax literal => literal.Token.ValueText,
             _ => value.ToString(),
         };
+    }
+
+    private static string? GetDocCommentElementContent(XElement? element)
+    {
+        return element is null
+            ? null
+            : string.Concat(values: element.Nodes());
     }
 
     private static string? NormalizeDocumentation(string? documentation)

--- a/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
+++ b/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
@@ -1521,7 +1521,7 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                     .Select(
                         selector: element => new ParameterCommentMetadata(
                             Name: element.Attribute(name: "name")?.Value.Trim() ?? string.Empty,
-                            Description: NormalizeDocumentation(documentation: element.Value) ?? string.Empty))
+                            Description: NormalizeDocumentation(documentation: GetDocCommentElementContent(element: element)) ?? string.Empty))
                     .ToArray());
         }
         catch (System.Xml.XmlException)

--- a/tests/unit/Typewriter.Engine.Tests/DocCommentExtensionsTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/DocCommentExtensionsTests.cs
@@ -1,0 +1,72 @@
+using Typewriter.CodeModel;
+using Typewriter.Extensions.Documentation;
+using Xunit;
+
+namespace Typewriter.Engine.Tests;
+
+public sealed class DocCommentExtensionsTests
+{
+    [Fact]
+    public void ToJsDocSummaryConvertsSeeCrefToLink()
+    {
+        var docComment = new DocComment
+        {
+            Summary = "Defines the types of a <see cref=\"T:Sample.GeometryFieldType\" />.",
+        };
+
+        docComment.ToJsDocSummary().Should().Be("Defines the types of a {@link GeometryFieldType}.");
+    }
+
+    [Fact]
+    public void ToJsDocSummaryConvertsInlineForms()
+    {
+        var docComment = new DocComment
+        {
+            Summary = "Use <c>map</c> when value is <see langword=\"null\"/>; see <see href=\"https://example.com\">docs</see> and <paramref name=\"value\"/>.",
+        };
+
+        docComment.ToJsDocSummary().Should().Be("Use `map` when value is `null`; see {@link https://example.com | docs} and `value`.");
+    }
+
+    [Fact]
+    public void ToJsDocReturnsConvertsSeeCref()
+    {
+        var docComment = new DocComment
+        {
+            Returns = "The <see cref=\"T:Sample.GeometryFieldType\"/> instance.",
+        };
+
+        docComment.ToJsDocReturns().Should().Be("The {@link GeometryFieldType} instance.");
+    }
+
+    [Fact]
+    public void ToJsDocBuildsBlockWithSummaryParamsAndReturns()
+    {
+        var docComment = new DocComment
+        {
+            Summary = "Echoes a <see cref=\"T:Sample.GeometryFieldType\"/>.",
+            Returns = "The echoed value.",
+            Parameters = new ParameterCommentCollection(
+            [
+                new ParameterComment { Name = "value", Description = "The <paramref name=\"value\"/> to echo." },
+            ]),
+        };
+
+        var jsDoc = docComment.ToJsDoc();
+
+        jsDoc.Should().Be(
+            "/**\n"
+            + " * Echoes a {@link GeometryFieldType}.\n"
+            + " * @param value The `value` to echo.\n"
+            + " * @returns The echoed value.\n"
+            + " */");
+    }
+
+    [Fact]
+    public void ToJsDocReturnsEmptyWhenNoContent()
+    {
+        var docComment = new DocComment();
+
+        docComment.ToJsDoc().Should().BeEmpty();
+    }
+}

--- a/tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs
@@ -1963,6 +1963,49 @@ public sealed class TemplateRendererTests
     }
 
     [Fact]
+    public void RenderInvokesDocCommentToJsDocExtension()
+    {
+        var metadata = new ProjectMetadata(
+            ProjectPath: "Sample.csproj",
+            SourceFiles: [],
+            Types:
+            [
+                new TypeMetadata(
+                    Name: "Widget",
+                    FullName: "Sample.Widget",
+                    Namespace: "Sample",
+                    Kind: TypeMetadataKind.Class,
+                    Accessibility: MetadataAccessibility.Public,
+                    Properties: [],
+                    Attributes: [],
+                    BaseTypes: [],
+                    EnumValues: [],
+                    IsNullableAware: true)
+                {
+                    DocComment = new DocCommentMetadata(
+                        Summary: "Defines a <see cref=\"T:Sample.Widget\" />.",
+                        Returns: string.Empty,
+                        Parameters: []),
+                },
+            ],
+            Diagnostics: []);
+        const string template = """
+            ${
+                string JsDoc(Class c) => c.DocComment.ToJsDocSummary();
+            }
+            $Classes[$JsDoc]
+            """;
+        var diagnostics = new List<GenerationDiagnostic>();
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+        var document = TemplateDocument.Parse(template: new TemplateFile(Path: "jsdoc.tst", Content: template), diagnostics: diagnostics);
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        diagnostics.Should().BeEmpty();
+        output.Should().Contain("Defines a {@link Widget}.");
+    }
+
+    [Fact]
     public void RenderExposesCodeModelParityMembers()
     {
         const string ModelFullName = "Sample.Widget";

--- a/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
+++ b/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
@@ -591,6 +591,71 @@ public sealed class CSharpProjectMetadataProviderTests
     }
 
     [Fact]
+    public async Task GetMetadataPreservesInlineElementsInDocComments()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var projectPath = Path.Combine(path1: directory, path2: "Sample.csproj");
+            await File.WriteAllTextAsync(
+                path: projectPath,
+                contents: """
+                          <Project Sdk="Microsoft.NET.Sdk">
+                            <PropertyGroup>
+                              <TargetFramework>net10.0</TargetFramework>
+                              <Nullable>enable</Nullable>
+                              <ImplicitUsings>enable</ImplicitUsings>
+                            </PropertyGroup>
+                          </Project>
+                          """);
+            await File.WriteAllTextAsync(
+                path: Path.Combine(path1: directory, path2: "Models.cs"),
+                contents: """
+                          namespace Sample;
+
+                          /// <summary>Target type.</summary>
+                          public class GeometryFieldType
+                          {
+                          }
+
+                          /// <summary>
+                          /// Defines the types of a <see cref="GeometryFieldType"/>.
+                          /// </summary>
+                          public class GeometryHolder
+                          {
+                              /// <summary>Gets a value.</summary>
+                              /// <returns>The <see cref="GeometryFieldType"/> instance.</returns>
+                              public GeometryFieldType Get()
+                              {
+                                  return new GeometryFieldType();
+                              }
+                          }
+                          """);
+            var provider = new CSharpProjectMetadataProvider();
+
+            var metadata = await provider.GetMetadataAsync(
+                project: new ProjectContext(ProjectPath: projectPath, WorkspacePath: directory),
+                cancellationToken: CancellationToken.None);
+
+            metadata.Diagnostics.Should().BeEmpty();
+            var holder = metadata.Types.Should().ContainSingle(type => type.Name == "GeometryHolder").Which;
+            holder.DocComment.Should().NotBeNull();
+            holder.DocComment!.Summary.Should().Contain("Defines the types of a");
+            holder.DocComment.Summary.Should().Contain("<see cref=\"T:");
+            holder.DocComment.Summary.Should().Contain("GeometryFieldType");
+
+            var get = holder.Methods.Should().ContainSingle(method => method.Name == "Get").Which;
+            get.DocComment.Should().NotBeNull();
+            get.DocComment!.Returns.Should().Contain("<see cref=\"T:");
+            get.DocComment.Returns.Should().Contain("GeometryFieldType");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
     public async Task GetMetadataCompilesProjectReferencesSeparatelyBeforeMergingMetadata()
     {
         var directory = CreateProjectDirectory();

--- a/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
+++ b/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
@@ -624,8 +624,9 @@ public sealed class CSharpProjectMetadataProviderTests
                           public class GeometryHolder
                           {
                               /// <summary>Gets a value.</summary>
+                              /// <param name="index">The index of the <see cref="GeometryFieldType"/> to return.</param>
                               /// <returns>The <see cref="GeometryFieldType"/> instance.</returns>
-                              public GeometryFieldType Get()
+                              public GeometryFieldType Get(int index)
                               {
                                   return new GeometryFieldType();
                               }
@@ -648,6 +649,11 @@ public sealed class CSharpProjectMetadataProviderTests
             get.DocComment.Should().NotBeNull();
             get.DocComment!.Returns.Should().Contain("<see cref=\"T:");
             get.DocComment.Returns.Should().Contain("GeometryFieldType");
+
+            var indexParam = get.DocComment.Parameters.Should().ContainSingle().Which;
+            indexParam.Name.Should().Be("index");
+            indexParam.Description.Should().Contain("<see cref=\"T:");
+            indexParam.Description.Should().Contain("GeometryFieldType");
         }
         finally
         {


### PR DESCRIPTION
This pull request introduces improvements to the handling and formatting of XML doc-comments, ensuring inline elements are preserved in metadata and providing new helpers to convert C# XML documentation to TypeScript JSDoc. It also updates dependencies and adds comprehensive unit tests to verify the new behavior.

**Doc-comment extraction and formatting improvements:**

* Fixed the extraction of XML doc-comments so that inline elements (like `<see cref="..."/>`) are preserved in the `$DocComment[$Summary]` and `$DocComment[$Returns]` properties, instead of being stripped to plain text. This ensures that referenced type names and other inline documentation tags are retained in the metadata. [[1]](diffhunk://#diff-131fd96b68788b0eb8457106af1bffe0cd099b9171832fb11bc7fd1a3be4390dL1518-R1519) [[2]](diffhunk://#diff-131fd96b68788b0eb8457106af1bffe0cd099b9171832fb11bc7fd1a3be4390dR1594-R1600) [[3]](diffhunk://#diff-94881705b1c8fbffa9dfdd9c776db95c165bf8e200ad1cba0c36964f57b6831bR593-R657)
* Added a new opt-in `Typewriter.Extensions.Documentation` formatter with extension methods `DocComment.ToJsDoc()`, `ToJsDocSummary()`, and `ToJsDocReturns()`. These helpers convert C# XML doc tags to TypeScript JSDoc format, handling tags like `<see>`, `<c>`, `<paramref>`, and more. [[1]](diffhunk://#diff-4bea198070ee3331155d258aa0c9dd89c8945d7de13435ae7b7b6778e8f449e1R1-R167) [[2]](diffhunk://#diff-983f75a9d29c7ff51d0d87297a1bdb594b4b063b6082c8bc170a2158acdde71dR159)

**Testing and validation:**

* Added unit tests in `DocCommentExtensionsTests` to verify correct conversion of XML doc-comment inline elements to JSDoc, and in `CSharpProjectMetadataProviderTests` to ensure inline elements are preserved in extracted metadata. [[1]](diffhunk://#diff-3edba01d25c32f0fb374910b23411d35dd86a6f429af9b561c670177ab66bca5R1-R72) [[2]](diffhunk://#diff-94881705b1c8fbffa9dfdd9c776db95c165bf8e200ad1cba0c36964f57b6831bR593-R657)
* Added an integration test in `TemplateRendererTests` to verify that templates can invoke the new JSDoc conversion helpers on doc-comments.

**Project and documentation updates:**

* Updated the project version to `4.4.0` and the `Meziantou.Analyzer` dependency version. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL14-R14) [[2]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL27-R27)
* Updated the `README.md` to document the new features and changelog for version 4.4.0. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R834-R838)