### PR TITLE
fix regression - generate typescript outside of workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Collect editor packages
         shell: pwsh
         run: |
-          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-3.0.0.vsix
-          Copy-Item rider/build/distributions/typewriter-rider-3.0.0.zip artifacts/packages/Typewriter-Rider-3.0.0.zip
+          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.5.1.vsix
+          Copy-Item rider/build/distributions/typewriter-rider-4.5.1.zip artifacts/packages/Typewriter-Rider-4.5.1.zip
 
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,56 +87,7 @@ jobs:
         shell: pwsh
         env:
           VERSION: ${{ steps.apply_version.outputs.version }}
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:VERSION)) {
-            throw "Resolved release version is empty."
-          }
-
-          npm --prefix vscode version $env:VERSION --no-git-tag-version --allow-same-version
-
-          $directoryBuildPropsPath = "Directory.Build.props"
-          $resolvedDirectoryBuildPropsPath = (Resolve-Path -LiteralPath $directoryBuildPropsPath).Path
-          $directoryBuildProps = New-Object System.Xml.XmlDocument
-          $directoryBuildProps.PreserveWhitespace = $true
-          $directoryBuildProps.Load($resolvedDirectoryBuildPropsPath)
-          $versionNode = $directoryBuildProps.SelectSingleNode("/*[local-name()='Project']/*[local-name()='PropertyGroup']/*[local-name()='Version']")
-          if ($null -eq $versionNode) {
-            throw "Unable to find Version in $directoryBuildPropsPath."
-          }
-
-          $versionNode.InnerText = $env:VERSION
-          $directoryBuildProps.Save($resolvedDirectoryBuildPropsPath)
-
-          $manifestPath = "src/Typewriter.VisualStudio/source.extension.vsixmanifest"
-          $resolvedManifestPath = (Resolve-Path -LiteralPath $manifestPath).Path
-          $manifest = New-Object System.Xml.XmlDocument
-          $manifest.PreserveWhitespace = $true
-          $manifest.Load($resolvedManifestPath)
-          $identity = $manifest.SelectSingleNode("/*[local-name()='PackageManifest']/*[local-name()='Metadata']/*[local-name()='Identity']")
-          if ($null -eq $identity) {
-            throw "Unable to find VSIX identity in $manifestPath."
-          }
-
-          $identity.SetAttribute("Version", $env:VERSION)
-          $manifest.Save($resolvedManifestPath)
-
-          $gradlePropertiesPath = "rider/gradle.properties"
-          $pluginVersionFound = $false
-          $gradleProperties = Get-Content -LiteralPath $gradlePropertiesPath | ForEach-Object {
-            if ($_ -match "^\s*pluginVersion\s*=") {
-              $pluginVersionFound = $true
-              "pluginVersion=$env:VERSION"
-            } else {
-              $_
-            }
-          }
-
-          if (-not $pluginVersionFound) {
-            throw "Unable to find pluginVersion in $gradlePropertiesPath."
-          }
-
-          $gradleProperties | Set-Content -LiteralPath $gradlePropertiesPath
-          Write-Host "Stamped release version: $env:VERSION"
+        run: .\setver.ps1 -Version $env:VERSION
 
       - name: Validate NuGet publishing configuration
         shell: pwsh

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ErrorLog>$(MSBuildThisFileDirectory).sarif\$(MSBuildProjectName).json</ErrorLog>
-    <Version>4.5.0</Version>
+    <Version>4.5.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.adaskothebeast.typewriter
 pluginName=Typewriter
-pluginVersion=3.0.0
+pluginVersion=4.5.1
 pluginSinceBuild=261
 platformVersion=2026.1.2
 

--- a/setver.ps1
+++ b/setver.ps1
@@ -1,0 +1,176 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^\d+\.\d+\.\d+(?:\.\d+)?(?:-[0-9A-Za-z.-]+)?$')]
+    [string]$Version
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-RepositoryPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RelativePath
+    )
+
+    return Join-Path -Path $PSScriptRoot -ChildPath $RelativePath
+}
+
+function Save-XmlDocument {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlDocument]$Document,
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $settings = [System.Xml.XmlWriterSettings]::new()
+    $settings.Encoding = [System.Text.UTF8Encoding]::new($false)
+    $settings.Indent = $false
+    $settings.NewLineHandling = [System.Xml.NewLineHandling]::None
+    $settings.OmitXmlDeclaration = $Document.FirstChild.NodeType -ne [System.Xml.XmlNodeType]::XmlDeclaration
+
+    $writer = [System.Xml.XmlWriter]::Create($Path, $settings)
+    try {
+        $Document.Save($writer)
+    } finally {
+        $writer.Dispose()
+    }
+}
+
+function Set-XmlNodeText {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RelativePath,
+        [Parameter(Mandatory = $true)]
+        [string]$XPath
+    )
+
+    $path = Get-RepositoryPath -RelativePath $RelativePath
+    $document = New-Object System.Xml.XmlDocument
+    $document.PreserveWhitespace = $true
+    $document.Load($path)
+
+    $node = $document.SelectSingleNode($XPath)
+    if ($null -eq $node) {
+        throw "Unable to find XML node '$XPath' in '$RelativePath'."
+    }
+
+    $node.InnerText = $Version
+    Save-XmlDocument -Document $document -Path $path
+    Write-Host "Updated $RelativePath"
+}
+
+function Set-XmlAttributeValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RelativePath,
+        [Parameter(Mandatory = $true)]
+        [string]$XPath,
+        [Parameter(Mandatory = $true)]
+        [string]$AttributeName
+    )
+
+    $path = Get-RepositoryPath -RelativePath $RelativePath
+    $document = New-Object System.Xml.XmlDocument
+    $document.PreserveWhitespace = $true
+    $document.Load($path)
+
+    $node = $document.SelectSingleNode($XPath)
+    if ($null -eq $node) {
+        throw "Unable to find XML node '$XPath' in '$RelativePath'."
+    }
+
+    if ($null -eq $node.Attributes[$AttributeName]) {
+        throw "Unable to find XML attribute '$AttributeName' in '$RelativePath'."
+    }
+
+    $node.SetAttribute($AttributeName, $Version)
+    Save-XmlDocument -Document $document -Path $path
+    Write-Host "Updated $RelativePath"
+}
+
+function Set-RegexValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RelativePath,
+        [Parameter(Mandatory = $true)]
+        [string]$Pattern,
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Replacement,
+        [int]$ExpectedCount = 1
+    )
+
+    $path = Get-RepositoryPath -RelativePath $RelativePath
+    $content = Get-Content -LiteralPath $path -Raw
+    $regex = [regex]::new($Pattern)
+    $matches = $regex.Matches($content)
+    if ($matches.Count -ne $ExpectedCount) {
+        throw "Expected $ExpectedCount match(es) for '$Pattern' in '$RelativePath', found $($matches.Count)."
+    }
+
+    $updated = $regex.Replace(
+        $content,
+        [System.Text.RegularExpressions.MatchEvaluator]{
+            param($match)
+            return (& $Replacement $match)
+        })
+
+    Set-Content -LiteralPath $path -Value $updated -NoNewline
+    Write-Host "Updated $RelativePath"
+}
+
+Set-XmlNodeText `
+    -RelativePath "Directory.Build.props" `
+    -XPath "/*[local-name()='Project']/*[local-name()='PropertyGroup']/*[local-name()='Version']"
+
+Set-XmlAttributeValue `
+    -RelativePath "src/Typewriter.VisualStudio/source.extension.vsixmanifest" `
+    -XPath "/*[local-name()='PackageManifest']/*[local-name()='Metadata']/*[local-name()='Identity']" `
+    -AttributeName "Version"
+
+Set-RegexValue `
+    -RelativePath "src/Typewriter.VisualStudio/TypewriterPackage.cs" `
+    -Pattern '(productId:\s*")[^"]+(")' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+Set-RegexValue `
+    -RelativePath "src/Typewriter.LanguageServer/LanguageServerHost.cs" `
+    -Pattern '(\bversion\s*=\s*")[^"]+(",)' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+Set-RegexValue `
+    -RelativePath "vscode/package.json" `
+    -Pattern '(?s)^(\{\s*\r?\n\s*"name"\s*:\s*"typewriter-vscode",.*?\r?\n\s*"version"\s*:\s*")[^"]+(")' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+Set-RegexValue `
+    -RelativePath "vscode/package-lock.json" `
+    -Pattern '(?s)^(\{\s*\r?\n\s*"name"\s*:\s*"typewriter-vscode",\s*\r?\n\s*"version"\s*:\s*")[^"]+(")' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+Set-RegexValue `
+    -RelativePath "vscode/package-lock.json" `
+    -Pattern '(?s)("packages"\s*:\s*\{\s*\r?\n\s*""\s*:\s*\{\s*\r?\n\s*"name"\s*:\s*"typewriter-vscode",\s*\r?\n\s*"version"\s*:\s*")[^"]+(")' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version$($match.Groups[2].Value)" }
+
+Set-RegexValue `
+    -RelativePath "rider/gradle.properties" `
+    -Pattern '(?m)^(pluginVersion=).*$' `
+    -Replacement { param($match) "$($match.Groups[1].Value)$Version" }
+
+Set-RegexValue `
+    -RelativePath ".github/workflows/ci.yml" `
+    -Pattern 'Typewriter\.VisualStudio-[0-9A-Za-z.+-]+\.vsix' `
+    -Replacement { param($match) "Typewriter.VisualStudio-$Version.vsix" }
+
+Set-RegexValue `
+    -RelativePath ".github/workflows/ci.yml" `
+    -Pattern 'typewriter-rider-[0-9A-Za-z.+-]+\.zip' `
+    -Replacement { param($match) "typewriter-rider-$Version.zip" }
+
+Set-RegexValue `
+    -RelativePath ".github/workflows/ci.yml" `
+    -Pattern 'Typewriter-Rider-[0-9A-Za-z.+-]+\.zip' `
+    -Replacement { param($match) "Typewriter-Rider-$Version.zip" }
+
+Write-Host "Version set to $Version"

--- a/src/Typewriter.Engine/GeneratedFilePlanner.cs
+++ b/src/Typewriter.Engine/GeneratedFilePlanner.cs
@@ -62,17 +62,6 @@ public sealed class GeneratedFilePlanner
         diagnostic = null;
 
         var resolvedOutputPath = ResolveOutputPath(template: template, configuredOutputPath: outputPath, fileNameConvention: fileNameConvention);
-        if (!IsInsideWorkspace(workspacePath: workspace.RootPath, outputPath: resolvedOutputPath))
-        {
-            diagnostic = new GenerationDiagnostic(
-                File: template.Path,
-                Line: null,
-                Column: null,
-                Severity: DiagnosticSeverity.Error,
-                Message: $"Output path is outside the workspace: {resolvedOutputPath}.",
-                Code: DiagnosticCodes.OutputPathOutsideWorkspace);
-            return false;
-        }
 
         if (string.Equals(
             a: Path.GetFullPath(path: template.Path),
@@ -143,24 +132,6 @@ public sealed class GeneratedFilePlanner
             : Path.Combine(path1: templateDirectory, path2: output);
 
         return Path.GetFullPath(path: combined);
-    }
-
-    private static bool IsInsideWorkspace(
-        string workspacePath,
-        string outputPath)
-    {
-        var root = Path.GetFullPath(path: workspacePath);
-        if (File.Exists(path: root))
-        {
-            root = Path.GetDirectoryName(path: root) ?? root;
-        }
-
-        if (!root.EndsWith(value: Path.DirectorySeparatorChar))
-        {
-            root += Path.DirectorySeparatorChar;
-        }
-
-        return outputPath.StartsWith(value: root, comparisonType: StringComparison.OrdinalIgnoreCase);
     }
 
     private static string EnsureGeneratedHeader(string content)

--- a/src/Typewriter.LanguageServer/LanguageServerHost.cs
+++ b/src/Typewriter.LanguageServer/LanguageServerHost.cs
@@ -99,7 +99,7 @@ internal sealed class LanguageServerHost
             serverInfo = new
             {
                 name = "Typewriter Language Server",
-                version = "3.0.0",
+                version = "4.5.1",
             },
         };
 

--- a/src/Typewriter.VisualStudio/TypewriterPackage.cs
+++ b/src/Typewriter.VisualStudio/TypewriterPackage.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 namespace Typewriter.VisualStudio;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "3.0.0")]
+[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.5.1")]
 [ProvideMenuResource(resourceID: "Menus.ctmenu", version: 1)]
 [ProvideOptionPage(pageType: typeof(TypewriterOptions), categoryName: "Typewriter", pageName: "General", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true)]
 [ProvideAutoLoad(cmdUiContextGuid: VSConstants.UICONTEXT.SolutionExists_string, flags: PackageAutoLoadFlags.BackgroundLoad)]

--- a/src/Typewriter.VisualStudio/source.extension.vsixmanifest
+++ b/src/Typewriter.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.5.0" Language="en-US" Publisher="AdaskoTheBeAsT" />
+    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.5.1" Language="en-US" Publisher="AdaskoTheBeAsT" />
     <DisplayName>Typewriter</DisplayName>
     <Description xml:space="preserve">Generate TypeScript from C# Typewriter templates.</Description>
     <Tags>Typewriter;TypeScript;C#;Code Generation</Tags>

--- a/tests/unit/Typewriter.Cli.Tests/CliIntegrationTests.cs
+++ b/tests/unit/Typewriter.Cli.Tests/CliIntegrationTests.cs
@@ -147,6 +147,55 @@ public sealed class CliIntegrationTests
     }
 
     [Fact]
+    public async Task RunAsyncGenerateWritesFileOutsideWorkspace()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var backendDirectory = Path.Combine(path1: directory, path2: "backend");
+            var generatedPath = Path.Combine(path1: directory, path2: "frontend", path3: "generated", path4: "models.ts");
+            var project = await CreateSimpleProjectAsync(
+                directory: backendDirectory,
+                templateContent: """
+                                 // output: ../frontend/generated/models.ts
+                                 $Classes[
+                                 export interface $Name {
+                                 $Properties[
+                                   $name: $Type;]
+                                 }
+                                 ]
+                                 """);
+
+            var result = await RunCliAsync(
+                "generate",
+                "--workspace",
+                backendDirectory,
+                "--project",
+                project.ProjectPath,
+                "--template",
+                project.TemplatePath,
+                "--framework",
+                "net10.0",
+                "--output",
+                "json");
+
+            result.ExitCode.Should().Be(0);
+            result.Success.Should().BeTrue(because: result.StandardError);
+            result.Diagnostics.Should().BeEmpty();
+
+            var generatedFile = result.GeneratedFiles.Should().ContainSingle().Which;
+            generatedFile.Path.Should().Be(generatedPath);
+
+            var generatedContent = await File.ReadAllTextAsync(path: generatedPath);
+            generatedContent.Should().Contain("export interface Customer");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
     public async Task RunAsyncGenerateAllProjectsWritesEveryProjectTemplate()
     {
         var directory = CreateProjectDirectory();

--- a/tests/unit/Typewriter.Engine.Tests/GeneratedFilePlannerTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/GeneratedFilePlannerTests.cs
@@ -50,6 +50,37 @@ public sealed class GeneratedFilePlannerTests
         }
     }
 
+    [Fact]
+    public async Task TryPlanAllowsOutputOutsideWorkspace()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var backendDirectory = Path.Combine(path1: directory, path2: "backend");
+            var templatePath = Path.Combine(path1: backendDirectory, path2: "Models.tst");
+            var expectedOutputPath = Path.Combine(path1: directory, path2: "frontend", path3: "generated", path4: "models.ts");
+            Directory.CreateDirectory(path: backendDirectory);
+            await File.WriteAllTextAsync(path: templatePath, contents: string.Empty);
+
+            var planner = new GeneratedFilePlanner();
+            var planned = planner.TryPlan(
+                workspace: new WorkspaceContext(RootPath: backendDirectory),
+                template: new TemplateDocument(Path: templatePath, Content: string.Empty, OutputPath: "../frontend/generated/models.ts"),
+                content: "export interface Customer {}",
+                generatedFile: out var generatedFile,
+                diagnostic: out var diagnostic);
+
+            planned.Should().BeTrue(because: diagnostic?.Message);
+            diagnostic.Should().BeNull();
+            generatedFile.Should().NotBeNull();
+            generatedFile!.Path.Should().Be(expectedOutputPath);
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
     private static string CreateProjectDirectory()
     {
         var directory = Path.Combine(

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typewriter-vscode",
-  "version": "3.0.0",
+  "version": "4.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typewriter-vscode",
-      "version": "3.0.0",
+      "version": "4.5.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^10.0.1"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typewriter-vscode",
   "displayName": "Typewriter",
   "description": "VS Code adapter for Typewriter .tst templates.",
-  "version": "3.0.0",
+  "version": "4.5.1",
   "publisher": "adaskothebeast",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
This pull request updates the Typewriter project to version 4.5.1 and introduces improvements to version management and output path handling. The most important changes include updating version numbers across all packages and artifacts, centralizing version stamping logic into a new script, and relaxing the restriction that generated files must be inside the workspace. Below are the key changes:

**Versioning and Release Automation:**

* All package and artifact version numbers have been updated from `3.0.0` (or `4.5.0`) to `4.5.1` in files such as `Directory.Build.props`, `rider/gradle.properties`, `src/Typewriter.VisualStudio/TypewriterPackage.cs`, `src/Typewriter.VisualStudio/source.extension.vsixmanifest`, `vscode/package.json`, and `vscode/package-lock.json`. (`[[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL14-R14)`, `[[2]](diffhunk://#diff-9a9ceaffbadf59cdb679b33f9b046dc11f5547bdd75a197dad5b74030dc25966L3-R3)`, `[[3]](diffhunk://#diff-0fe60420e46f2d750c12fb98ec460ddaa6982b52270f65451e0e4943223ebc4aL13-R13)`, `[[4]](diffhunk://#diff-e51f2f3de5be31955cb798c4ba2db57f3de15f96ce94f80efb7c5747ef3974dfL4-R4)`, `[[5]](diffhunk://#diff-35017bf2deb6f8fcfcad9110fc8c9a9402caddc668c2d3e352290ab57cb65521L102-R102)`, `[[6]](diffhunk://#diff-a80e103c30d6e330f516b0e27b1072a48509d32373887ecbc9768fd09eb7b9b7L3-R9)`, `[[7]](diffhunk://#diff-99d7a3c2c2975fcaf8184c4639922f5ef6c915610b6f8e15ffa8fb8b329828d8L5-R5)`)
* The CI workflow (`.github/workflows/ci.yml`) now collects and names editor packages using the new version, and the release workflow (`.github/workflows/release.yml`) delegates all version stamping to a new script. (`[[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL94-R95)`, `[[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L90-R90)`)
* Introduced a new `setver.ps1` script that centralizes and automates version stamping across all relevant files and artifacts. (`[setver.ps1R1-R176](diffhunk://#diff-05f746b4f2219e34432d8be096b722af2603f0f47f968384940c714fdc8567ecR1-R176)`)

**Output Path Handling:**

* The restriction that generated files must be inside the workspace has been removed from `GeneratedFilePlanner`. This allows output paths outside the workspace, as verified by new and updated unit/integration tests. (`[[1]](diffhunk://#diff-d2dad72ac6519b63da40b6037a86f72b7a6b9ec903cba2fd4ae6ba4ec65747b0L65-L75)`, `[[2]](diffhunk://#diff-d2dad72ac6519b63da40b6037a86f72b7a6b9ec903cba2fd4ae6ba4ec65747b0L148-L165)`, `[[3]](diffhunk://#diff-725c81477d1285574594e90f8eefb111470aad486e2f870c5235a5d333fddf9fR53-R83)`, `[[4]](diffhunk://#diff-141b1e0b6d72adf92848976a521f4f71fb60fc8953f6bd657861ca79ec5042f7R149-R197)`)

**Testing:**

* Added and updated tests to ensure that output files can be generated outside the workspace and that versioning changes are correctly applied. (`[[1]](diffhunk://#diff-725c81477d1285574594e90f8eefb111470aad486e2f870c5235a5d333fddf9fR53-R83)`, `[[2]](diffhunk://#diff-141b1e0b6d72adf92848976a521f4f71fb60fc8953f6bd657861ca79ec5042f7R149-R197)`)

These changes streamline the release process, improve flexibility for generated file locations, and ensure consistency in versioning across all project components.