### PR TITLE
cs outside of workspace and duplicate assembly identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Collect editor packages
         shell: pwsh
         run: |
-          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.5.1.vsix
-          Copy-Item rider/build/distributions/typewriter-rider-4.5.1.zip artifacts/packages/Typewriter-Rider-4.5.1.zip
+          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.5.2.vsix
+          Copy-Item rider/build/distributions/typewriter-rider-4.5.2.zip artifacts/packages/Typewriter-Rider-4.5.2.zip
 
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ErrorLog>$(MSBuildThisFileDirectory).sarif\$(MSBuildProjectName).json</ErrorLog>
-    <Version>4.5.1</Version>
+    <Version>4.5.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
   - [🔨 Building from Source](#-building-from-source)
   - [🗺 Project Status and Roadmap](#-project-status-and-roadmap)
   - [Changelog](#changelog)
+    - [4.5.2](#452)
     - [4.5.0](#450)
     - [4.4.0](#440)
     - [4.3.0](#430)
@@ -794,7 +795,7 @@ dotnet test AdaskoTheBeAsT.Typewriter.slnx --configuration Release --no-build -m
 npm ci --prefix vscode
 npm --prefix vscode run lint
 npm --prefix vscode run bundle
-npm --prefix vscode run package -- --out ../artifacts/packages/typewriter-vscode-3.0.0.vsix
+npm --prefix vscode run package -- --out ../artifacts/packages/typewriter-vscode-4.5.2.vsix
 
 # JetBrains Rider plugin
 ./rider/gradlew -p rider verifyPluginProjectConfiguration
@@ -835,6 +836,12 @@ dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj --config
 ---
 
 ## Changelog
+
+### 4.5.2
+
+- Fixed IDE generate-on-save for C# source changes when templates are stored outside the saved file's project directory.
+- Fixed duplicate assembly identity loading during analyzer/source-generator and template helper resolution, avoiding intermittent "assembly already loaded" failures.
+- Updated the Rider plugin build to IntelliJ Platform Gradle Plugin `2.17.0`.
 
 ### 4.5.0
 

--- a/rider/build.gradle.kts
+++ b/rider/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "2.2.21"
-    id("org.jetbrains.intellij.platform") version "2.16.0"
+    id("org.jetbrains.intellij.platform") version "2.17.0"
 }
 
 group = providers.gradleProperty("pluginGroup").get()

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.adaskothebeast.typewriter
 pluginName=Typewriter
-pluginVersion=4.5.1
+pluginVersion=4.5.2
 pluginSinceBuild=261
 platformVersion=2026.1.2
 

--- a/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterCliService.kt
+++ b/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterCliService.kt
@@ -179,11 +179,7 @@ class TypewriterCliService(private val project: Project) {
         try {
             val workingDirectory = getPathBase(workspacePath).toString()
             val projectPath = resolveOptionalPath(settings.projectPath, getPathBase(workspacePath).toString()) ?: projectPathOverride
-            val templateSearchPath = if (projectScoped) {
-                projectPath?.let { Paths.get(it).parent?.toString() }
-            } else {
-                null
-            }
+            val templateSearchPath = if (projectScoped) resolveProjectTemplateSearchPath(projectPath) else null
             val persistentResult = project.service<TypewriterLanguageServerClient>().tryGenerate(
                 request = PersistentGenerationRequest(
                     command = command,
@@ -365,6 +361,34 @@ class TypewriterCliService(private val project: Project) {
         return null
     }
 
+    private fun resolveProjectTemplateSearchPath(projectPath: String?): String? {
+        if (projectPath.isNullOrBlank()) {
+            return null
+        }
+
+        val projectDirectory = Paths.get(projectPath).parent ?: return null
+        return if (containsTemplateFile(projectDirectory)) projectDirectory.toString() else null
+    }
+
+    private fun containsTemplateFile(root: Path): Boolean {
+        return try {
+            Files.walk(root).use { paths ->
+                paths.anyMatch { candidate ->
+                    !hasIgnoredInputSegment(candidate) &&
+                        Files.isRegularFile(candidate) &&
+                        candidate.fileName.toString().endsWith(".tst", ignoreCase = true)
+                }
+            }
+        } catch (_: IOException) {
+            false
+        } catch (_: SecurityException) {
+            false
+        }
+    }
+
+    private fun hasIgnoredInputSegment(path: Path): Boolean =
+        path.any { it.toString().lowercase() in IgnoredInputDirectories }
+
     private fun readConfiguredInputExtensions(filePath: String): Set<String> {
         var extensions = DefaultInputExtensions
         for (configurationPath in findConfigurationFiles(filePath)) {
@@ -500,5 +524,6 @@ class TypewriterCliService(private val project: Project) {
         const val SaveDebounceMillis = 300
         val ConfigurationFileNames = listOf("typewriter.json", "typewriter.config.json", ".typewriterrc.json")
         val DefaultInputExtensions = setOf(".cs", ".csproj", ".json", ".props", ".sln", ".slnx", ".targets", ".tst")
+        val IgnoredInputDirectories = setOf("bin", "obj", "node_modules", "generated")
     }
 }

--- a/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterCliService.kt
+++ b/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterCliService.kt
@@ -20,9 +20,13 @@ import com.intellij.util.Alarm
 import com.intellij.util.execution.ParametersListUtil
 import java.io.IOException
 import java.nio.charset.StandardCharsets
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
+import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 
 @Service(Service.Level.PROJECT)
 class TypewriterCliService(private val project: Project) {
@@ -366,28 +370,47 @@ class TypewriterCliService(private val project: Project) {
             return null
         }
 
-        val projectDirectory = Paths.get(projectPath).parent ?: return null
+        val projectDirectory = try {
+            Paths.get(projectPath).parent ?: return null
+        } catch (_: InvalidPathException) {
+            return null
+        }
+
         return if (containsTemplateFile(projectDirectory)) projectDirectory.toString() else null
     }
 
     private fun containsTemplateFile(root: Path): Boolean {
+        var found = false
         return try {
-            Files.walk(root).use { paths ->
-                paths.anyMatch { candidate ->
-                    !hasIgnoredInputSegment(candidate) &&
-                        Files.isRegularFile(candidate) &&
-                        candidate.fileName.toString().endsWith(".tst", ignoreCase = true)
+            Files.walkFileTree(root, object : SimpleFileVisitor<Path>() {
+                override fun preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult {
+                    if (dir != root && dir.fileName.toString().lowercase() in IgnoredInputDirectories) {
+                        return FileVisitResult.SKIP_SUBTREE
+                    }
+
+                    return FileVisitResult.CONTINUE
                 }
-            }
+
+                override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                    if (file.fileName.toString().endsWith(".tst", ignoreCase = true)) {
+                        found = true
+                        return FileVisitResult.TERMINATE
+                    }
+
+                    return FileVisitResult.CONTINUE
+                }
+
+                override fun visitFileFailed(file: Path, exc: IOException): FileVisitResult =
+                    FileVisitResult.CONTINUE
+            })
+
+            found
         } catch (_: IOException) {
             false
         } catch (_: SecurityException) {
             false
         }
     }
-
-    private fun hasIgnoredInputSegment(path: Path): Boolean =
-        path.any { it.toString().lowercase() in IgnoredInputDirectories }
 
     private fun readConfiguredInputExtensions(filePath: String): Set<String> {
         var extensions = DefaultInputExtensions
@@ -524,6 +547,6 @@ class TypewriterCliService(private val project: Project) {
         const val SaveDebounceMillis = 300
         val ConfigurationFileNames = listOf("typewriter.json", "typewriter.config.json", ".typewriterrc.json")
         val DefaultInputExtensions = setOf(".cs", ".csproj", ".json", ".props", ".sln", ".slnx", ".targets", ".tst")
-        val IgnoredInputDirectories = setOf("bin", "obj", "node_modules", "generated")
+        val IgnoredInputDirectories = setOf(".git", ".gradle", ".idea", ".vs", ".vscode", "bin", "obj", "node_modules", "generated")
     }
 }

--- a/src/Typewriter.Engine/TemplateAssemblyLoadContext.cs
+++ b/src/Typewriter.Engine/TemplateAssemblyLoadContext.cs
@@ -5,6 +5,7 @@ namespace Typewriter.Engine;
 
 internal sealed class TemplateAssemblyLoadContext : AssemblyLoadContext
 {
+    private readonly Lock _loadLock = new();
     private readonly IReadOnlyDictionary<string, string> _referencePaths;
 
     public TemplateAssemblyLoadContext(
@@ -29,10 +30,16 @@ internal sealed class TemplateAssemblyLoadContext : AssemblyLoadContext
             return sharedAssembly;
         }
 
+        var loadedAssembly = FindLoadedAssembly(assemblyName: assemblyName);
+        if (loadedAssembly is not null)
+        {
+            return loadedAssembly;
+        }
+
         if (assemblyName.Name is not null
             && _referencePaths.TryGetValue(key: assemblyName.Name, value: out var referencePath))
         {
-            return LoadFromAssemblyPath(assemblyPath: referencePath);
+            return LoadFromAssemblyPathOnce(assemblyPath: referencePath, requestedName: assemblyName);
         }
 
         return null;
@@ -60,4 +67,53 @@ internal sealed class TemplateAssemblyLoadContext : AssemblyLoadContext
             return null;
         }
     }
+
+    private static AssemblyName? TryGetAssemblyName(string path)
+    {
+        try
+        {
+            return AssemblyName.GetAssemblyName(assemblyFile: path);
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+        catch (FileLoadException)
+        {
+            return null;
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    private Assembly LoadFromAssemblyPathOnce(
+        string assemblyPath,
+        AssemblyName requestedName)
+    {
+        var fullPath = Path.GetFullPath(path: assemblyPath);
+        var candidateName = TryGetAssemblyName(path: fullPath) ?? requestedName;
+        lock (_loadLock)
+        {
+            var loadedAssembly = FindLoadedAssembly(assemblyName: candidateName);
+            if (loadedAssembly is not null)
+            {
+                return loadedAssembly;
+            }
+
+            try
+            {
+                return LoadFromAssemblyPath(assemblyPath: fullPath);
+            }
+            catch (FileLoadException) when (FindLoadedAssembly(assemblyName: candidateName) is not null)
+            {
+                return FindLoadedAssembly(assemblyName: candidateName)!;
+            }
+        }
+    }
+
+    private Assembly? FindLoadedAssembly(AssemblyName assemblyName) =>
+        Assemblies.FirstOrDefault(
+            predicate: assembly => AssemblyName.ReferenceMatchesDefinition(reference: assemblyName, definition: assembly.GetName()));
 }

--- a/src/Typewriter.LanguageServer/LanguageServerHost.cs
+++ b/src/Typewriter.LanguageServer/LanguageServerHost.cs
@@ -99,7 +99,7 @@ internal sealed class LanguageServerHost
             serverInfo = new
             {
                 name = "Typewriter Language Server",
-                version = "4.5.1",
+                version = "4.5.2",
             },
         };
 

--- a/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
+++ b/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
@@ -2021,6 +2021,7 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         {
             private readonly ConcurrentDictionary<string, byte> _dependencyLocations = new(comparer: StringComparer.OrdinalIgnoreCase);
             private readonly ConcurrentDictionary<string, string> _referencePaths = new(comparer: StringComparer.OrdinalIgnoreCase);
+            private readonly Lock _loadLock = new();
 
             public AnalyzerAssemblyLoadContext()
                 : base(name: "Typewriter.SourceGenerators", isCollectible: true)
@@ -2064,9 +2065,8 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
 
             public Assembly LoadAnalyzerAssembly(string assemblyPath)
             {
-#pragma warning disable SCS0018
-                return LoadFromAssemblyPath(assemblyPath: assemblyPath);
-#pragma warning restore SCS0018
+                var analyzerPath = Path.GetFullPath(path: assemblyPath);
+                return LoadFromAssemblyPathOnce(assemblyPath: analyzerPath, requestedName: TryGetAssemblyName(path: analyzerPath));
             }
 
             protected override Assembly? Load(AssemblyName assemblyName)
@@ -2078,15 +2078,39 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                     return sharedAssembly;
                 }
 
+                var loadedAssembly = FindLoadedAssembly(assemblyName: assemblyName);
+                if (loadedAssembly is not null)
+                {
+                    return loadedAssembly;
+                }
+
                 if (assemblyName.Name is not null
                     && _referencePaths.TryGetValue(key: assemblyName.Name, value: out var referencePath))
                 {
-#pragma warning disable SCS0018
-                    return LoadFromAssemblyPath(assemblyPath: referencePath);
-#pragma warning restore SCS0018
+                    return LoadFromAssemblyPathOnce(assemblyPath: referencePath, requestedName: assemblyName);
                 }
 
                 return LoadFromDependencyDirectory(assemblyName: assemblyName);
+            }
+
+            private static AssemblyName? TryGetAssemblyName(string path)
+            {
+                try
+                {
+                    return AssemblyName.GetAssemblyName(assemblyFile: path);
+                }
+                catch (BadImageFormatException)
+                {
+                    return null;
+                }
+                catch (FileLoadException)
+                {
+                    return null;
+                }
+                catch (FileNotFoundException)
+                {
+                    return null;
+                }
             }
 
             private Assembly? LoadFromDependencyDirectory(AssemblyName assemblyName)
@@ -2108,13 +2132,56 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                     var candidate = Path.Combine(path1: directory, path2: assemblyFileName);
                     if (File.Exists(path: candidate))
                     {
-#pragma warning disable SCS0018
-                        return LoadFromAssemblyPath(assemblyPath: candidate);
-#pragma warning restore SCS0018
+                        return LoadFromAssemblyPathOnce(assemblyPath: candidate, requestedName: assemblyName);
                     }
                 }
 
                 return null;
+            }
+
+            private Assembly LoadFromAssemblyPathOnce(
+                string assemblyPath,
+                AssemblyName? requestedName)
+            {
+                var fullPath = Path.GetFullPath(path: assemblyPath);
+                var candidateName = TryGetAssemblyName(path: fullPath) ?? requestedName;
+                lock (_loadLock)
+                {
+                    var loadedAssembly = candidateName is null
+                        ? FindLoadedAssemblyByPath(assemblyPath: fullPath)
+                        : FindLoadedAssembly(assemblyName: candidateName);
+                    if (loadedAssembly is not null)
+                    {
+                        return loadedAssembly;
+                    }
+
+                    try
+                    {
+#pragma warning disable SCS0018
+                        return LoadFromAssemblyPath(assemblyPath: fullPath);
+#pragma warning restore SCS0018
+                    }
+                    catch (FileLoadException) when (candidateName is not null && FindLoadedAssembly(assemblyName: candidateName) is not null)
+                    {
+                        return FindLoadedAssembly(assemblyName: candidateName)!;
+                    }
+                    catch (FileLoadException) when (FindLoadedAssemblyByPath(assemblyPath: fullPath) is not null)
+                    {
+                        return FindLoadedAssemblyByPath(assemblyPath: fullPath)!;
+                    }
+                }
+            }
+
+            private Assembly? FindLoadedAssembly(AssemblyName assemblyName) =>
+                Assemblies.FirstOrDefault(
+                    predicate: assembly => AssemblyName.ReferenceMatchesDefinition(reference: assemblyName, definition: assembly.GetName()));
+
+            private Assembly? FindLoadedAssemblyByPath(string assemblyPath)
+            {
+                var fullPath = Path.GetFullPath(path: assemblyPath);
+                return Assemblies.FirstOrDefault(
+                    predicate: assembly => assembly.Location.Length > 0
+                                           && string.Equals(a: Path.GetFullPath(path: assembly.Location), b: fullPath, comparisonType: StringComparison.OrdinalIgnoreCase));
             }
         }
     }

--- a/src/Typewriter.VisualStudio/TypewriterCommandService.cs
+++ b/src/Typewriter.VisualStudio/TypewriterCommandService.cs
@@ -814,7 +814,28 @@ internal sealed class TypewriterCommandService
             return null;
         }
 
-        var projectDirectory = Path.GetDirectoryName(path: Path.GetFullPath(path: projectPath));
+        string? projectDirectory;
+        try
+        {
+            projectDirectory = Path.GetDirectoryName(path: Path.GetFullPath(path: projectPath));
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+
         if (string.IsNullOrWhiteSpace(value: projectDirectory) || !Directory.Exists(path: projectDirectory))
         {
             return null;
@@ -857,7 +878,12 @@ internal sealed class TypewriterCommandService
     }
 
     private static bool IsIgnoredTemplateDirectory(string name) =>
-        name.Equals(value: "bin", comparisonType: StringComparison.OrdinalIgnoreCase)
+        name.Equals(value: ".git", comparisonType: StringComparison.OrdinalIgnoreCase)
+        || name.Equals(value: ".gradle", comparisonType: StringComparison.OrdinalIgnoreCase)
+        || name.Equals(value: ".idea", comparisonType: StringComparison.OrdinalIgnoreCase)
+        || name.Equals(value: ".vs", comparisonType: StringComparison.OrdinalIgnoreCase)
+        || name.Equals(value: ".vscode", comparisonType: StringComparison.OrdinalIgnoreCase)
+        || name.Equals(value: "bin", comparisonType: StringComparison.OrdinalIgnoreCase)
         || name.Equals(value: "obj", comparisonType: StringComparison.OrdinalIgnoreCase)
         || name.Equals(value: "node_modules", comparisonType: StringComparison.OrdinalIgnoreCase)
         || name.Equals(value: "generated", comparisonType: StringComparison.OrdinalIgnoreCase);

--- a/src/Typewriter.VisualStudio/TypewriterCommandService.cs
+++ b/src/Typewriter.VisualStudio/TypewriterCommandService.cs
@@ -298,7 +298,7 @@ internal sealed class TypewriterCommandService
 
         var resolvedWorkspacePath = workspacePath ?? string.Empty;
         var templateSearchPath = inputPath is not null && !string.IsNullOrWhiteSpace(value: projectPath)
-            ? Path.GetDirectoryName(path: projectPath)
+            ? ResolveProjectTemplateSearchPath(projectPath: projectPath)
             : null;
         return new GenerationContext(
             workspacePath: resolvedWorkspacePath,
@@ -806,6 +806,61 @@ internal sealed class TypewriterCommandService
             .FirstOrDefault(predicate: projectPath =>
                 IsPathBelowDirectory(path: fullInputPath, directory: Path.GetDirectoryName(path: projectPath) ?? string.Empty));
     }
+
+    private static string? ResolveProjectTemplateSearchPath(string? projectPath)
+    {
+        if (string.IsNullOrWhiteSpace(value: projectPath))
+        {
+            return null;
+        }
+
+        var projectDirectory = Path.GetDirectoryName(path: Path.GetFullPath(path: projectPath));
+        if (string.IsNullOrWhiteSpace(value: projectDirectory) || !Directory.Exists(path: projectDirectory))
+        {
+            return null;
+        }
+
+        return ContainsTemplateFile(directory: projectDirectory)
+            ? projectDirectory
+            : null;
+    }
+
+    private static bool ContainsTemplateFile(string directory)
+    {
+        var pending = new Stack<string>();
+        pending.Push(item: directory);
+        while (pending.Count > 0)
+        {
+            var current = pending.Pop();
+            try
+            {
+                if (Directory.EnumerateFiles(path: current, searchPattern: "*.tst", searchOption: SearchOption.TopDirectoryOnly).Any())
+                {
+                    return true;
+                }
+
+                foreach (var childDirectory in Directory.EnumerateDirectories(path: current)
+                             .Where(predicate: childDirectory => !IsIgnoredTemplateDirectory(name: Path.GetFileName(path: childDirectory))))
+                {
+                    pending.Push(item: childDirectory);
+                }
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsIgnoredTemplateDirectory(string name) =>
+        name.Equals(value: "bin", comparisonType: StringComparison.OrdinalIgnoreCase)
+        || name.Equals(value: "obj", comparisonType: StringComparison.OrdinalIgnoreCase)
+        || name.Equals(value: "node_modules", comparisonType: StringComparison.OrdinalIgnoreCase)
+        || name.Equals(value: "generated", comparisonType: StringComparison.OrdinalIgnoreCase);
 
     private static IEnumerable<Project> EnumerateProjects(Projects projects)
     {

--- a/src/Typewriter.VisualStudio/TypewriterPackage.cs
+++ b/src/Typewriter.VisualStudio/TypewriterPackage.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 namespace Typewriter.VisualStudio;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.5.1")]
+[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.5.2")]
 [ProvideMenuResource(resourceID: "Menus.ctmenu", version: 1)]
 [ProvideOptionPage(pageType: typeof(TypewriterOptions), categoryName: "Typewriter", pageName: "General", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true)]
 [ProvideAutoLoad(cmdUiContextGuid: VSConstants.UICONTEXT.SolutionExists_string, flags: PackageAutoLoadFlags.BackgroundLoad)]

--- a/src/Typewriter.VisualStudio/source.extension.vsixmanifest
+++ b/src/Typewriter.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.5.1" Language="en-US" Publisher="AdaskoTheBeAsT" />
+    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.5.2" Language="en-US" Publisher="AdaskoTheBeAsT" />
     <DisplayName>Typewriter</DisplayName>
     <Description xml:space="preserve">Generate TypeScript from C# Typewriter templates.</Description>
     <Tags>Typewriter;TypeScript;C#;Code Generation</Tags>

--- a/tests/unit/Typewriter.Engine.Tests/TemplateAssemblyLoadContextTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/TemplateAssemblyLoadContextTests.cs
@@ -1,0 +1,122 @@
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Typewriter.Engine.Tests;
+
+public sealed class TemplateAssemblyLoadContextTests
+{
+    [Fact]
+    public void LoadFromAssemblyNameReturnsExistingAssemblyForDuplicateIdentity()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var firstPath = Path.Combine(path1: directory, path2: "first", path3: "DuplicateReference.dll");
+            var secondPath = Path.Combine(path1: directory, path2: "second", path3: "DuplicateReference.dll");
+            Directory.CreateDirectory(path: Path.GetDirectoryName(path: firstPath)!);
+            Directory.CreateDirectory(path: Path.GetDirectoryName(path: secondPath)!);
+            EmitAssembly(path: firstPath, assemblyName: "DuplicateReference");
+            File.Copy(sourceFileName: firstPath, destFileName: secondPath);
+
+            var contextReference = LoadDuplicateReference(firstPath: firstPath, secondPath: secondPath);
+            ForceCollectibleContextCollection(contextReference: contextReference);
+
+            contextReference.IsAlive.Should().BeFalse();
+        }
+        finally
+        {
+            DeleteDirectoryWithRetry(directory: directory);
+        }
+    }
+
+    private static void EmitAssembly(
+        string path,
+        string assemblyName)
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName: assemblyName,
+            syntaxTrees:
+            [
+                CSharpSyntaxTree.ParseText(text: "namespace DuplicateReference; public sealed class Marker { }"),
+            ],
+            references: GetTrustedReferences(),
+            options: new CSharpCompilationOptions(outputKind: OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(path: path);
+        var result = compilation.Emit(peStream: stream);
+        result.Success.Should().BeTrue(because: string.Join(separator: Environment.NewLine, values: result.Diagnostics));
+    }
+
+    private static WeakReference LoadDuplicateReference(
+        string firstPath,
+        string secondPath)
+    {
+        var context = new TemplateAssemblyLoadContext(name: "Typewriter.Tests", referencePaths: [secondPath]);
+        var loaded = context.LoadFromAssemblyPath(assemblyPath: firstPath);
+        var resolved = context.LoadFromAssemblyName(new AssemblyName("DuplicateReference"));
+        resolved.Should().BeSameAs(loaded);
+        var contextReference = new WeakReference(target: context);
+        context.Unload();
+        return contextReference;
+    }
+
+    private static IReadOnlyList<MetadataReference> GetTrustedReferences()
+    {
+        var trustedAssemblies = (string?)AppContext.GetData(name: "TRUSTED_PLATFORM_ASSEMBLIES");
+        trustedAssemblies.Should().NotBeNullOrWhiteSpace();
+        return trustedAssemblies!
+            .Split(separator: Path.PathSeparator, options: StringSplitOptions.RemoveEmptyEntries)
+            .Select(selector: path => MetadataReference.CreateFromFile(path: path))
+            .ToArray();
+    }
+
+    private static string CreateProjectDirectory()
+    {
+        var directory = Path.Combine(
+            path1: Path.GetTempPath(),
+            path2: "Typewriter.Engine.Tests",
+            path3: Guid.NewGuid().ToString(format: "N"));
+        Directory.CreateDirectory(path: directory);
+        return directory;
+    }
+
+#pragma warning disable S1215
+    private static void ForceCollectibleContextCollection(WeakReference contextReference)
+    {
+        for (var attempt = 0; attempt < 10 && contextReference.IsAlive; attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+    }
+
+    private static void DeleteDirectoryWithRetry(string directory)
+    {
+        for (var attempt = 1; attempt <= 5; attempt++)
+        {
+            try
+            {
+                if (Directory.Exists(path: directory))
+                {
+                    Directory.Delete(path: directory, recursive: true);
+                }
+
+                return;
+            }
+            catch (IOException) when (attempt < 5)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+            catch (UnauthorizedAccessException) when (attempt < 5)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+        }
+    }
+#pragma warning restore S1215
+}

--- a/tests/unit/Typewriter.LanguageServer.Tests/WorkspaceGenerationServiceTests.cs
+++ b/tests/unit/Typewriter.LanguageServer.Tests/WorkspaceGenerationServiceTests.cs
@@ -60,6 +60,66 @@ public sealed class WorkspaceGenerationServiceTests
         }
     }
 
+    [Fact]
+    public async Task GenerateAsyncRefreshesOutputAfterSourceFileChanges()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var projectPath = Path.Combine(path1: directory, path2: "App.csproj");
+            var sourcePath = Path.Combine(path1: directory, path2: "Model.cs");
+            var outputPath = Path.Combine(path1: directory, path2: "generated", path3: "models.ts");
+            await File.WriteAllTextAsync(
+                path: projectPath,
+                contents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net10.0</TargetFramework>
+                      </PropertyGroup>
+                    </Project>
+                    """);
+            await File.WriteAllTextAsync(
+                path: sourcePath,
+                contents: "namespace App; public sealed class Model { public string Name { get; set; } = string.Empty; }");
+            await File.WriteAllTextAsync(
+                path: Path.Combine(path1: directory, path2: "Models.tst"),
+                contents: """
+                    // output: generated/models.ts
+                    $Classes[export interface $Name {
+                    $Properties[  $name: $Type;
+                    ]}]
+                    """);
+
+            using var service = new WorkspaceGenerationService();
+            var request = new WorkspaceGenerationRequest(
+                Command: "generate",
+                WorkspacePath: directory,
+                ProjectPath: projectPath,
+                TemplatePath: null,
+                TemplateSearchPath: directory,
+                Framework: null,
+                AllProjects: false);
+            var settings = LanguageServerSettings.Default;
+
+            var first = await service.GenerateAsync(request: request, settings: settings, cancellationToken: CancellationToken.None);
+            await File.WriteAllTextAsync(
+                path: sourcePath,
+                contents: "namespace App; public sealed class Model { public string Name { get; set; } = string.Empty; public int Age { get; set; } }");
+            var second = await service.GenerateAsync(request: request, settings: settings, cancellationToken: CancellationToken.None);
+
+            first.Success.Should().BeTrue();
+            second.Success.Should().BeTrue();
+            second.GeneratedFiles.Should().ContainSingle().Which.Changed.Should().BeTrue();
+            var output = await File.ReadAllTextAsync(path: outputPath);
+            output.Should().Contain("  name: string;");
+            output.Should().Contain("  age: number;");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
     private static string CreateProjectDirectory()
     {
         var directory = Path.Combine(

--- a/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
+++ b/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Typewriter.Abstractions;
 using Typewriter.Roslyn;
 using Xunit;
@@ -1164,6 +1166,52 @@ public sealed class CSharpProjectMetadataProviderTests
         }
     }
 
+    [Fact]
+    public async Task GetMetadataHandlesDuplicateAnalyzerAssemblyIdentities()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var firstAnalyzerPath = Path.Combine(path1: directory, path2: "first", path3: "DuplicateGenerator.dll");
+            var secondAnalyzerPath = Path.Combine(path1: directory, path2: "second", path3: "DuplicateGenerator.dll");
+            Directory.CreateDirectory(path: Path.GetDirectoryName(path: firstAnalyzerPath)!);
+            Directory.CreateDirectory(path: Path.GetDirectoryName(path: secondAnalyzerPath)!);
+            EmitSourceGeneratorAssembly(path: firstAnalyzerPath);
+            File.Copy(sourceFileName: firstAnalyzerPath, destFileName: secondAnalyzerPath);
+
+            var projectPath = Path.Combine(path1: directory, path2: "Sample.csproj");
+            await File.WriteAllTextAsync(
+                path: projectPath,
+                contents: $$"""
+                          <Project Sdk="Microsoft.NET.Sdk">
+                            <PropertyGroup>
+                              <TargetFramework>net10.0</TargetFramework>
+                            </PropertyGroup>
+                            <ItemGroup>
+                              <Analyzer Include="{{firstAnalyzerPath}}" />
+                              <Analyzer Include="{{secondAnalyzerPath}}" />
+                            </ItemGroup>
+                          </Project>
+                          """);
+            await File.WriteAllTextAsync(
+                path: Path.Combine(path1: directory, path2: "Model.cs"),
+                contents: "namespace Sample; public sealed class Model { public string Name { get; set; } = string.Empty; }");
+            var provider = new CSharpProjectMetadataProvider();
+
+            var metadata = await provider.GetMetadataAsync(
+                project: new ProjectContext(ProjectPath: projectPath, WorkspacePath: directory),
+                cancellationToken: CancellationToken.None);
+
+            metadata.Diagnostics.Should().NotContain(diagnostic => diagnostic.Message.Contains(value: "already loaded", comparisonType: StringComparison.OrdinalIgnoreCase));
+            metadata.Types.Should().ContainSingle(type => type.Name == "Model");
+            ForceGarbageCollection();
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
     private static string CreateProjectDirectory()
     {
         var directory = Path.Combine(
@@ -1173,6 +1221,58 @@ public sealed class CSharpProjectMetadataProviderTests
         Directory.CreateDirectory(path: directory);
         return directory;
     }
+
+    private static void EmitSourceGeneratorAssembly(string path)
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "DuplicateGenerator",
+            syntaxTrees:
+            [
+                CSharpSyntaxTree.ParseText(
+                    text: """
+                          using Microsoft.CodeAnalysis;
+
+                          [Generator]
+                          public sealed class DuplicateGenerator : ISourceGenerator
+                          {
+                              public void Initialize(GeneratorInitializationContext context)
+                              {
+                              }
+
+                              public void Execute(GeneratorExecutionContext context)
+                              {
+                              }
+                          }
+                          """),
+            ],
+            references: GetSourceGeneratorReferences(),
+            options: new CSharpCompilationOptions(outputKind: OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(path: path);
+        var result = compilation.Emit(peStream: stream);
+        result.Success.Should().BeTrue(because: string.Join(separator: Environment.NewLine, values: result.Diagnostics));
+    }
+
+    private static IReadOnlyList<MetadataReference> GetSourceGeneratorReferences()
+    {
+        var trustedAssemblies = (string?)AppContext.GetData(name: "TRUSTED_PLATFORM_ASSEMBLIES");
+        trustedAssemblies.Should().NotBeNullOrWhiteSpace();
+        return trustedAssemblies!
+            .Split(separator: Path.PathSeparator, options: StringSplitOptions.RemoveEmptyEntries)
+            .Append(element: typeof(ISourceGenerator).Assembly.Location)
+            .Distinct(comparer: StringComparer.OrdinalIgnoreCase)
+            .Select(selector: path => MetadataReference.CreateFromFile(path: path))
+            .ToArray();
+    }
+
+#pragma warning disable S1215
+    private static void ForceGarbageCollection()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+#pragma warning restore S1215
 
     private static async Task DeleteDirectoryWithRetryAsync(string directory)
     {

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typewriter-vscode",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typewriter-vscode",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^10.0.1"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typewriter-vscode",
   "displayName": "Typewriter",
   "description": "VS Code adapter for Typewriter .tst templates.",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "publisher": "adaskothebeast",
   "license": "MIT",
   "icon": "images/icon.png",

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -12,7 +12,7 @@ const saveDebounceDelayMs = 300;
 const configurationFileNames = ["typewriter.json", "typewriter.config.json", ".typewriterrc.json"];
 const defaultInputExtensions = [".cs", ".csproj", ".json", ".props", ".sln", ".slnx", ".targets", ".tst"];
 const templateExtensions = new Set([".tst"]);
-const ignoredInputDirectories = new Set(["bin", "obj", "node_modules", "generated"]);
+const ignoredInputDirectories = new Set([".git", ".gradle", ".idea", ".vs", ".vscode", "bin", "obj", "node_modules", "generated"]);
 const saveQueue = {
     pending: undefined,
     timer: undefined,

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -330,7 +330,7 @@ function buildTypewriterArguments(command, workspacePath, templatePath, configur
         args.push("--project", projectPath);
     }
 
-    const templateSearchPath = options.projectScoped && projectPath ? path.dirname(projectPath) : undefined;
+    const templateSearchPath = options.projectScoped ? resolveProjectTemplateSearchPath(projectPath) : undefined;
     if (templateSearchPath) {
         args.push("--template-search-path", templateSearchPath);
     }
@@ -603,6 +603,44 @@ function findNearestProjectPathForInput(filePath) {
     return undefined;
 }
 
+function resolveProjectTemplateSearchPath(projectPath) {
+    if (!projectPath) {
+        return undefined;
+    }
+
+    const projectDirectory = path.dirname(projectPath);
+    return containsTemplateFile(projectDirectory) ? projectDirectory : undefined;
+}
+
+function containsTemplateFile(directory) {
+    const pending = [directory];
+    while (pending.length > 0) {
+        const current = pending.pop();
+        let entries;
+        try {
+            entries = fs.readdirSync(current, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+
+        for (const entry of entries) {
+            if (entry.isDirectory()) {
+                if (!ignoredInputDirectories.has(entry.name.toLowerCase())) {
+                    pending.push(path.join(current, entry.name));
+                }
+
+                continue;
+            }
+
+            if (entry.isFile() && templateExtensions.has(path.extname(entry.name).toLowerCase())) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 function readConfiguredInputExtensions(filePath) {
     let extensions = defaultInputExtensions;
     for (const configurationPath of findConfigurationFiles(filePath)) {
@@ -856,7 +894,7 @@ async function tryRunPersistentGeneration(request) {
 
 function buildGenerationRequest(command, workspacePath, templatePath, configuration, options) {
     const projectPath = resolveOptionalPath(configuration.get("projectPath"), getPathBase(workspacePath)) || options.projectPath;
-    const templateSearchPath = options.projectScoped && projectPath ? path.dirname(projectPath) : undefined;
+    const templateSearchPath = options.projectScoped ? resolveProjectTemplateSearchPath(projectPath) : undefined;
     const framework = configuration.get("framework");
     return {
         command,


### PR DESCRIPTION
- Fixed IDE generate-on-save for C# source changes when templates are… stored outside the saved file's project directory.
- Fixed duplicate assembly identity loading during analyzer/source-generator and template helper resolution, avoiding intermittent "assembly already loaded" failures.
- Updated the Rider plugin build to IntelliJ Platform Gradle Plugin `2.17.0`.