### PR TITLE
restore detailed diagnostic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Collect editor packages
         shell: pwsh
         run: |
-          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.5.3.vsix
-          Copy-Item rider/build/distributions/typewriter-rider-4.5.3.zip artifacts/packages/Typewriter-Rider-4.5.3.zip
+          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.5.4.vsix
+          Copy-Item rider/build/distributions/typewriter-rider-4.5.4.zip artifacts/packages/Typewriter-Rider-4.5.4.zip
 
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ErrorLog>$(MSBuildThisFileDirectory).sarif\$(MSBuildProjectName).json</ErrorLog>
-    <Version>4.5.3</Version>
+    <Version>4.5.4</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
     <PackageReference Include="AdaskoTheBeAsT.Puma.Security.Rules.2022" Version="2.3.1.50" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="AdaskoTheBeAsT.ReflectionAnalyzer" Version="0.3.1.50" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="AdaskoTheBeAsT.SecurityCodeScan.VS2022" Version="5.6.7.50" PrivateAssets="all" ExcludeAssets="runtime" />
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.110" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.117" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" ExcludeAssets="runtime" />

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
   - [🔨 Building from Source](#-building-from-source)
   - [🗺 Project Status and Roadmap](#-project-status-and-roadmap)
   - [Changelog](#changelog)
+    - [4.5.4](#454)
     - [4.5.3](#453)
     - [4.5.2](#452)
     - [4.5.0](#450)
@@ -1088,7 +1089,7 @@ dotnet test AdaskoTheBeAsT.Typewriter.slnx --configuration Release --no-build -m
 npm ci --prefix vscode
 npm --prefix vscode run lint
 npm --prefix vscode run bundle
-npm --prefix vscode run package -- --out ../artifacts/packages/typewriter-vscode-4.5.2.vsix
+npm --prefix vscode run package -- --out ../artifacts/packages/typewriter-vscode-4.5.4.vsix
 
 # JetBrains Rider plugin
 ./rider/gradlew -p rider verifyPluginProjectConfiguration
@@ -1129,6 +1130,12 @@ dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj --config
 ---
 
 ## Changelog
+
+### 4.5.4
+
+- Restored detailed project-load diagnostics for Buildalyzer/MSBuild failures, including file, line, column, and underlying MSBuild error text in `TW0003` JSON diagnostics.
+- Restored full JSON result output for the Visual Studio persistent language-server generation path, so VS Output includes detailed diagnostics instead of only a diagnostic count.
+- Added regression coverage for Buildalyzer project-load diagnostics through the loader, CLI JSON output, and language-server generation service.
 
 ### 4.5.3
 

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.adaskothebeast.typewriter
 pluginName=Typewriter
-pluginVersion=4.5.3
+pluginVersion=4.5.4
 pluginSinceBuild=261
 platformVersion=2026.1.2
 

--- a/src/Typewriter.Buildalyzer/MsBuildProjectLoader.cs
+++ b/src/Typewriter.Buildalyzer/MsBuildProjectLoader.cs
@@ -1,3 +1,4 @@
+using Microsoft.Build.Framework;
 using Typewriter.Abstractions;
 
 namespace Typewriter.Buildalyzer;
@@ -101,27 +102,21 @@ public sealed class MsBuildProjectLoader : IProjectWorkspaceLoader
         var result = SelectResult(results: results, requestedTargetFramework: requestedTargetFramework);
         if (result is null)
         {
-            state.Diagnostics.Add(
-                item: new GenerationDiagnostic(
-                    File: projectPath,
-                    Line: null,
-                    Column: null,
-                    Severity: DiagnosticSeverity.Error,
-                    Message: $"Buildalyzer did not return metadata for project: {projectPath}.",
-                    Code: "TW0003"));
+            state.Diagnostics.AddRange(
+                collection: CreateBuildErrorDiagnostics(
+                    results: results,
+                    projectPath: projectPath,
+                    fallbackMessage: $"Buildalyzer did not return metadata for project: {projectPath}."));
             return;
         }
 
         if (!result.Succeeded && result.SourceFiles.Length == 0)
         {
-            state.Diagnostics.Add(
-                item: new GenerationDiagnostic(
-                    File: projectPath,
-                    Line: null,
-                    Column: null,
-                    Severity: DiagnosticSeverity.Error,
-                    Message: $"Buildalyzer could not evaluate project: {projectPath}.",
-                    Code: "TW0003"));
+            state.Diagnostics.AddRange(
+                collection: CreateBuildErrorDiagnostics(
+                    results: results,
+                    projectPath: projectPath,
+                    fallbackMessage: $"Buildalyzer could not evaluate project: {projectPath}."));
             return;
         }
 
@@ -193,6 +188,86 @@ public sealed class MsBuildProjectLoader : IProjectWorkspaceLoader
 
         return results.Results.FirstOrDefault(predicate: result => result.Succeeded && result.SourceFiles.Length > 0)
             ?? results.Results.FirstOrDefault();
+    }
+
+    private static IReadOnlyList<GenerationDiagnostic> CreateBuildErrorDiagnostics(
+        global::Buildalyzer.IAnalyzerResults results,
+        string projectPath,
+        string fallbackMessage)
+    {
+        var diagnostics = results.BuildEventArguments
+            .OfType<BuildErrorEventArgs>()
+            .Select(selector: error => CreateBuildErrorDiagnostic(error: error, projectPath: projectPath))
+            .DistinctBy(
+                keySelector: diagnostic => new
+                {
+                    File = diagnostic.File ?? string.Empty,
+                    diagnostic.Line,
+                    diagnostic.Column,
+                    diagnostic.Message,
+                    Code = diagnostic.Code ?? string.Empty,
+                })
+            .ToArray();
+        return diagnostics.Length > 0
+            ? diagnostics
+            : [
+                new GenerationDiagnostic(
+                    File: projectPath,
+                    Line: null,
+                    Column: null,
+                    Severity: DiagnosticSeverity.Error,
+                    Message: fallbackMessage,
+                    Code: "TW0003"),
+            ];
+    }
+
+    private static GenerationDiagnostic CreateBuildErrorDiagnostic(
+        BuildErrorEventArgs error,
+        string projectPath) =>
+        new(
+            File: ResolveBuildErrorFile(errorFile: error.File, projectPath: projectPath),
+            Line: error.LineNumber > 0 ? error.LineNumber : null,
+            Column: error.ColumnNumber > 0 ? error.ColumnNumber : null,
+            Severity: DiagnosticSeverity.Error,
+            Message: FormatBuildErrorMessage(error: error),
+            Code: "TW0003");
+
+    private static string FormatBuildErrorMessage(BuildErrorEventArgs error)
+    {
+        var message = string.IsNullOrWhiteSpace(value: error.Message)
+            ? "MSBuild reported an error while evaluating project."
+            : error.Message;
+        if (string.IsNullOrWhiteSpace(value: error.Code)
+            || message.Contains(value: error.Code, comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            return message;
+        }
+
+        return error.Code + ": " + message;
+    }
+
+    private static string ResolveBuildErrorFile(
+        string? errorFile,
+        string projectPath)
+    {
+        if (string.IsNullOrWhiteSpace(value: errorFile))
+        {
+            return projectPath;
+        }
+
+        try
+        {
+            return Path.IsPathRooted(path: errorFile)
+                ? Path.GetFullPath(path: errorFile)
+                : Path.GetFullPath(
+                    path: Path.Combine(
+                        path1: Path.GetDirectoryName(path: projectPath) ?? Environment.CurrentDirectory,
+                        path2: errorFile));
+        }
+        catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)
+        {
+            return errorFile;
+        }
     }
 
     private static global::Buildalyzer.AnalyzerManager CreateAnalyzerManager(string workspacePath)

--- a/src/Typewriter.LanguageServer/LanguageServerHost.cs
+++ b/src/Typewriter.LanguageServer/LanguageServerHost.cs
@@ -99,7 +99,7 @@ internal sealed class LanguageServerHost
             serverInfo = new
             {
                 name = "Typewriter Language Server",
-                version = "4.5.3",
+                version = "4.5.4",
             },
         };
 

--- a/src/Typewriter.VisualStudio/TypewriterCliModels.cs
+++ b/src/Typewriter.VisualStudio/TypewriterCliModels.cs
@@ -84,6 +84,8 @@ internal sealed class CliDiagnostic
     public string Message { get; set; } = string.Empty;
 
     public string? Code { get; set; }
+
+    public string? HelpLink { get; set; }
 }
 
 internal sealed class GenerationContext

--- a/src/Typewriter.VisualStudio/TypewriterCommandService.cs
+++ b/src/Typewriter.VisualStudio/TypewriterCommandService.cs
@@ -349,6 +349,7 @@ internal sealed class TypewriterCommandService
         {
             await _package.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken: CancellationToken.None);
             _outputPane.WriteLine(message: "> Typewriter language server: typewriter/generate");
+            WriteJsonResult(payload: persistentResult);
             _diagnosticReporter.Publish(diagnostics: persistentResult.Diagnostics, workingDirectory: context.WorkingDirectory);
             WriteResultSummary(payload: persistentResult);
             if (!persistentResult.Success)
@@ -488,6 +489,19 @@ internal sealed class TypewriterCommandService
             _outputPane.WriteLine(message: processResult.StandardError.TrimEnd());
         }
     }
+
+    private void WriteJsonResult(CliResult payload) =>
+        _outputPane.WriteLine(
+            message: JsonSerializer.Serialize(
+                value: payload,
+                options: CreateJsonOptions()));
+
+    private static JsonSerializerOptions CreateJsonOptions() =>
+        new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+        };
 
     private void WriteResultSummary(CliResult payload)
     {

--- a/src/Typewriter.VisualStudio/TypewriterPackage.cs
+++ b/src/Typewriter.VisualStudio/TypewriterPackage.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 namespace Typewriter.VisualStudio;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.5.3")]
+[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.5.4")]
 [ProvideMenuResource(resourceID: "Menus.ctmenu", version: 1)]
 [ProvideOptionPage(pageType: typeof(TypewriterOptions), categoryName: "Typewriter", pageName: "General", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true)]
 [ProvideAutoLoad(cmdUiContextGuid: VSConstants.UICONTEXT.SolutionExists_string, flags: PackageAutoLoadFlags.BackgroundLoad)]

--- a/src/Typewriter.VisualStudio/source.extension.vsixmanifest
+++ b/src/Typewriter.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.5.3" Language="en-US" Publisher="AdaskoTheBeAsT" />
+    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.5.4" Language="en-US" Publisher="AdaskoTheBeAsT" />
     <DisplayName>Typewriter</DisplayName>
     <Description xml:space="preserve">Generate TypeScript from C# Typewriter templates.</Description>
     <Tags>Typewriter;TypeScript;C#;Code Generation</Tags>

--- a/tests/unit/Typewriter.Buildalyzer.Tests/MsBuildProjectLoaderTests.cs
+++ b/tests/unit/Typewriter.Buildalyzer.Tests/MsBuildProjectLoaderTests.cs
@@ -246,6 +246,46 @@ public sealed class MsBuildProjectLoaderTests
     }
 
     [Fact]
+    public async Task LoadAsyncReportsBuildErrorDiagnosticsWhenCompilerInputsAreUnavailable()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var projectPath = Path.Combine(path1: directory, path2: "Sample.csproj");
+            await File.WriteAllTextAsync(
+                path: projectPath,
+                contents: """
+                          <Project Sdk="Microsoft.NET.Sdk">
+                            <PropertyGroup>
+                              <TargetFramework>net10.0</TargetFramework>
+                            </PropertyGroup>
+                            <Target Name="FailBeforeCompile" BeforeTargets="CoreCompile">
+                              <Error Text="Detailed project evaluation failure." />
+                            </Target>
+                          </Project>
+                          """);
+            await File.WriteAllTextAsync(path: Path.Combine(path1: directory, path2: "Model.cs"), contents: "namespace Sample; public sealed class Model { }");
+
+            var loader = new MsBuildProjectLoader();
+
+            var result = await loader.LoadAsync(
+                project: new ProjectContext(ProjectPath: projectPath, WorkspacePath: directory, TargetFramework: "net10.0"),
+                cancellationToken: CancellationToken.None);
+
+            var diagnostic = result.Diagnostics.Should().ContainSingle().Which;
+            diagnostic.Code.Should().Be("TW0003");
+            diagnostic.Severity.Should().Be(DiagnosticSeverity.Error);
+            diagnostic.File.Should().Be(projectPath);
+            diagnostic.Line.Should().BePositive();
+            diagnostic.Message.Should().Contain("Detailed project evaluation failure.");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
     public async Task LoadAsyncUsesSolutionPropertiesFromSlnxWorkspace()
     {
         var directory = CreateProjectDirectory();

--- a/tests/unit/Typewriter.Cli.Tests/CliIntegrationTests.cs
+++ b/tests/unit/Typewriter.Cli.Tests/CliIntegrationTests.cs
@@ -619,6 +619,63 @@ public sealed class CliIntegrationTests
     }
 
     [Fact]
+    public async Task RunAsyncProjectEvaluationFailureReturnsDetailedJsonDiagnostic()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var projectPath = Path.Combine(path1: directory, path2: "Sample.csproj");
+            await File.WriteAllTextAsync(
+                path: projectPath,
+                contents: """
+                          <Project Sdk="Microsoft.NET.Sdk">
+                            <PropertyGroup>
+                              <TargetFramework>net10.0</TargetFramework>
+                            </PropertyGroup>
+                            <Target Name="FailBeforeCompile" BeforeTargets="CoreCompile">
+                              <Error Text="Detailed project evaluation failure." />
+                            </Target>
+                          </Project>
+                          """);
+            await File.WriteAllTextAsync(path: Path.Combine(path1: directory, path2: "Model.cs"), contents: "namespace Sample; public sealed class Model { }");
+            var templatePath = Path.Combine(path1: directory, path2: "Models.tst");
+            await File.WriteAllTextAsync(
+                path: templatePath,
+                contents: """
+                          // output: generated/models.ts
+                          $Classes[]
+                          """);
+
+            var result = await RunCliAsync(
+                "generate",
+                "--workspace",
+                directory,
+                "--project",
+                projectPath,
+                "--template",
+                templatePath,
+                "--framework",
+                "net10.0",
+                "--output",
+                "json");
+
+            result.ExitCode.Should().Be(3);
+            result.Success.Should().BeFalse();
+
+            var diagnostic = result.Diagnostics.Should().ContainSingle().Which;
+            diagnostic.Code.Should().Be("TW0003");
+            diagnostic.Severity.Should().Be("error");
+            diagnostic.File.Should().Be(projectPath);
+            diagnostic.Line.Should().BePositive();
+            diagnostic.Message.Should().Contain("Detailed project evaluation failure.");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
     public async Task RunAsyncTemplateParseFailureReturnsTemplateExitCodeAndJsonDiagnostic()
     {
         var directory = CreateProjectDirectory();
@@ -840,12 +897,26 @@ public sealed class CliIntegrationTests
             var diagnostic = diagnosticEnumerator.Current;
             diagnostics.Add(
                 item: new CliDiagnostic(
+                    File: diagnostic.GetProperty(propertyName: "file").GetString(),
+                    Line: ReadNullableInt(element: diagnostic, propertyName: "line"),
+                    Column: ReadNullableInt(element: diagnostic, propertyName: "column"),
                     Severity: diagnostic.GetProperty(propertyName: "severity").GetString() ?? string.Empty,
                     Message: diagnostic.GetProperty(propertyName: "message").GetString() ?? string.Empty,
-                    Code: diagnostic.GetProperty(propertyName: "code").GetString()));
+                    Code: diagnostic.GetProperty(propertyName: "code").GetString(),
+                    HelpLink: diagnostic.GetProperty(propertyName: "helpLink").GetString()));
         }
 
         return diagnostics;
+    }
+
+    private static int? ReadNullableInt(
+        JsonElement element,
+        string propertyName)
+    {
+        var property = element.GetProperty(propertyName: propertyName);
+        return property.ValueKind == JsonValueKind.Null
+            ? null
+            : property.GetInt32();
     }
 
     private static IReadOnlyList<string?> ReadStringArray(JsonElement element)
@@ -1037,7 +1108,11 @@ public sealed class CliIntegrationTests
     private sealed record CliGeneratedFile(string Path, bool Changed);
 
     private sealed record CliDiagnostic(
+        string? File,
+        int? Line,
+        int? Column,
         string Severity,
         string Message,
-        string? Code);
+        string? Code,
+        string? HelpLink);
 }

--- a/tests/unit/Typewriter.LanguageServer.Tests/WorkspaceGenerationServiceTests.cs
+++ b/tests/unit/Typewriter.LanguageServer.Tests/WorkspaceGenerationServiceTests.cs
@@ -120,6 +120,59 @@ public sealed class WorkspaceGenerationServiceTests
         }
     }
 
+    [Fact]
+    public async Task GenerateAsyncPreservesDetailedProjectLoadDiagnostics()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var projectPath = Path.Combine(path1: directory, path2: "App.csproj");
+            var templatePath = Path.Combine(path1: directory, path2: "Models.tst");
+            await File.WriteAllTextAsync(
+                path: projectPath,
+                contents: """
+                    <Project Sdk="Microsoft.NET.Sdk">
+                      <PropertyGroup>
+                        <TargetFramework>net10.0</TargetFramework>
+                      </PropertyGroup>
+                      <Target Name="FailBeforeCompile" BeforeTargets="CoreCompile">
+                        <Error Text="Detailed project evaluation failure." />
+                      </Target>
+                    </Project>
+                    """);
+            await File.WriteAllTextAsync(path: Path.Combine(path1: directory, path2: "Model.cs"), contents: "namespace App; public sealed class Model { }");
+            await File.WriteAllTextAsync(
+                path: templatePath,
+                contents: """
+                    // output: generated/models.ts
+                    $Classes[]
+                    """);
+
+            using var service = new WorkspaceGenerationService();
+            var request = new WorkspaceGenerationRequest(
+                Command: "generate",
+                WorkspacePath: directory,
+                ProjectPath: projectPath,
+                TemplatePath: templatePath,
+                Framework: null,
+                AllProjects: false);
+
+            var result = await service.GenerateAsync(request: request, settings: LanguageServerSettings.Default, cancellationToken: CancellationToken.None);
+
+            result.Success.Should().BeFalse();
+            var diagnostic = result.Diagnostics.Should().ContainSingle().Which;
+            diagnostic.Code.Should().Be("TW0003");
+            diagnostic.Severity.Should().Be("error");
+            diagnostic.File.Should().Be(projectPath);
+            diagnostic.Line.Should().BePositive();
+            diagnostic.Message.Should().Contain("Detailed project evaluation failure.");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
     private static string CreateProjectDirectory()
     {
         var directory = Path.Combine(

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typewriter-vscode",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typewriter-vscode",
-      "version": "4.5.3",
+      "version": "4.5.4",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^10.0.1"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typewriter-vscode",
   "displayName": "Typewriter",
   "description": "VS Code adapter for Typewriter .tst templates.",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "publisher": "adaskothebeast",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
This pull request introduces Typewriter version 4.5.4, focusing on restoring detailed project-load diagnostics for Buildalyzer/MSBuild failures and ensuring full diagnostic output in Visual Studio's persistent language-server generation path. It also adds regression test coverage for these areas and updates version numbers and dependencies across the project.

**Enhanced diagnostics and error reporting:**

* Restored detailed project-load diagnostics for Buildalyzer/MSBuild failures. Diagnostics now include file, line, column, and MSBuild error text in `TW0003` JSON diagnostics, improving troubleshooting for project evaluation failures (`src/Typewriter.Buildalyzer/MsBuildProjectLoader.cs`, `src/Typewriter.VisualStudio/TypewriterCommandService.cs`). [[1]](diffhunk://#diff-1df0157873ab4026793a61be4dba2be8ec66fa9957f60b1c24babab460112692L104-R119) [[2]](diffhunk://#diff-1df0157873ab4026793a61be4dba2be8ec66fa9957f60b1c24babab460112692R193-R272) [[3]](diffhunk://#diff-e81f26f8841db4b82f45969e56ff7fd2cfc20ff3d31e60224f447b5019266a08R352)
* Restored full JSON result output for Visual Studio's persistent language-server generation path, so the VS Output pane includes detailed diagnostics instead of only a diagnostic count (`src/Typewriter.VisualStudio/TypewriterCommandService.cs`). [[1]](diffhunk://#diff-e81f26f8841db4b82f45969e56ff7fd2cfc20ff3d31e60224f447b5019266a08R352) [[2]](diffhunk://#diff-e81f26f8841db4b82f45969e56ff7fd2cfc20ff3d31e60224f447b5019266a08R493-R505)

**Testing and regression coverage:**

* Added regression coverage for Buildalyzer project-load diagnostics through the loader, CLI JSON output, and language-server generation service (`tests/unit/Typewriter.Buildalyzer.Tests/MsBuildProjectLoaderTests.cs`, `tests/unit/Typewriter.Cli.Tests/CliIntegrationTests.cs`). [[1]](diffhunk://#diff-b1c449f43edaf47e8ac006e151656de1c7e29a73706c289520d3c35631250b76R248-R287) [[2]](diffhunk://#diff-141b1e0b6d72adf92848976a521f4f71fb60fc8953f6bd657861ca79ec5042f7R621-R677) [[3]](diffhunk://#diff-141b1e0b6d72adf92848976a521f4f71fb60fc8953f6bd657861ca79ec5042f7R900-R921) [[4]](diffhunk://#diff-141b1e0b6d72adf92848976a521f4f71fb60fc8953f6bd657861ca79ec5042f7R1111-R1117)

**Version and dependency updates:**

* Bumped version numbers from 4.5.3 to 4.5.4 across all relevant files and build artifacts, including VSIX, Rider, and CLI (`Directory.Build.props`, `src/Typewriter.VisualStudio/source.extension.vsixmanifest`, `src/Typewriter.VisualStudio/TypewriterPackage.cs`, `README.md`, `.github/workflows/ci.yml`, `rider/gradle.properties`, `src/Typewriter.LanguageServer/LanguageServerHost.cs`). [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL14-R14) [[2]](diffhunk://#diff-e51f2f3de5be31955cb798c4ba2db57f3de15f96ce94f80efb7c5747ef3974dfL4-R4) [[3]](diffhunk://#diff-0fe60420e46f2d750c12fb98ec460ddaa6982b52270f65451e0e4943223ebc4aL13-R13) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1091-R1092) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1134-R1139) [[6]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL94-R95) [[7]](diffhunk://#diff-9a9ceaffbadf59cdb679b33f9b046dc11f5547bdd75a197dad5b74030dc25966L3-R3) [[8]](diffhunk://#diff-35017bf2deb6f8fcfcad9110fc8c9a9402caddc668c2d3e352290ab57cb65521L102-R102)
* Updated the `Meziantou.Analyzer` package dependency from version 3.0.110 to 3.0.117 (`Directory.Build.props`).

**Minor improvements:**

* Extended the `CliDiagnostic` model to include an optional `HelpLink` property for future extensibility (`src/Typewriter.VisualStudio/TypewriterCliModels.cs`, `tests/unit/Typewriter.Cli.Tests/CliIntegrationTests.cs`). [[1]](diffhunk://#diff-a34ac5e25dfec07410bbe0718e0624d609b6fbda0ac7b2d3fe7764aed87537e3R87-R88) [[2]](diffhunk://#diff-141b1e0b6d72adf92848976a521f4f71fb60fc8953f6bd657861ca79ec5042f7R900-R921) [[3]](diffhunk://#diff-141b1e0b6d72adf92848976a521f4f71fb60fc8953f6bd657861ca79ec5042f7R1111-R1117)
* Added a missing `using Microsoft.Build.Framework;` directive in `MsBuildProjectLoader.cs` to support enhanced diagnostics.