### PR TITLE
new configuration possibilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Collect editor packages
         shell: pwsh
         run: |
-          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.5.4.vsix
-          Copy-Item rider/build/distributions/typewriter-rider-4.5.4.zip artifacts/packages/Typewriter-Rider-4.5.4.zip
+          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.6.0.vsix
+          Copy-Item rider/build/distributions/typewriter-rider-4.6.0.zip artifacts/packages/Typewriter-Rider-4.6.0.zip
 
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ErrorLog>$(MSBuildThisFileDirectory).sarif\$(MSBuildProjectName).json</ErrorLog>
-    <Version>4.5.4</Version>
+    <Version>4.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
   - [🔨 Building from Source](#-building-from-source)
   - [🗺 Project Status and Roadmap](#-project-status-and-roadmap)
   - [Changelog](#changelog)
+    - [4.6.0](#460)
     - [4.5.4](#454)
     - [4.5.3](#453)
     - [4.5.2](#452)
@@ -91,6 +92,7 @@
 - 🎯 **Type safety end to end** — eliminate hand-written DTO drift between backend and frontend
 - 🔌 **Powerful `.tst` templates** — filters, lambdas, shared local/remote helpers, and compiled C# helper methods with `#r` NuGet references
 - 🧩 **Legacy compatible** — runs the original Typewriter template dialect, validated against real-world recipes
+- 📅 **Configurable temporal types** — map `DateTime`, `DateOnly`, `TimeOnly`, NodaTime types, `Guid`, and `decimal` to the TypeScript/runtime types your frontend actually uses
 - 🚦 **CI-friendly** — JSON output, dry-run, deterministic exit codes, `--fail-on-warning`
 - ⚡ **Fast feedback** — live diagnostics, completion, hover, and semantic highlighting for `.tst` files
 
@@ -111,6 +113,9 @@ The previous [`AdaskoTheBeAsT/Typewriter`](https://github.com/AdaskoTheBeAsT/Typ
 | Project loading   | Visual Studio-oriented solution/project context                                        | Buildalyzer and Roslyn loading for solutions, projects, folders, target frameworks, references, and multi-project workspaces                                                    |
 | File safety       | Generated file behavior depends on the VS extension workflow                           | Planned writes block paths outside the workspace, refuse non-Typewriter overwrites, skip unchanged files, and warn on duplicate outputs                                         |
 | Template runtime  | Classic helpers and settings                                                           | Classic helpers plus `#load`, NuGet `#r`, `settings.Log` diagnostics, `Template(Settings, File)`, `OnRenderComplete`, parent/current helper parameters, and richer stack traces |
+| Type mapping      | Mostly template-authored conventions                                                   | Configurable date-time, date-only, time-only, NodaTime, `Guid`, and `decimal` mappings with matching default initializers                                                       |
+| Metadata depth    | Classic type/member surface                                                            | Structs, indexers, member initializer `$Value`, preserved XML doc inline elements, and JSDoc formatting helpers                                                                 |
+| Performance       | Event-driven generation per IDE workflow                                               | Persistent generation, scoped discovery, metadata indexes, cached templates, glob matchers, type mappings, and loaded dependencies                                             |
 | Packaging         | VSIX releases                                                                          | NuGet tool packages, language-server package, VSIX, VS Code VSIX, and Rider plugin artifacts from CI                                                                            |
 
 ### New goodies at a glance
@@ -122,6 +127,11 @@ The previous [`AdaskoTheBeAsT/Typewriter`](https://github.com/AdaskoTheBeAsT/Typ
 - **Shared helper files**: `#load "shared-helpers.cs"` or `#load "https://raw.githubusercontent.com/..."` keeps large templates maintainable and reusable.
 - **Configurable output style**: line endings, UTF-8 BOM, indentation, trailing whitespace, final newline, quote style, strict null generation, and file naming are all configuration-driven.
 - **Better diagnostics**: template logs surface as `TW0007`, helper failures include template method/line details, and editors show diagnostics live.
+- **Post-4.0 metadata upgrades**: structs, indexers, property/field initializer `$Value`, cyclic-reference handling, transitive project references, source generators, and full .NET Framework projects are covered.
+- **Post-4.0 documentation upgrades**: XML doc-comment inline tags are preserved, and `Typewriter.Extensions.Documentation` can convert raw XML docs to TypeScript JSDoc.
+- **Post-4.0 performance upgrades**: generation reuses persistent processes and caches parsed templates, metadata indexes, glob matchers, file contents, type mappings, and loaded dependencies.
+- **Post-4.0 type mapping upgrades**: configurable `DateTime`/`DateOnly`/`TimeOnly`, NodaTime, `Guid`, and `decimal` mappings, with default initializers and date-interceptor guidance for runtime string conversion.
+- **Post-4.0 reliability fixes**: primitive collection imports, closed generic arguments, dictionary key types, duplicate assembly identities, Buildalyzer diagnostics, and editor generate-on-save edge cases have regression coverage.
 - **Modern C# metadata**: Roslyn metadata covers records, nullable reference types, generics, tuples, doc comments, attributes, static constants, static readonly fields, events, delegates, nested types, and Web API helpers.
 - **Web API hardening**: route helpers ignore named-only HTTP attribute arguments, honor `Template = "..."`, and safely encode nullable string/date query values.
 - **Recipe-backed compatibility**: real Angular/React recipes from `NetCoreTypewriterRecipes` are snapshot-tested so old-template support improves against production templates, not toy examples.
@@ -157,6 +167,8 @@ choose a tag, expand **Assets**, then install the matching package.
 | VS Code            | `typewriter-vscode-<version>.vsix`       | Run `code --install-extension typewriter-vscode-<version>.vsix`, or use **Extensions → ... → Install from VSIX...**  |
 | Visual Studio 2026 | `Typewriter.VisualStudio-<version>.vsix` | Double-click the VSIX, or open it with the Visual Studio VSIX installer, then restart Visual Studio                  |
 | JetBrains Rider    | `Typewriter-Rider-<version>.zip`         | Use **Settings/Preferences → Plugins → gear menu → Install Plugin from Disk...**, select the ZIP, then restart Rider |
+
+For Visual Studio, uninstall the old `Typewriter64` extension before installing this VSIX. Only one Typewriter add-in should be installed at a time.
 
 The CLI and language server are also published to NuGet as dotnet tools:
 
@@ -302,6 +314,12 @@ Generated by `typewriter init`. All values below are the defaults:
     "trimTrailingWhitespace": false,
     "quoteStyle": "double",
     "dateType": "Date",
+    "dateInitializer": "new Date()",
+    "dateOnlyType": "Date",
+    "dateOnlyInitializer": "new Date()",
+    "timeOnlyType": "string",
+    "timeOnlyInitializer": "\"00:00:00\"",
+    "guidType": "string",
     "decimalType": "number"
   },
   "diagnostics": {
@@ -334,12 +352,18 @@ Generated by `typewriter init`. All values below are the defaults:
 | `insertFinalNewline`     | `false`      | Ensure generated files end with a single trailing newline                                                                                                |
 | `trimTrailingWhitespace` | `false`      | Strip trailing spaces and tabs from every generated line                                                                                                 |
 | `quoteStyle`             | `"double"`   | Default string literal character for generated defaults: `double`, `single`, or `backtick`; `settings.UseStringLiteralCharacter(...)` in a template wins |
-| `dateType`               | `"Date"`     | TypeScript type used for `DateTime`, `DateTimeOffset`, and `DateOnly`; `settings.UseDateType(...)` in a template wins                                   |
+| `dateType`               | `"Date"`     | TypeScript type used for `DateTime`, `DateTimeOffset`, and date-time-like NodaTime values; `settings.UseDateType(...)` wins                             |
+| `dateInitializer`        | `"new Date()"` | TypeScript initializer used for non-null date-time defaults; `settings.UseDateInitializer(...)` wins                                                    |
+| `dateOnlyType`           | `"Date"`     | TypeScript type used for `DateOnly`, `NodaTime.LocalDate`, and `NodaTime.OffsetDate`; `settings.UseDateOnlyType(...)` wins                              |
+| `dateOnlyInitializer`    | `"new Date()"` | TypeScript initializer used for non-null date-only defaults; `settings.UseDateOnlyInitializer(...)` wins                                                |
+| `timeOnlyType`           | `"string"`   | TypeScript type used for `TimeOnly`, `NodaTime.LocalTime`, and `NodaTime.OffsetTime`; `settings.UseTimeOnlyType(...)` wins                              |
+| `timeOnlyInitializer`    | `"\"00:00:00\""` | TypeScript initializer used for non-null time-only defaults; default literal follows `quoteStyle`, and `settings.UseTimeOnlyInitializer(...)` wins   |
+| `guidType`               | `"string"`   | TypeScript type used for C# `Guid`; set to `uuid`, `UUID`, or a branded alias with `settings.UseGuidType(...)` or config                                |
 | `decimalType`            | `"number"`   | TypeScript type used for C# `decimal`; `settings.UseDecimalType(...)` in a template wins                                                                 |
 
 ### Date and time mapping
 
-`DateTime`, `DateTimeOffset`, and `DateOnly` generate `Date` by default. Nullable value types keep the normal strict-null behavior, so `DateTime?` and `Nullable<DateTime>` generate `Date | null` when `output.strictNull` is `true`.
+`DateTime`, `DateTimeOffset`, and date-time-like NodaTime values generate `Date` by default, and non-null defaults generate `new Date()`. `DateOnly`, `NodaTime.LocalDate`, and `NodaTime.OffsetDate` also default to `Date`/`new Date()`. `TimeOnly`, `NodaTime.LocalTime`, and `NodaTime.OffsetTime` default to `string`/`"00:00:00"`. Nullable value types keep the normal strict-null behavior, so `DateTime?` and `Nullable<DateTime>` generate `Date | null` when `output.strictNull` is `true`.
 
 ```csharp
 public sealed record AuditDto(
@@ -356,12 +380,17 @@ export interface AuditDto {
 }
 ```
 
-To use another date library in generated types, configure `output.dateType` or call `settings.UseDateType(...)` from a template:
+To use another date library in generated types, configure the date-time, date-only, and time-only type/initializer pairs, or call the matching `Settings` methods from a template:
 
 ```json
 {
   "output": {
-    "dateType": "Dayjs"
+    "dateType": "Dayjs",
+    "dateInitializer": "dayjs()",
+    "dateOnlyType": "Dayjs",
+    "dateOnlyInitializer": "dayjs()",
+    "timeOnlyType": "string",
+    "timeOnlyInitializer": "\"00:00:00\""
   }
 }
 ```
@@ -371,22 +400,28 @@ ${
     Template(Settings settings)
     {
         settings.UseDateType("DateTime"); // for Luxon
+        settings.UseDateInitializer("DateTime.now()");
+        settings.UseDateOnlyType("DateTime");
+        settings.UseDateOnlyInitializer("DateTime.now().startOf('day')");
+        settings.UseTimeOnlyType("string");
+        settings.UseTimeOnlyInitializer("\"00:00:00\"");
     }
 }
 ```
 
 If the selected date type is not global, update your template to emit the required TypeScript import, for example `import type { Dayjs } from 'dayjs';`.
 
-If your API returns ISO strings for `DateTime`, `DateTimeOffset`, or NodaTime values, pair generated models with [date-interceptors](https://github.com/adaskothebeast/date-interceptors) for runtime conversion. It provides converters for native `Date`, date-fns, Day.js, Moment.js, Luxon, js-joda, plus Angular, React, and Axios integrations.
+If your API returns ISO strings for `DateTime`, `DateTimeOffset`, `DateOnly`, or NodaTime values, pair generated models with [date-interceptors](https://github.com/adaskothebeast/date-interceptors) for runtime conversion. This is required when generated TypeScript uses `Date`, Day.js, Moment.js, Luxon, js-joda, Temporal, or another runtime date type, because JSON still arrives as strings and must be translated to the corresponding object type.
 
-| Target runtime | `output.dateType` | Type import for generated models | Converter package | Converter function |
-| -------------- | ----------------- | -------------------------------- | ----------------- | ------------------ |
-| Native `Date` | `"Date"` | none | `@adaskothebeast/hierarchical-convert-to-date` | `hierarchicalConvertToDate` |
-| date-fns | `"Date"` | none | `@adaskothebeast/hierarchical-convert-to-date-fns` | `hierarchicalConvertToDateFns` |
-| Day.js | `"Dayjs"` | `import type { Dayjs } from 'dayjs';` | `@adaskothebeast/hierarchical-convert-to-dayjs` | `hierarchicalConvertToDayjs` |
-| Moment.js | `"Moment"` | `import type { Moment } from 'moment';` | `@adaskothebeast/hierarchical-convert-to-moment` | `hierarchicalConvertToMoment` |
-| Luxon | `"DateTime"` | `import type { DateTime } from 'luxon';` | `@adaskothebeast/hierarchical-convert-to-luxon` | `hierarchicalConvertToLuxon` |
-| js-joda | `"ZonedDateTime"` | `import type { ZonedDateTime } from '@js-joda/core';` | `@adaskothebeast/hierarchical-convert-to-js-joda` | `hierarchicalConvertToJsJoda` |
+| Target runtime | Date-time config | Date-only config | Time-only config | Type imports | Converter |
+| -------------- | ---------------- | ---------------- | ---------------- | ------------ | --------- |
+| Native `Date` | `dateType: "Date"`, `dateInitializer: "new Date()"` | `dateOnlyType: "Date"`, `dateOnlyInitializer: "new Date()"` | `timeOnlyType: "string"`, `timeOnlyInitializer: "\"00:00:00\""` | none | `@adaskothebeast/hierarchical-convert-to-date` |
+| date-fns | same as native `Date` | same as native `Date` | ISO `string` | none | `@adaskothebeast/hierarchical-convert-to-date-fns` |
+| Day.js | `Dayjs`, `dayjs()` | `Dayjs`, `dayjs()` | ISO `string` | `import type { Dayjs } from 'dayjs';` | `@adaskothebeast/hierarchical-convert-to-dayjs` |
+| Moment.js | `Moment`, `moment()` | `Moment`, `moment()` | ISO `string` | `import type { Moment } from 'moment';` | `@adaskothebeast/hierarchical-convert-to-moment` |
+| Luxon | `DateTime`, `DateTime.now()` | `DateTime`, `DateTime.now().startOf('day')` | ISO `string` | `import type { DateTime } from 'luxon';` | `@adaskothebeast/hierarchical-convert-to-luxon` |
+| js-joda | `ZonedDateTime`, `ZonedDateTime.now()` or `LocalDateTime`, `LocalDateTime.now()` | `LocalDate`, `LocalDate.now()` | `LocalTime`, `LocalTime.now()` | `import type { LocalDate, LocalTime, ZonedDateTime } from '@js-joda/core';` | `@adaskothebeast/hierarchical-convert-to-js-joda` |
+| Temporal | `Temporal.Instant`, `Temporal.Now.instant()` or `Temporal.PlainDateTime`, `Temporal.Now.plainDateTimeISO()` | `Temporal.PlainDate`, `Temporal.Now.plainDateISO()` | `Temporal.PlainTime`, `Temporal.Now.plainTimeISO()` | none when Temporal is global | custom adapter |
 
 ```bash
 # Native Date
@@ -460,6 +495,17 @@ createdAt: ZonedDateTime;
 approvedAt: ZonedDateTime | null;
 ```
 
+Recommended semantic mappings:
+
+| C# or NodaTime type | Recommended TypeScript shape | Notes |
+| ------------------- | ---------------------------- | ----- |
+| `DateTime`, `DateTimeOffset`, `NodaTime.Instant`, `NodaTime.OffsetDateTime`, `NodaTime.ZonedDateTime` | `Date`, `Temporal.Instant`, Luxon `DateTime`, Day.js `Dayjs`, or js-joda `Instant`/`ZonedDateTime` | Use a real date-time object when clients compare, format, or calculate with the value. Use [date-interceptors](https://github.com/adaskothebeast/date-interceptors) to convert JSON strings at runtime. |
+| `DateOnly`, `NodaTime.LocalDate`, `NodaTime.OffsetDate` | ISO `string`, `Temporal.PlainDate`, or js-joda `LocalDate` | Avoid native `Date` for pure dates if timezone shifts matter. |
+| `TimeOnly`, `NodaTime.LocalTime`, `NodaTime.OffsetTime` | ISO `string`, `Temporal.PlainTime`, or js-joda `LocalTime` | JavaScript has no native time-only type. |
+| `NodaTime.LocalDateTime` | `Temporal.PlainDateTime`, Luxon `DateTime`, js-joda `LocalDateTime`, or ISO `string` | Use `output.dateType` for this local date-time type. |
+| `TimeSpan`, `NodaTime.Duration` | ISO duration `string`, `Temporal.Duration`, js-joda `Duration`, or a numeric convention such as milliseconds | Pick one wire format and document it. `Duration` means elapsed time. |
+| `NodaTime.Period` | ISO period `string`, `Temporal.Duration`, js-joda `Period`, or date-fns `Duration` | `Period` is calendar-based, such as 1 month and 3 days, so keep it distinct from elapsed `Duration`. |
+
 For date types that need an import, emit the import only when the current class actually has date fields or properties:
 
 ```csharp
@@ -469,6 +515,7 @@ ${
     Template(Settings settings)
     {
         settings.UseDateType("Dayjs");
+        settings.UseDateInitializer("dayjs()");
         dateTypeImport = settings.DateTypeGeneration switch
         {
             "Dayjs" => "import type { Dayjs } from 'dayjs';",
@@ -527,7 +574,14 @@ ${
     {
         return property.Type.FullName switch
         {
-            "NodaTime.Instant" or "NodaTime.OffsetDateTime" => "ZonedDateTime",
+            "NodaTime.Instant" => "Instant",
+            "NodaTime.ZonedDateTime" => "ZonedDateTime",
+            "NodaTime.OffsetDateTime" => "OffsetDateTime",
+            "NodaTime.LocalDateTime" => "LocalDateTime",
+            "NodaTime.LocalDate" => "LocalDate",
+            "NodaTime.LocalTime" => "LocalTime",
+            "NodaTime.Duration" => "Duration",
+            "NodaTime.Period" => "Period",
             _ => property.Type.Name,
         };
     }
@@ -538,6 +592,29 @@ $Properties[
   $name: $TypeName;]
 }
 ```
+
+### Guid mapping
+
+C# `Guid` maps to TypeScript `string` by default. If your frontend uses a stronger UUID alias, configure `output.guidType` or call `settings.UseGuidType(...)` from a template:
+
+```json
+{
+  "output": {
+    "guidType": "uuid"
+  }
+}
+```
+
+```csharp
+${
+    Template(Settings settings)
+    {
+        settings.UseGuidType("uuid");
+    }
+}
+```
+
+TypeScript does not have a built-in `uuid` type, so emit or import one in your template, for example `type uuid = string;` or a project-specific branded type. `$Type[$Default]` for `Guid` continues to generate the empty GUID string.
 
 ### Numeric and decimal mapping
 
@@ -640,6 +717,12 @@ With `settings.UseDecimalType("Decimal")`, `decimal Amount` generates `amount: D
 | `TYPEWRITER_DEFAULT_TARGET_FRAMEWORK` | `defaultTargetFramework`                       |
 | `TYPEWRITER_OUTPUT_NEWLINE`           | `output.newline`                               |
 | `TYPEWRITER_OUTPUT_DATE_TYPE`         | `output.dateType`                              |
+| `TYPEWRITER_OUTPUT_DATE_INITIALIZER`  | `output.dateInitializer`                       |
+| `TYPEWRITER_OUTPUT_DATE_ONLY_TYPE`    | `output.dateOnlyType`                          |
+| `TYPEWRITER_OUTPUT_DATE_ONLY_INITIALIZER` | `output.dateOnlyInitializer`               |
+| `TYPEWRITER_OUTPUT_TIME_ONLY_TYPE`    | `output.timeOnlyType`                          |
+| `TYPEWRITER_OUTPUT_TIME_ONLY_INITIALIZER` | `output.timeOnlyInitializer`               |
+| `TYPEWRITER_OUTPUT_GUID_TYPE`         | `output.guidType`                              |
 | `TYPEWRITER_OUTPUT_DECIMAL_TYPE`      | `output.decimalType`                           |
 | `TYPEWRITER_FAIL_ON_WARNING`          | `diagnostics.failOnWarning` (`true`/`1`/`yes`) |
 
@@ -919,7 +1002,13 @@ The `Settings` object passed to the template constructor keeps the original API 
 | `OutputDirectory`                                                                                           |   ✅    | Relative paths resolve against the template location                                                            |
 | `SingleFileMode("name.ts")`                                                                                 |   ✅    | Renders the whole template into one file                                                                        |
 | `UseStringLiteralCharacter('\'')`                                                                           |   ✅    | Affects generated string literals and defaults; defaults from `output.quoteStyle` in `typewriter.json`          |
-| `UseDateType("Date")`                                                                                       |   ✅    | Overrides the generated TypeScript type for `DateTime`, `DateTimeOffset`, and `DateOnly`                        |
+| `UseDateType("Date")`                                                                                       |   ✅    | Overrides date-time types such as `DateTime`, `DateTimeOffset`, and NodaTime `Instant`                          |
+| `UseDateInitializer("new Date()")`                                                                          |   ✅    | Overrides the generated TypeScript initializer for non-null date-time defaults                                   |
+| `UseDateOnlyType("Date")`                                                                                   |   ✅    | Overrides date-only types such as `DateOnly` and NodaTime `LocalDate`                                           |
+| `UseDateOnlyInitializer("new Date()")`                                                                      |   ✅    | Overrides the generated TypeScript initializer for non-null date-only defaults                                   |
+| `UseTimeOnlyType("string")`                                                                                 |   ✅    | Overrides time-only types such as `TimeOnly` and NodaTime `LocalTime`                                           |
+| `UseTimeOnlyInitializer("\"00:00:00\"")`                                                                    |   ✅    | Overrides the generated TypeScript initializer for non-null time-only defaults                                   |
+| `UseGuidType("string")`                                                                                     |   ✅    | Overrides the generated TypeScript type for C# `Guid`, for example `uuid` or `UUID`                             |
 | `UseDecimalType("number")`                                                                                  |   ✅    | Overrides the generated TypeScript type for C# `decimal`, for example `Decimal` from `decimal.js`               |
 | `TemplatePath`                                                                                              |   ✅    | Full path of the executing template                                                                             |
 | `Log` (`ILog`)                                                                                              |   ✅    | Messages surface as `TW0007` diagnostics in CLI output and editors                                              |
@@ -1089,7 +1178,7 @@ dotnet test AdaskoTheBeAsT.Typewriter.slnx --configuration Release --no-build -m
 npm ci --prefix vscode
 npm --prefix vscode run lint
 npm --prefix vscode run bundle
-npm --prefix vscode run package -- --out ../artifacts/packages/typewriter-vscode-4.5.4.vsix
+npm --prefix vscode run package -- --out ../artifacts/packages/typewriter-vscode-4.6.0.vsix
 
 # JetBrains Rider plugin
 ./rider/gradlew -p rider verifyPluginProjectConfiguration
@@ -1130,6 +1219,13 @@ dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj --config
 ---
 
 ## Changelog
+
+### 4.6.0
+
+- Added configurable date-time, date-only, and time-only TypeScript mappings and default initializers with `output.dateType`, `output.dateOnlyType`, `output.timeOnlyType`, their initializer settings, and matching template `Settings` methods.
+- Added NodaTime date/time mapping support for `Instant`, `LocalDate`, `LocalTime`, `LocalDateTime`, `OffsetDate`, `OffsetTime`, `OffsetDateTime`, and `ZonedDateTime`.
+- Added configurable C# `Guid` TypeScript mapping with `output.guidType` and `settings.UseGuidType(...)`, defaulting to `string` and allowing aliases such as `uuid` or `UUID`.
+- Documented DateOnly, TimeOnly, TimeSpan, NodaTime, Duration, Period, and runtime conversion guidance, including the need for [date-interceptors](https://github.com/adaskothebeast/date-interceptors) when JSON strings should become date library objects.
 
 ### 4.5.4
 

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.adaskothebeast.typewriter
 pluginName=Typewriter
-pluginVersion=4.5.4
+pluginVersion=4.6.0
 pluginSinceBuild=261
 platformVersion=2026.1.2
 

--- a/src/Typewriter.Abstractions/OutputConfiguration.cs
+++ b/src/Typewriter.Abstractions/OutputConfiguration.cs
@@ -13,8 +13,62 @@ public sealed record OutputConfiguration(
     bool TrimTrailingWhitespace,
     QuoteStyle QuoteStyle,
     string DateType,
+    string DateInitializer,
+    string DateOnlyType,
+    string DateOnlyInitializer,
+    string TimeOnlyType,
+    string TimeOnlyInitializer,
+    string GuidType,
     string DecimalType)
 {
+    public const string DefaultDateType = "Date";
+    public const string DefaultDateInitializer = "new Date()";
+    public const string DefaultDateOnlyType = DefaultDateType;
+    public const string DefaultDateOnlyInitializer = DefaultDateInitializer;
+    public const string DefaultTimeOnlyType = "string";
+    public const string DefaultTimeOnlyInitializer = "\"00:00:00\"";
+    public const string DefaultGuidType = "string";
+    public const string DefaultDecimalType = "number";
+
+#pragma warning disable SA1313
+    public OutputConfiguration(
+        string Newline,
+        string Encoding,
+        bool WriteOnlyWhenChanged,
+        bool DryRun,
+        FileNameConvention FileNameConvention,
+        bool StrictNull,
+        IndentStyle IndentStyle,
+        int IndentSize,
+        bool InsertFinalNewline,
+        bool TrimTrailingWhitespace,
+        QuoteStyle QuoteStyle,
+        string DateType,
+        string DecimalType)
+        : this(
+            Newline: Newline,
+            Encoding: Encoding,
+            WriteOnlyWhenChanged: WriteOnlyWhenChanged,
+            DryRun: DryRun,
+            FileNameConvention: FileNameConvention,
+            StrictNull: StrictNull,
+            IndentStyle: IndentStyle,
+            IndentSize: IndentSize,
+            InsertFinalNewline: InsertFinalNewline,
+            TrimTrailingWhitespace: TrimTrailingWhitespace,
+            QuoteStyle: QuoteStyle,
+            DateType: DateType,
+            DateInitializer: DefaultDateInitializer,
+            DateOnlyType: DateType,
+            DateOnlyInitializer: DefaultDateOnlyInitializer,
+            TimeOnlyType: DefaultTimeOnlyType,
+            TimeOnlyInitializer: DefaultTimeOnlyInitializer,
+            GuidType: DefaultGuidType,
+            DecimalType: DecimalType)
+    {
+    }
+#pragma warning restore SA1313
+
     public static OutputConfiguration Default { get; } = new(
         Newline: "lf",
         Encoding: "utf-8",
@@ -27,6 +81,42 @@ public sealed record OutputConfiguration(
         InsertFinalNewline: false,
         TrimTrailingWhitespace: false,
         QuoteStyle: QuoteStyle.Double,
-        DateType: "Date",
-        DecimalType: "number");
+        DateType: DefaultDateType,
+        DateInitializer: DefaultDateInitializer,
+        DateOnlyType: DefaultDateOnlyType,
+        DateOnlyInitializer: DefaultDateOnlyInitializer,
+        TimeOnlyType: DefaultTimeOnlyType,
+        TimeOnlyInitializer: DefaultTimeOnlyInitializer,
+        GuidType: DefaultGuidType,
+        DecimalType: DefaultDecimalType);
+
+    public void Deconstruct(
+        out string newline,
+        out string encoding,
+        out bool writeOnlyWhenChanged,
+        out bool dryRun,
+        out FileNameConvention fileNameConvention,
+        out bool strictNull,
+        out IndentStyle indentStyle,
+        out int indentSize,
+        out bool insertFinalNewline,
+        out bool trimTrailingWhitespace,
+        out QuoteStyle quoteStyle,
+        out string dateType,
+        out string decimalType)
+    {
+        newline = Newline;
+        encoding = Encoding;
+        writeOnlyWhenChanged = WriteOnlyWhenChanged;
+        dryRun = DryRun;
+        fileNameConvention = FileNameConvention;
+        strictNull = StrictNull;
+        indentStyle = IndentStyle;
+        indentSize = IndentSize;
+        insertFinalNewline = InsertFinalNewline;
+        trimTrailingWhitespace = TrimTrailingWhitespace;
+        quoteStyle = QuoteStyle;
+        dateType = DateType;
+        decimalType = DecimalType;
+    }
 }

--- a/src/Typewriter.Engine/Configuration/Settings.cs
+++ b/src/Typewriter.Engine/Configuration/Settings.cs
@@ -1,3 +1,4 @@
+using Typewriter.Engine;
 using Typewriter.VisualStudio;
 using CodeFile = Typewriter.CodeModel.File;
 
@@ -25,9 +26,21 @@ public class Settings
 
     public virtual char StringLiteralCharacter => _stringLiteralCharacter;
 
-    public virtual string DateTypeGeneration { get; private set; } = "Date";
+    public virtual string DateTypeGeneration { get; private set; } = TypeScriptTypeMapper.DefaultDateType;
 
-    public virtual string DecimalTypeGeneration { get; private set; } = "number";
+    public virtual string DateInitializerGeneration { get; private set; } = TypeScriptTypeMapper.DefaultDateInitializer;
+
+    public virtual string DateOnlyTypeGeneration { get; private set; } = TypeScriptTypeMapper.DefaultDateOnlyType;
+
+    public virtual string DateOnlyInitializerGeneration { get; private set; } = TypeScriptTypeMapper.DefaultDateOnlyInitializer;
+
+    public virtual string TimeOnlyTypeGeneration { get; private set; } = TypeScriptTypeMapper.DefaultTimeOnlyType;
+
+    public virtual string TimeOnlyInitializerGeneration { get; private set; } = TypeScriptTypeMapper.DefaultTimeOnlyInitializer;
+
+    public virtual string GuidTypeGeneration { get; private set; } = TypeScriptTypeMapper.DefaultGuidType;
+
+    public virtual string DecimalTypeGeneration { get; private set; } = TypeScriptTypeMapper.DefaultDecimalType;
 
     public virtual bool StrictNullGeneration { get; private set; } = true;
 
@@ -73,15 +86,63 @@ public class Settings
     public virtual Settings UseDateType(string dateType)
     {
         DateTypeGeneration = string.IsNullOrWhiteSpace(value: dateType)
-            ? "Date"
+            ? TypeScriptTypeMapper.DefaultDateType
             : dateType.Trim();
+        return this;
+    }
+
+    public virtual Settings UseDateInitializer(string dateInitializer)
+    {
+        DateInitializerGeneration = string.IsNullOrWhiteSpace(value: dateInitializer)
+            ? TypeScriptTypeMapper.DefaultDateInitializer
+            : dateInitializer.Trim();
+        return this;
+    }
+
+    public virtual Settings UseDateOnlyType(string dateOnlyType)
+    {
+        DateOnlyTypeGeneration = string.IsNullOrWhiteSpace(value: dateOnlyType)
+            ? TypeScriptTypeMapper.DefaultDateOnlyType
+            : dateOnlyType.Trim();
+        return this;
+    }
+
+    public virtual Settings UseDateOnlyInitializer(string dateOnlyInitializer)
+    {
+        DateOnlyInitializerGeneration = string.IsNullOrWhiteSpace(value: dateOnlyInitializer)
+            ? TypeScriptTypeMapper.DefaultDateOnlyInitializer
+            : dateOnlyInitializer.Trim();
+        return this;
+    }
+
+    public virtual Settings UseTimeOnlyType(string timeOnlyType)
+    {
+        TimeOnlyTypeGeneration = string.IsNullOrWhiteSpace(value: timeOnlyType)
+            ? TypeScriptTypeMapper.DefaultTimeOnlyType
+            : timeOnlyType.Trim();
+        return this;
+    }
+
+    public virtual Settings UseTimeOnlyInitializer(string timeOnlyInitializer)
+    {
+        TimeOnlyInitializerGeneration = string.IsNullOrWhiteSpace(value: timeOnlyInitializer)
+            ? TypeScriptTypeMapper.DefaultTimeOnlyInitializer
+            : timeOnlyInitializer.Trim();
+        return this;
+    }
+
+    public virtual Settings UseGuidType(string guidType)
+    {
+        GuidTypeGeneration = string.IsNullOrWhiteSpace(value: guidType)
+            ? TypeScriptTypeMapper.DefaultGuidType
+            : guidType.Trim();
         return this;
     }
 
     public virtual Settings UseDecimalType(string decimalType)
     {
         DecimalTypeGeneration = string.IsNullOrWhiteSpace(value: decimalType)
-            ? "number"
+            ? TypeScriptTypeMapper.DefaultDecimalType
             : decimalType.Trim();
         return this;
     }
@@ -103,12 +164,24 @@ public class Settings
         bool utf8BomGeneration,
         char stringLiteralCharacter,
         string dateTypeGeneration,
+        string dateInitializerGeneration,
+        string dateOnlyTypeGeneration,
+        string dateOnlyInitializerGeneration,
+        string timeOnlyTypeGeneration,
+        string timeOnlyInitializerGeneration,
+        string guidTypeGeneration,
         string decimalTypeGeneration)
     {
         StrictNullGeneration = strictNullGeneration;
         Utf8BomGeneration = utf8BomGeneration;
         _stringLiteralCharacter = stringLiteralCharacter;
         UseDateType(dateType: dateTypeGeneration);
+        UseDateInitializer(dateInitializer: dateInitializerGeneration);
+        UseDateOnlyType(dateOnlyType: dateOnlyTypeGeneration);
+        UseDateOnlyInitializer(dateOnlyInitializer: dateOnlyInitializerGeneration);
+        UseTimeOnlyType(timeOnlyType: timeOnlyTypeGeneration);
+        UseTimeOnlyInitializer(timeOnlyInitializer: timeOnlyInitializerGeneration);
+        UseGuidType(guidType: guidTypeGeneration);
         UseDecimalType(decimalType: decimalTypeGeneration);
     }
 }

--- a/src/Typewriter.Engine/Extensions/Types/TypeExtensions.cs
+++ b/src/Typewriter.Engine/Extensions/Types/TypeExtensions.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Typewriter.Engine;
 using Type = Typewriter.CodeModel.Type;
 
 namespace Typewriter.Extensions.Types;
@@ -51,22 +52,9 @@ public static class TypeExtensions
 
         if (type.FullName.Equals(value: "System.Decimal", comparisonType: StringComparison.Ordinal)
             && type.Settings?.DecimalTypeGeneration is { } decimalType
-            && !decimalType.Equals(value: "number", comparisonType: StringComparison.Ordinal))
+            && !decimalType.Equals(value: TypeScriptTypeMapper.DefaultDecimalType, comparisonType: StringComparison.Ordinal))
         {
             return $"new {decimalType}(0)";
-        }
-
-        if (type.Name.Equals(value: "number", comparisonType: StringComparison.OrdinalIgnoreCase)
-            || (type.IsPrimitive
-                && !type.Name.Equals(value: "string", comparisonType: StringComparison.OrdinalIgnoreCase)
-                && !type.FullName.Equals(value: "System.String", comparisonType: StringComparison.OrdinalIgnoreCase)))
-        {
-            return "0";
-        }
-
-        if (type.Name.Equals(value: "void", comparisonType: StringComparison.OrdinalIgnoreCase))
-        {
-            return "void(0)";
         }
 
         var stringLiteralCharacter = type.Settings?.StringLiteralCharacter ?? '"';
@@ -80,9 +68,34 @@ public static class TypeExtensions
             return $"{stringLiteralCharacter}00:00:00{stringLiteralCharacter}";
         }
 
-        if (type.IsDate)
+        if (TypeScriptTemporalTypes.IsDateOnly(fullName: type.FullName))
         {
-            return "new Date()";
+            return type.Settings?.DateOnlyInitializerGeneration ?? TypeScriptTypeMapper.DefaultDateOnlyInitializer;
+        }
+
+        if (TypeScriptTemporalTypes.IsTimeOnly(fullName: type.FullName))
+        {
+            return TypeScriptTemporalTypes.FormatTimeOnlyInitializer(
+                initializer: type.Settings?.TimeOnlyInitializerGeneration ?? TypeScriptTypeMapper.DefaultTimeOnlyInitializer,
+                stringLiteralCharacter: stringLiteralCharacter);
+        }
+
+        if (type.IsDate || TypeScriptTemporalTypes.IsDateTime(fullName: type.FullName))
+        {
+            return type.Settings?.DateInitializerGeneration ?? TypeScriptTypeMapper.DefaultDateInitializer;
+        }
+
+        if (type.Name.Equals(value: "number", comparisonType: StringComparison.OrdinalIgnoreCase)
+            || (type.IsPrimitive
+                && !type.Name.Equals(value: "string", comparisonType: StringComparison.OrdinalIgnoreCase)
+                && !type.FullName.Equals(value: "System.String", comparisonType: StringComparison.OrdinalIgnoreCase)))
+        {
+            return "0";
+        }
+
+        if (type.Name.Equals(value: "void", comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            return "void(0)";
         }
 
         if (type.IsEnum)

--- a/src/Typewriter.Engine/TemplateCodeModelAdapterFactory.cs
+++ b/src/Typewriter.Engine/TemplateCodeModelAdapterFactory.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Typewriter.Abstractions;
 using CodeAttribute = Typewriter.CodeModel.Attribute;
 using CodeClass = Typewriter.CodeModel.Class;
@@ -201,6 +203,9 @@ internal sealed class TemplateCodeModelAdapterFactory
             : type;
         return effectiveType.IsPrimitive
             || effectiveType.IsDateLike
+            || TypeScriptTemporalTypes.IsDateTime(fullName: effectiveType.FullName)
+            || TypeScriptTemporalTypes.IsDateOnly(fullName: effectiveType.FullName)
+            || TypeScriptTemporalTypes.IsTimeOnly(fullName: effectiveType.FullName)
             || effectiveType.FullName.Equals(value: "System.Guid", comparisonType: StringComparison.Ordinal);
     }
 
@@ -521,7 +526,10 @@ internal sealed class TemplateCodeModelAdapterFactory
             type: type,
             strictNull: _settings.StrictNullGeneration,
             dateType: _settings.DateTypeGeneration,
-            decimalType: _settings.DecimalTypeGeneration);
+            decimalType: _settings.DecimalTypeGeneration,
+            guidType: _settings.GuidTypeGeneration,
+            dateOnlyType: _settings.DateOnlyTypeGeneration,
+            timeOnlyType: _settings.TimeOnlyTypeGeneration);
         var isStruct = _typesByFullName.TryGetValue(key: type.FullName, value: out var metadata)
                        && metadata.Kind == TypeMetadataKind.Struct;
         return new CodeType
@@ -1087,20 +1095,9 @@ internal sealed class TemplateCodeModelAdapterFactory
         }
 
         var stringLiteralCharacter = _settings.StringLiteralCharacter;
-        if (type.FullName.Equals(value: "System.TimeSpan", comparisonType: StringComparison.Ordinal))
+        if (TryGetSpecialDefault(type: type, stringLiteralCharacter: stringLiteralCharacter, value: out var specialDefault))
         {
-            return $"{stringLiteralCharacter}00:00:00{stringLiteralCharacter}";
-        }
-
-        if (type.FullName.Equals(value: "System.Decimal", comparisonType: StringComparison.Ordinal)
-            && !_settings.DecimalTypeGeneration.Equals(value: TypeScriptTypeMapper.DefaultDecimalType, comparisonType: StringComparison.Ordinal))
-        {
-            return $"new {_settings.DecimalTypeGeneration}(0)";
-        }
-
-        if (type.IsDateLike)
-        {
-            return "new Date()";
+            return specialDefault;
         }
 
         if (type.IsEnum)
@@ -1126,6 +1123,54 @@ internal sealed class TemplateCodeModelAdapterFactory
             || type.FullName.Equals(value: "System.String", comparisonType: StringComparison.OrdinalIgnoreCase)
                 ? $"{stringLiteralCharacter}{stringLiteralCharacter}"
                 : "null";
+    }
+
+    private bool TryGetSpecialDefault(
+        TypeMetadataReference type,
+        char stringLiteralCharacter,
+        [NotNullWhen(returnValue: true)] out string? value)
+    {
+        if (type.FullName.Equals(value: "System.Guid", comparisonType: StringComparison.Ordinal))
+        {
+            value = $"{stringLiteralCharacter}{Guid.Empty.ToString(format: "D", provider: CultureInfo.InvariantCulture)}{stringLiteralCharacter}";
+            return true;
+        }
+
+        if (type.FullName.Equals(value: "System.TimeSpan", comparisonType: StringComparison.Ordinal))
+        {
+            value = $"{stringLiteralCharacter}00:00:00{stringLiteralCharacter}";
+            return true;
+        }
+
+        if (TypeScriptTemporalTypes.IsDateOnly(fullName: type.FullName))
+        {
+            value = _settings.DateOnlyInitializerGeneration;
+            return true;
+        }
+
+        if (TypeScriptTemporalTypes.IsTimeOnly(fullName: type.FullName))
+        {
+            value = TypeScriptTemporalTypes.FormatTimeOnlyInitializer(
+                initializer: _settings.TimeOnlyInitializerGeneration,
+                stringLiteralCharacter: stringLiteralCharacter);
+            return true;
+        }
+
+        value = GetConfiguredNonStringDefault(type: type);
+        return value is not null;
+    }
+
+    private string? GetConfiguredNonStringDefault(TypeMetadataReference type)
+    {
+        if (type.FullName.Equals(value: "System.Decimal", comparisonType: StringComparison.Ordinal)
+            && !_settings.DecimalTypeGeneration.Equals(value: TypeScriptTypeMapper.DefaultDecimalType, comparisonType: StringComparison.Ordinal))
+        {
+            return $"new {_settings.DecimalTypeGeneration}(0)";
+        }
+
+        return type.IsDateLike || TypeScriptTemporalTypes.IsDateTime(fullName: type.FullName)
+            ? _settings.DateInitializerGeneration
+            : null;
     }
 
     private string? ResolveEnumDefault(TypeMetadataReference type)

--- a/src/Typewriter.Engine/TemplateRenderDefaults.cs
+++ b/src/Typewriter.Engine/TemplateRenderDefaults.cs
@@ -8,6 +8,12 @@ public sealed record TemplateRenderDefaults(
     string SolutionFullName,
     char StringLiteralCharacter = '"',
     string DateTypeGeneration = TypeScriptTypeMapper.DefaultDateType,
+    string DateInitializerGeneration = TypeScriptTypeMapper.DefaultDateInitializer,
+    string DateOnlyTypeGeneration = TypeScriptTypeMapper.DefaultDateOnlyType,
+    string DateOnlyInitializerGeneration = TypeScriptTypeMapper.DefaultDateOnlyInitializer,
+    string TimeOnlyTypeGeneration = TypeScriptTypeMapper.DefaultTimeOnlyType,
+    string TimeOnlyInitializerGeneration = TypeScriptTypeMapper.DefaultTimeOnlyInitializer,
+    string GuidTypeGeneration = TypeScriptTypeMapper.DefaultGuidType,
     string DecimalTypeGeneration = TypeScriptTypeMapper.DefaultDecimalType)
 {
     // Matches the original Typewriter defaults: strict null unions and a UTF-8 BOM.
@@ -28,6 +34,12 @@ public sealed record TemplateRenderDefaults(
             SolutionFullName: solutionFullName ?? string.Empty,
             StringLiteralCharacter: ToStringLiteralCharacter(quoteStyle: configuration.Output.QuoteStyle),
             DateTypeGeneration: configuration.Output.DateType,
+            DateInitializerGeneration: configuration.Output.DateInitializer,
+            DateOnlyTypeGeneration: configuration.Output.DateOnlyType,
+            DateOnlyInitializerGeneration: configuration.Output.DateOnlyInitializer,
+            TimeOnlyTypeGeneration: configuration.Output.TimeOnlyType,
+            TimeOnlyInitializerGeneration: configuration.Output.TimeOnlyInitializer,
+            GuidTypeGeneration: configuration.Output.GuidType,
             DecimalTypeGeneration: configuration.Output.DecimalType);
     }
 

--- a/src/Typewriter.Engine/TemplateRenderer.cs
+++ b/src/Typewriter.Engine/TemplateRenderer.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using Typewriter.Abstractions;
@@ -688,6 +689,9 @@ public sealed class TemplateRenderer
             : type;
         return effectiveType.IsPrimitive
             || effectiveType.IsDateLike
+            || TypeScriptTemporalTypes.IsDateTime(fullName: effectiveType.FullName)
+            || TypeScriptTemporalTypes.IsDateOnly(fullName: effectiveType.FullName)
+            || TypeScriptTemporalTypes.IsTimeOnly(fullName: effectiveType.FullName)
             || effectiveType.FullName.Equals(value: "System.Guid", comparisonType: StringComparison.Ordinal);
     }
 
@@ -821,6 +825,36 @@ public sealed class TemplateRenderer
         Typewriter.Configuration.Settings? settings,
         RenderState? state) =>
         settings?.DateTypeGeneration ?? state?.DateTypeGeneration ?? TypeScriptTypeMapper.DefaultDateType;
+
+    private static string ResolveDateInitializer(
+        Typewriter.Configuration.Settings? settings,
+        RenderState? state) =>
+        settings?.DateInitializerGeneration ?? state?.DateInitializerGeneration ?? TypeScriptTypeMapper.DefaultDateInitializer;
+
+    private static string ResolveDateOnlyType(
+        Typewriter.Configuration.Settings? settings,
+        RenderState? state) =>
+        settings?.DateOnlyTypeGeneration ?? state?.DateOnlyTypeGeneration ?? TypeScriptTypeMapper.DefaultDateOnlyType;
+
+    private static string ResolveDateOnlyInitializer(
+        Typewriter.Configuration.Settings? settings,
+        RenderState? state) =>
+        settings?.DateOnlyInitializerGeneration ?? state?.DateOnlyInitializerGeneration ?? TypeScriptTypeMapper.DefaultDateOnlyInitializer;
+
+    private static string ResolveTimeOnlyType(
+        Typewriter.Configuration.Settings? settings,
+        RenderState? state) =>
+        settings?.TimeOnlyTypeGeneration ?? state?.TimeOnlyTypeGeneration ?? TypeScriptTypeMapper.DefaultTimeOnlyType;
+
+    private static string ResolveTimeOnlyInitializer(
+        Typewriter.Configuration.Settings? settings,
+        RenderState? state) =>
+        settings?.TimeOnlyInitializerGeneration ?? state?.TimeOnlyInitializerGeneration ?? TypeScriptTypeMapper.DefaultTimeOnlyInitializer;
+
+    private static string ResolveGuidType(
+        Typewriter.Configuration.Settings? settings,
+        RenderState? state) =>
+        settings?.GuidTypeGeneration ?? state?.GuidTypeGeneration ?? TypeScriptTypeMapper.DefaultGuidType;
 
     private static string ResolveDecimalType(
         Typewriter.Configuration.Settings? settings,
@@ -2233,26 +2267,35 @@ public sealed class TemplateRenderer
             type: type,
             strictNull: state?.StrictNullGeneration ?? true,
             dateType: state?.DateTypeGeneration,
-            decimalType: state?.DecimalTypeGeneration);
+            decimalType: state?.DecimalTypeGeneration,
+            guidType: state?.GuidTypeGeneration,
+            dateOnlyType: state?.DateOnlyTypeGeneration,
+            timeOnlyType: state?.TimeOnlyTypeGeneration);
 
     private string GetLegacyTypeName(
         TypeMetadataReference type,
         bool strictNull = true,
         string? dateType = null,
+        string? guidType = null,
+        string? dateOnlyType = null,
+        string? timeOnlyType = null,
         string? decimalType = null)
     {
-        return _typeMapper.Map(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType);
+        return _typeMapper.Map(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType);
     }
 
     private string GetClassName(
         TypeMetadataReference type,
         bool strictNull = true,
         string? dateType = null,
+        string? guidType = null,
+        string? dateOnlyType = null,
+        string? timeOnlyType = null,
         string? decimalType = null)
     {
         var className = type.IsCollection && type.ElementType is not null
-            ? _typeMapper.Map(type: type.ElementType, strictNull: strictNull, dateType: dateType, decimalType: decimalType)
-            : _typeMapper.Map(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType);
+            ? _typeMapper.Map(type: type.ElementType, strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType)
+            : _typeMapper.Map(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType);
         return className
             .Replace(oldValue: " | null", newValue: string.Empty, comparisonType: StringComparison.Ordinal)
             .Replace(oldValue: "(", newValue: string.Empty, comparisonType: StringComparison.Ordinal)
@@ -2286,20 +2329,9 @@ public sealed class TemplateRenderer
             return $"{stringLiteralCharacter}{Guid.Empty.ToString(format: "D", provider: CultureInfo.InvariantCulture)}{stringLiteralCharacter}";
         }
 
-        if (type.FullName.Equals(value: "System.TimeSpan", comparisonType: StringComparison.Ordinal))
+        if (TryGetSpecialDefault(type: type, state: state, settings: settings, stringLiteralCharacter: stringLiteralCharacter, value: out var specialDefault))
         {
-            return $"{stringLiteralCharacter}00:00:00{stringLiteralCharacter}";
-        }
-
-        var decimalDefault = GetConfiguredDecimalDefault(type: type, state: state, settings: settings);
-        if (decimalDefault is not null)
-        {
-            return decimalDefault;
-        }
-
-        if (type.IsDateLike)
-        {
-            return "new Date()";
+            return specialDefault;
         }
 
         if (type.IsEnum)
@@ -2346,6 +2378,53 @@ public sealed class TemplateRenderer
         return type.IsCollection ? "[]" : null;
     }
 
+    private bool TryGetSpecialDefault(
+        TypeMetadataReference type,
+        RenderState? state,
+        Typewriter.Configuration.Settings? settings,
+        char stringLiteralCharacter,
+        [NotNullWhen(returnValue: true)] out string? value)
+    {
+        if (type.FullName.Equals(value: "System.TimeSpan", comparisonType: StringComparison.Ordinal))
+        {
+            value = $"{stringLiteralCharacter}00:00:00{stringLiteralCharacter}";
+            return true;
+        }
+
+        if (TypeScriptTemporalTypes.IsDateOnly(fullName: type.FullName))
+        {
+            value = ResolveDateOnlyInitializer(settings: settings, state: state);
+            return true;
+        }
+
+        if (TypeScriptTemporalTypes.IsTimeOnly(fullName: type.FullName))
+        {
+            value = TypeScriptTemporalTypes.FormatTimeOnlyInitializer(
+                initializer: ResolveTimeOnlyInitializer(settings: settings, state: state),
+                stringLiteralCharacter: stringLiteralCharacter);
+            return true;
+        }
+
+        value = GetConfiguredTemporalOrDecimalDefault(type: type, state: state, settings: settings);
+        return value is not null;
+    }
+
+    private string? GetConfiguredTemporalOrDecimalDefault(
+        TypeMetadataReference type,
+        RenderState? state,
+        Typewriter.Configuration.Settings? settings)
+    {
+        var decimalDefault = GetConfiguredDecimalDefault(type: type, state: state, settings: settings);
+        if (decimalDefault is not null)
+        {
+            return decimalDefault;
+        }
+
+        return type.IsDateLike || TypeScriptTemporalTypes.IsDateTime(fullName: type.FullName)
+            ? ResolveDateInitializer(settings: settings, state: state)
+            : null;
+    }
+
     private string? GetConfiguredDecimalDefault(
         TypeMetadataReference type,
         RenderState? state,
@@ -2361,6 +2440,7 @@ public sealed class TemplateRenderer
             ? null
             : $"new {decimalType}(0)";
     }
+
 #pragma warning restore CC0091,S2325
 
     private bool TryResolve(
@@ -2711,19 +2791,22 @@ public sealed class TemplateRenderer
     {
         var strictNull = ResolveStrictNull(settings: settings, state: state);
         var dateType = ResolveDateType(settings: settings, state: state);
+        var dateOnlyType = ResolveDateOnlyType(settings: settings, state: state);
+        var timeOnlyType = ResolveTimeOnlyType(settings: settings, state: state);
+        var guidType = ResolveGuidType(settings: settings, state: state);
         var decimalType = ResolveDecimalType(settings: settings, state: state);
         return identifier switch
         {
-            "Name" => GetLegacyTypeName(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType),
-            "name" => GetLegacyTypeName(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType),
+            "Name" => GetLegacyTypeName(type: type, strictNull: strictNull, dateType: dateType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType, decimalType: decimalType),
+            "name" => GetLegacyTypeName(type: type, strictNull: strictNull, dateType: dateType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType, decimalType: decimalType),
             "FullName" => type.FullName,
             "AssemblyName" => type.AssemblyName,
             "Namespace" => type.Namespace,
             "OriginalName" => type.Name,
-            "Type" => new TypeTemplateValue(Reference: type, Text: _typeMapper.Map(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType), Settings: settings),
-            "TypeScriptType" => _typeMapper.Map(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType),
-            "Class" => GetClassName(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType),
-            "ClassName" => GetClassName(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType),
+            "Type" => new TypeTemplateValue(Reference: type, Text: _typeMapper.Map(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType), Settings: settings),
+            "TypeScriptType" => _typeMapper.Map(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType),
+            "Class" => GetClassName(type: type, strictNull: strictNull, dateType: dateType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType, decimalType: decimalType),
+            "ClassName" => GetClassName(type: type, strictNull: strictNull, dateType: dateType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType, decimalType: decimalType),
             "Default" => GetDefaultValue(type: type, state: state, settings: settings),
             "DefaultValue" => GetDefaultValue(type: type, state: state, settings: settings),
             "ElementType" => type.ElementType,
@@ -2855,6 +2938,18 @@ public sealed class TemplateRenderer
         public bool StrictNullGeneration => TemplateSettings?.StrictNullGeneration ?? _defaults.StrictNullGeneration;
 
         public string DateTypeGeneration => TemplateSettings?.DateTypeGeneration ?? _defaults.DateTypeGeneration;
+
+        public string DateInitializerGeneration => TemplateSettings?.DateInitializerGeneration ?? _defaults.DateInitializerGeneration;
+
+        public string DateOnlyTypeGeneration => TemplateSettings?.DateOnlyTypeGeneration ?? _defaults.DateOnlyTypeGeneration;
+
+        public string DateOnlyInitializerGeneration => TemplateSettings?.DateOnlyInitializerGeneration ?? _defaults.DateOnlyInitializerGeneration;
+
+        public string TimeOnlyTypeGeneration => TemplateSettings?.TimeOnlyTypeGeneration ?? _defaults.TimeOnlyTypeGeneration;
+
+        public string TimeOnlyInitializerGeneration => TemplateSettings?.TimeOnlyInitializerGeneration ?? _defaults.TimeOnlyInitializerGeneration;
+
+        public string GuidTypeGeneration => TemplateSettings?.GuidTypeGeneration ?? _defaults.GuidTypeGeneration;
 
         public string DecimalTypeGeneration => TemplateSettings?.DecimalTypeGeneration ?? _defaults.DecimalTypeGeneration;
 

--- a/src/Typewriter.Engine/TemplateRuntimeCompiler.cs
+++ b/src/Typewriter.Engine/TemplateRuntimeCompiler.cs
@@ -134,6 +134,12 @@ internal static class TemplateRuntimeCompiler
             utf8BomGeneration: defaults.Utf8BomGeneration,
             stringLiteralCharacter: defaults.StringLiteralCharacter,
             dateTypeGeneration: defaults.DateTypeGeneration,
+            dateInitializerGeneration: defaults.DateInitializerGeneration,
+            dateOnlyTypeGeneration: defaults.DateOnlyTypeGeneration,
+            dateOnlyInitializerGeneration: defaults.DateOnlyInitializerGeneration,
+            timeOnlyTypeGeneration: defaults.TimeOnlyTypeGeneration,
+            timeOnlyInitializerGeneration: defaults.TimeOnlyInitializerGeneration,
+            guidTypeGeneration: defaults.GuidTypeGeneration,
             decimalTypeGeneration: defaults.DecimalTypeGeneration);
         var adapterFactory = new TemplateCodeModelAdapterFactory(metadata: metadata, settings: settings, metadataIndex: metadataIndex);
         var host = CreateHost(hostType: hostType, settings: settings, file: adapterFactory.CreateFile(project: metadata));

--- a/src/Typewriter.Engine/TypeScriptTemporalTypes.cs
+++ b/src/Typewriter.Engine/TypeScriptTemporalTypes.cs
@@ -1,0 +1,29 @@
+namespace Typewriter.Engine;
+
+internal static class TypeScriptTemporalTypes
+{
+    public static bool IsDateTime(string fullName) =>
+        fullName.Equals(value: "System.DateTime", comparisonType: StringComparison.Ordinal)
+        || fullName.Equals(value: "System.DateTimeOffset", comparisonType: StringComparison.Ordinal)
+        || fullName.Equals(value: "NodaTime.Instant", comparisonType: StringComparison.Ordinal)
+        || fullName.Equals(value: "NodaTime.LocalDateTime", comparisonType: StringComparison.Ordinal)
+        || fullName.Equals(value: "NodaTime.OffsetDateTime", comparisonType: StringComparison.Ordinal)
+        || fullName.Equals(value: "NodaTime.ZonedDateTime", comparisonType: StringComparison.Ordinal);
+
+    public static bool IsDateOnly(string fullName) =>
+        fullName.Equals(value: "System.DateOnly", comparisonType: StringComparison.Ordinal)
+        || fullName.Equals(value: "NodaTime.LocalDate", comparisonType: StringComparison.Ordinal)
+        || fullName.Equals(value: "NodaTime.OffsetDate", comparisonType: StringComparison.Ordinal);
+
+    public static bool IsTimeOnly(string fullName) =>
+        fullName.Equals(value: "System.TimeOnly", comparisonType: StringComparison.Ordinal)
+        || fullName.Equals(value: "NodaTime.LocalTime", comparisonType: StringComparison.Ordinal)
+        || fullName.Equals(value: "NodaTime.OffsetTime", comparisonType: StringComparison.Ordinal);
+
+    public static string FormatTimeOnlyInitializer(
+        string initializer,
+        char stringLiteralCharacter) =>
+        initializer.Equals(value: TypeScriptTypeMapper.DefaultTimeOnlyInitializer, comparisonType: StringComparison.Ordinal)
+            ? $"{stringLiteralCharacter}00:00:00{stringLiteralCharacter}"
+            : initializer;
+}

--- a/src/Typewriter.Engine/TypeScriptTypeMapper.cs
+++ b/src/Typewriter.Engine/TypeScriptTypeMapper.cs
@@ -6,8 +6,14 @@ namespace Typewriter.Engine;
 
 public sealed class TypeScriptTypeMapper
 {
-    public const string DefaultDateType = "Date";
-    public const string DefaultDecimalType = "number";
+    public const string DefaultDateType = OutputConfiguration.DefaultDateType;
+    public const string DefaultDateInitializer = OutputConfiguration.DefaultDateInitializer;
+    public const string DefaultDateOnlyType = OutputConfiguration.DefaultDateOnlyType;
+    public const string DefaultDateOnlyInitializer = OutputConfiguration.DefaultDateOnlyInitializer;
+    public const string DefaultTimeOnlyType = OutputConfiguration.DefaultTimeOnlyType;
+    public const string DefaultTimeOnlyInitializer = OutputConfiguration.DefaultTimeOnlyInitializer;
+    public const string DefaultDecimalType = OutputConfiguration.DefaultDecimalType;
+    public const string DefaultGuidType = OutputConfiguration.DefaultGuidType;
 
     private readonly ConcurrentDictionary<MapCacheKey, string> _cache = new();
 
@@ -17,25 +23,48 @@ public sealed class TypeScriptTypeMapper
     public string Map(
         TypeMetadataReference type,
         bool strictNull) =>
-        Map(type: type, strictNull: strictNull, dateType: DefaultDateType, decimalType: DefaultDecimalType);
+        Map(
+            type: type,
+            strictNull: strictNull,
+            dateType: DefaultDateType,
+            decimalType: DefaultDecimalType,
+            guidType: DefaultGuidType,
+            dateOnlyType: DefaultDateOnlyType,
+            timeOnlyType: DefaultTimeOnlyType);
 
     public string Map(
         TypeMetadataReference type,
         bool strictNull,
         string? dateType,
-        string? decimalType = null)
+        string? decimalType = null,
+        string? guidType = null,
+        string? dateOnlyType = null,
+        string? timeOnlyType = null)
     {
         ArgumentNullException.ThrowIfNull(argument: type);
 
         var normalizedDateType = NormalizeDateType(dateType: dateType);
         var normalizedDecimalType = NormalizeDecimalType(decimalType: decimalType);
+        var normalizedGuidType = NormalizeGuidType(guidType: guidType);
+        var normalizedDateOnlyType = NormalizeDateOnlyType(dateOnlyType: dateOnlyType);
+        var normalizedTimeOnlyType = NormalizeTimeOnlyType(timeOnlyType: timeOnlyType);
         return _cache.GetOrAdd(
-            key: new MapCacheKey(Type: type, StrictNull: strictNull, DateType: normalizedDateType, DecimalType: normalizedDecimalType),
+            key: new MapCacheKey(
+                Type: type,
+                StrictNull: strictNull,
+                DateType: normalizedDateType,
+                DecimalType: normalizedDecimalType,
+                GuidType: normalizedGuidType,
+                DateOnlyType: normalizedDateOnlyType,
+                TimeOnlyType: normalizedTimeOnlyType),
             valueFactory: static (key, mapper) => mapper.MapUncached(
                 type: key.Type,
                 strictNull: key.StrictNull,
                 dateType: key.DateType,
-                decimalType: key.DecimalType),
+                decimalType: key.DecimalType,
+                guidType: key.GuidType,
+                dateOnlyType: key.DateOnlyType,
+                timeOnlyType: key.TimeOnlyType),
             factoryArgument: this);
     }
 
@@ -48,8 +77,10 @@ public sealed class TypeScriptTypeMapper
 
     private static bool IsString(string fullName) =>
         fullName.Equals(value: "System.String", comparisonType: StringComparison.Ordinal)
-        || fullName.Equals(value: "System.Char", comparisonType: StringComparison.Ordinal)
-        || fullName.Equals(value: "System.Guid", comparisonType: StringComparison.Ordinal);
+        || fullName.Equals(value: "System.Char", comparisonType: StringComparison.Ordinal);
+
+    private static bool IsGuid(string fullName) =>
+        fullName.Equals(value: "System.Guid", comparisonType: StringComparison.Ordinal);
 
     private static bool IsNumber(string fullName) =>
         fullName.Equals(value: "System.Byte", comparisonType: StringComparison.Ordinal)
@@ -76,10 +107,20 @@ public sealed class TypeScriptTypeMapper
             ? DefaultDecimalType
             : decimalType.Trim();
 
-    private static bool IsConfigurableDate(string fullName) =>
-        fullName.Equals(value: "System.DateTime", comparisonType: StringComparison.Ordinal)
-        || fullName.Equals(value: "System.DateTimeOffset", comparisonType: StringComparison.Ordinal)
-        || fullName.Equals(value: "System.DateOnly", comparisonType: StringComparison.Ordinal);
+    private static string NormalizeGuidType(string? guidType) =>
+        string.IsNullOrWhiteSpace(value: guidType)
+            ? DefaultGuidType
+            : guidType.Trim();
+
+    private static string NormalizeDateOnlyType(string? dateOnlyType) =>
+        string.IsNullOrWhiteSpace(value: dateOnlyType)
+            ? DefaultDateOnlyType
+            : dateOnlyType.Trim();
+
+    private static string NormalizeTimeOnlyType(string? timeOnlyType) =>
+        string.IsNullOrWhiteSpace(value: timeOnlyType)
+            ? DefaultTimeOnlyType
+            : timeOnlyType.Trim();
 
     private static string FormatArrayElementType(string mapped)
     {
@@ -182,6 +223,9 @@ public sealed class TypeScriptTypeMapper
         TypeMetadataReference type,
         string dateType,
         string decimalType,
+        string guidType,
+        string dateOnlyType,
+        string timeOnlyType,
         [NotNullWhen(returnValue: true)] out string? mapped)
     {
         if (type.IsEnum)
@@ -190,84 +234,114 @@ public sealed class TypeScriptTypeMapper
             return true;
         }
 
-        if (type.IsDateLike)
+        var fullName = type.FullName;
+        return TryMapKnownTemporalType(type: type, dateType: dateType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType, mapped: out mapped)
+               || TryMapKnownScalarType(fullName: fullName, decimalType: decimalType, guidType: guidType, mapped: out mapped);
+    }
+
+    private static bool TryMapKnownTemporalType(
+        TypeMetadataReference type,
+        string dateType,
+        string dateOnlyType,
+        string timeOnlyType,
+        [NotNullWhen(returnValue: true)] out string? mapped)
+    {
+        var fullName = type.FullName;
+        if (TypeScriptTemporalTypes.IsDateTime(fullName: fullName))
         {
-            mapped = IsConfigurableDate(fullName: type.FullName) ? dateType : "string";
+            mapped = dateType;
             return true;
         }
 
-        var fullName = type.FullName;
-        if (IsBoolean(fullName: fullName))
+        if (TypeScriptTemporalTypes.IsDateOnly(fullName: fullName))
+        {
+            mapped = dateOnlyType;
+            return true;
+        }
+
+        if (TypeScriptTemporalTypes.IsTimeOnly(fullName: fullName))
+        {
+            mapped = timeOnlyType;
+            return true;
+        }
+
+        mapped = type.IsDateLike ? "string" : null;
+        return type.IsDateLike;
+    }
+
+    private static bool TryMapKnownScalarType(
+        string fullName,
+        string decimalType,
+        string guidType,
+        [NotNullWhen(returnValue: true)] out string? mapped)
+    {
+        mapped = null;
+        if (IsGuid(fullName: fullName))
+        {
+            mapped = guidType;
+        }
+        else if (IsBoolean(fullName: fullName))
         {
             mapped = "boolean";
-            return true;
         }
-
-        if (IsDecimal(fullName: fullName))
+        else if (IsDecimal(fullName: fullName))
         {
             mapped = decimalType;
-            return true;
         }
-
-        if (IsNumber(fullName: fullName))
+        else if (IsNumber(fullName: fullName))
         {
             mapped = "number";
-            return true;
         }
-
-        if (IsString(fullName: fullName))
+        else if (IsString(fullName: fullName))
         {
             mapped = "string";
-            return true;
         }
-
-        if (fullName.Equals(value: "System.Void", comparisonType: StringComparison.Ordinal))
+        else if (fullName.Equals(value: "System.Void", comparisonType: StringComparison.Ordinal))
         {
             mapped = "void";
-            return true;
         }
-
-        if (fullName.Equals(value: "dynamic", comparisonType: StringComparison.OrdinalIgnoreCase)
-            || fullName.Equals(value: "System.Object", comparisonType: StringComparison.Ordinal))
+        else if (fullName.Equals(value: "dynamic", comparisonType: StringComparison.OrdinalIgnoreCase)
+                 || fullName.Equals(value: "System.Object", comparisonType: StringComparison.Ordinal))
         {
             mapped = "unknown";
-            return true;
         }
 
-        mapped = null;
-        return false;
+        return mapped is not null;
     }
 
     private string MapCore(
         TypeMetadataReference type,
         bool strictNull,
         string dateType,
-        string decimalType)
+        string decimalType,
+        string guidType,
+        string dateOnlyType,
+        string timeOnlyType)
     {
         if (IsTaskLike(fullName: type.FullName))
         {
             return type.TypeArguments.Count > 0
-                ? Map(type: type.TypeArguments[index: 0], strictNull: strictNull, dateType: dateType, decimalType: decimalType)
+                ? Map(type: type.TypeArguments[index: 0], strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType)
                 : "void";
         }
 
         if (type.IsDictionary)
         {
-            return MapDictionaryType(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType);
+            return MapDictionaryType(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType);
         }
 
         if (type.IsCollection && type.ElementType is not null)
         {
-            return $"{FormatArrayElementType(mapped: Map(type: type.ElementType, strictNull: strictNull, dateType: dateType, decimalType: decimalType))}[]";
+            return $"{FormatArrayElementType(mapped: Map(type: type.ElementType, strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType))}[]";
         }
 
-        if (TryMapKnownType(type: type, dateType: dateType, decimalType: decimalType, mapped: out var mapped))
+        if (TryMapKnownType(type: type, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType, mapped: out var mapped))
         {
             return mapped;
         }
 
         return type.TypeArguments.Count > 0
-            ? MapGenericType(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType)
+            ? MapGenericType(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType)
             : type.Name;
     }
 
@@ -275,19 +349,23 @@ public sealed class TypeScriptTypeMapper
         TypeMetadataReference type,
         bool strictNull,
         string dateType,
-        string decimalType)
+        string decimalType,
+        string guidType,
+        string dateOnlyType,
+        string timeOnlyType)
     {
         var keyType = type.TypeArguments.Count > 0
             ? type.TypeArguments[index: 0]
             : null;
         var valueType = type.TypeArguments.Count > 1
-            ? Map(type: type.TypeArguments[index: 1], strictNull: strictNull, dateType: dateType, decimalType: decimalType)
+            ? Map(type: type.TypeArguments[index: 1], strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType)
             : "unknown";
         var keyTypeName = keyType is null
             ? "string"
-            : MapDictionaryKeyType(type: keyType, dateType: dateType);
+            : MapDictionaryKeyType(type: keyType, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType);
 
         return keyTypeName is "string" or "number"
+            || (keyType is not null && IsGuid(fullName: keyType.FullName))
             || keyType?.IsEnum == true
             ? $"Record<{keyTypeName}, {valueType}>"
             : $"Map<{keyTypeName}, {valueType}>";
@@ -295,7 +373,11 @@ public sealed class TypeScriptTypeMapper
 
     private string MapDictionaryKeyType(
         TypeMetadataReference type,
-        string dateType)
+        string dateType,
+        string decimalType,
+        string guidType,
+        string dateOnlyType,
+        string timeOnlyType)
     {
         if (type.IsEnum)
         {
@@ -313,18 +395,21 @@ public sealed class TypeScriptTypeMapper
             return "string";
         }
 
-        return Map(type: type, strictNull: false, dateType: dateType);
+        return Map(type: type, strictNull: false, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType);
     }
 
     private string MapGenericType(
         TypeMetadataReference type,
         bool strictNull,
         string dateType,
-        string decimalType)
+        string decimalType,
+        string guidType,
+        string dateOnlyType,
+        string timeOnlyType)
     {
         var arguments = string.Join(
             separator: ", ",
-            values: type.TypeArguments.Select(selector: argument => Map(type: argument, strictNull: strictNull, dateType: dateType, decimalType: decimalType)));
+            values: type.TypeArguments.Select(selector: argument => Map(type: argument, strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType)));
         return type.Name + "<" + arguments + ">";
     }
 
@@ -332,9 +417,12 @@ public sealed class TypeScriptTypeMapper
         TypeMetadataReference type,
         bool strictNull,
         string dateType,
-        string decimalType)
+        string decimalType,
+        string guidType,
+        string dateOnlyType,
+        string timeOnlyType)
     {
-        var mapped = MapCore(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType);
+        var mapped = MapCore(type: type, strictNull: strictNull, dateType: dateType, decimalType: decimalType, guidType: guidType, dateOnlyType: dateOnlyType, timeOnlyType: timeOnlyType);
         if (strictNull && type.IsNullable && !HasTopLevelNullUnion(mapped: mapped))
         {
             return $"{mapped} | null";
@@ -347,5 +435,8 @@ public sealed class TypeScriptTypeMapper
         TypeMetadataReference Type,
         bool StrictNull,
         string DateType,
-        string DecimalType);
+        string DecimalType,
+        string GuidType,
+        string DateOnlyType,
+        string TimeOnlyType);
 }

--- a/src/Typewriter.Engine/TypewriterConfigurationLoader.cs
+++ b/src/Typewriter.Engine/TypewriterConfigurationLoader.cs
@@ -115,6 +115,12 @@ public static class TypewriterConfigurationLoader
                 TrimTrailingWhitespace = loaded.Output?.TrimTrailingWhitespace ?? current.Output.TrimTrailingWhitespace,
                 QuoteStyle = loaded.Output?.QuoteStyle ?? current.Output.QuoteStyle,
                 DateType = loaded.Output?.DateType ?? current.Output.DateType,
+                DateInitializer = loaded.Output?.DateInitializer ?? current.Output.DateInitializer,
+                DateOnlyType = loaded.Output?.DateOnlyType ?? current.Output.DateOnlyType,
+                DateOnlyInitializer = loaded.Output?.DateOnlyInitializer ?? current.Output.DateOnlyInitializer,
+                TimeOnlyType = loaded.Output?.TimeOnlyType ?? current.Output.TimeOnlyType,
+                TimeOnlyInitializer = loaded.Output?.TimeOnlyInitializer ?? current.Output.TimeOnlyInitializer,
+                GuidType = loaded.Output?.GuidType ?? current.Output.GuidType,
                 DecimalType = loaded.Output?.DecimalType ?? current.Output.DecimalType,
             },
             Diagnostics = current.Diagnostics with
@@ -137,6 +143,18 @@ public static class TypewriterConfigurationLoader
                     ?? configuration.Output.Newline,
                 DateType = Environment.GetEnvironmentVariable(variable: "TYPEWRITER_OUTPUT_DATE_TYPE")
                     ?? configuration.Output.DateType,
+                DateInitializer = Environment.GetEnvironmentVariable(variable: "TYPEWRITER_OUTPUT_DATE_INITIALIZER")
+                    ?? configuration.Output.DateInitializer,
+                DateOnlyType = Environment.GetEnvironmentVariable(variable: "TYPEWRITER_OUTPUT_DATE_ONLY_TYPE")
+                    ?? configuration.Output.DateOnlyType,
+                DateOnlyInitializer = Environment.GetEnvironmentVariable(variable: "TYPEWRITER_OUTPUT_DATE_ONLY_INITIALIZER")
+                    ?? configuration.Output.DateOnlyInitializer,
+                TimeOnlyType = Environment.GetEnvironmentVariable(variable: "TYPEWRITER_OUTPUT_TIME_ONLY_TYPE")
+                    ?? configuration.Output.TimeOnlyType,
+                TimeOnlyInitializer = Environment.GetEnvironmentVariable(variable: "TYPEWRITER_OUTPUT_TIME_ONLY_INITIALIZER")
+                    ?? configuration.Output.TimeOnlyInitializer,
+                GuidType = Environment.GetEnvironmentVariable(variable: "TYPEWRITER_OUTPUT_GUID_TYPE")
+                    ?? configuration.Output.GuidType,
                 DecimalType = Environment.GetEnvironmentVariable(variable: "TYPEWRITER_OUTPUT_DECIMAL_TYPE")
                     ?? configuration.Output.DecimalType,
             },
@@ -231,6 +249,18 @@ public static class TypewriterConfigurationLoader
         public QuoteStyle? QuoteStyle { get; init; }
 
         public string? DateType { get; init; }
+
+        public string? DateInitializer { get; init; }
+
+        public string? DateOnlyType { get; init; }
+
+        public string? DateOnlyInitializer { get; init; }
+
+        public string? TimeOnlyType { get; init; }
+
+        public string? TimeOnlyInitializer { get; init; }
+
+        public string? GuidType { get; init; }
 
         public string? DecimalType { get; init; }
     }

--- a/src/Typewriter.LanguageServer/LanguageServerHost.cs
+++ b/src/Typewriter.LanguageServer/LanguageServerHost.cs
@@ -99,7 +99,7 @@ internal sealed class LanguageServerHost
             serverInfo = new
             {
                 name = "Typewriter Language Server",
-                version = "4.5.4",
+                version = "4.6.0",
             },
         };
 

--- a/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
+++ b/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
@@ -1472,7 +1472,15 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
             || fullName.Equals(value: "System.DateTimeOffset", comparisonType: StringComparison.Ordinal)
             || fullName.Equals(value: "System.DateOnly", comparisonType: StringComparison.Ordinal)
             || fullName.Equals(value: "System.TimeOnly", comparisonType: StringComparison.Ordinal)
-            || fullName.Equals(value: "System.TimeSpan", comparisonType: StringComparison.Ordinal);
+            || fullName.Equals(value: "System.TimeSpan", comparisonType: StringComparison.Ordinal)
+            || fullName.Equals(value: "NodaTime.Instant", comparisonType: StringComparison.Ordinal)
+            || fullName.Equals(value: "NodaTime.LocalDate", comparisonType: StringComparison.Ordinal)
+            || fullName.Equals(value: "NodaTime.LocalTime", comparisonType: StringComparison.Ordinal)
+            || fullName.Equals(value: "NodaTime.LocalDateTime", comparisonType: StringComparison.Ordinal)
+            || fullName.Equals(value: "NodaTime.OffsetDate", comparisonType: StringComparison.Ordinal)
+            || fullName.Equals(value: "NodaTime.OffsetTime", comparisonType: StringComparison.Ordinal)
+            || fullName.Equals(value: "NodaTime.OffsetDateTime", comparisonType: StringComparison.Ordinal)
+            || fullName.Equals(value: "NodaTime.ZonedDateTime", comparisonType: StringComparison.Ordinal);
     }
 
     private static bool IsNullableValueType(INamedTypeSymbol symbol)

--- a/src/Typewriter.VisualStudio/TypewriterPackage.cs
+++ b/src/Typewriter.VisualStudio/TypewriterPackage.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 namespace Typewriter.VisualStudio;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.5.4")]
+[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.6.0")]
 [ProvideMenuResource(resourceID: "Menus.ctmenu", version: 1)]
 [ProvideOptionPage(pageType: typeof(TypewriterOptions), categoryName: "Typewriter", pageName: "General", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true)]
 [ProvideAutoLoad(cmdUiContextGuid: VSConstants.UICONTEXT.SolutionExists_string, flags: PackageAutoLoadFlags.BackgroundLoad)]

--- a/src/Typewriter.VisualStudio/source.extension.vsixmanifest
+++ b/src/Typewriter.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.5.4" Language="en-US" Publisher="AdaskoTheBeAsT" />
+    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.6.0" Language="en-US" Publisher="AdaskoTheBeAsT" />
     <DisplayName>Typewriter</DisplayName>
     <Description xml:space="preserve">Generate TypeScript from C# Typewriter templates.</Description>
     <Tags>Typewriter;TypeScript;C#;Code Generation</Tags>

--- a/tests/unit/Typewriter.Cli.Tests/CliIntegrationTests.cs
+++ b/tests/unit/Typewriter.Cli.Tests/CliIntegrationTests.cs
@@ -43,6 +43,14 @@ public sealed class CliIntegrationTests
             output.GetProperty(propertyName: "writeOnlyWhenChanged").GetBoolean().Should().BeTrue();
             output.GetProperty(propertyName: "dryRun").GetBoolean().Should().BeFalse();
             output.GetProperty(propertyName: "fileNameConvention").GetString().Should().Be("preserve");
+            output.GetProperty(propertyName: "dateType").GetString().Should().Be("Date");
+            output.GetProperty(propertyName: "dateInitializer").GetString().Should().Be("new Date()");
+            output.GetProperty(propertyName: "dateOnlyType").GetString().Should().Be("Date");
+            output.GetProperty(propertyName: "dateOnlyInitializer").GetString().Should().Be("new Date()");
+            output.GetProperty(propertyName: "timeOnlyType").GetString().Should().Be("string");
+            output.GetProperty(propertyName: "timeOnlyInitializer").GetString().Should().Be("\"00:00:00\"");
+            output.GetProperty(propertyName: "guidType").GetString().Should().Be("string");
+            output.GetProperty(propertyName: "decimalType").GetString().Should().Be("number");
 
             var diagnostics = root.GetProperty(propertyName: "diagnostics");
             diagnostics.GetProperty(propertyName: "failOnWarning").GetBoolean().Should().BeFalse();

--- a/tests/unit/Typewriter.Engine.Tests/ConfigurationDefaultsTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/ConfigurationDefaultsTests.cs
@@ -156,23 +156,144 @@ public sealed class ConfigurationDefaultsTests
     }
 
     [Fact]
-    public void RenderUsesConfiguredDateTypeForDefaults()
+    public void RenderUsesConfiguredGuidType()
     {
-        var metadata = CreateDateMetadata();
-        var document = new TemplateDocument(Path: "models.tst", Content: "$Classes[$Properties[$name: $Type;]]", OutputPath: "models.ts");
+        var metadata = CreateGuidIdMetadata();
+        var document = new TemplateDocument(Path: "models.tst", Content: "$Classes[$Properties[$name: $Type = $Type[$Default];]]", OutputPath: "models.ts");
         var diagnostics = new List<GenerationDiagnostic>();
         var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
         var defaults = TemplateRenderDefaults.FromConfiguration(
-            configuration: CreateConfiguration(strictNull: true, dateType: "Dayjs"));
+            configuration: CreateConfiguration(strictNull: true, guidType: "uuid"));
 
         var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics, defaults: defaults);
 
         diagnostics.Should().BeEmpty();
-        output.Should().Contain("createdAt: Dayjs;");
+        output.Should().Contain("id: uuid = \"00000000-0000-0000-0000-000000000000\";");
     }
 
     [Fact]
-    public void TemplateOverrideUsesConfiguredDateType()
+    public void OutputConfigurationLegacyConstructorUsesDateTypeForDateOnlyType()
+    {
+        var output = new OutputConfiguration(
+            Newline: "crlf",
+            Encoding: "utf-8-bom",
+            WriteOnlyWhenChanged: false,
+            DryRun: true,
+            FileNameConvention: FileNameConvention.Camel,
+            StrictNull: false,
+            IndentStyle: IndentStyle.Space,
+            IndentSize: 2,
+            InsertFinalNewline: true,
+            TrimTrailingWhitespace: true,
+            QuoteStyle: QuoteStyle.Single,
+            DateType: "Dayjs",
+            DecimalType: "Decimal");
+
+        output.DateInitializer.Should().Be(TypeScriptTypeMapper.DefaultDateInitializer);
+        output.DateOnlyType.Should().Be("Dayjs");
+        output.DateOnlyInitializer.Should().Be(TypeScriptTypeMapper.DefaultDateOnlyInitializer);
+        output.TimeOnlyType.Should().Be(TypeScriptTypeMapper.DefaultTimeOnlyType);
+        output.TimeOnlyInitializer.Should().Be(TypeScriptTypeMapper.DefaultTimeOnlyInitializer);
+        output.GuidType.Should().Be(TypeScriptTypeMapper.DefaultGuidType);
+        output.DecimalType.Should().Be("Decimal");
+
+        output.Deconstruct(
+            out var newline,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _,
+            out var dateType,
+            out var decimalType);
+
+        newline.Should().Be("crlf");
+        dateType.Should().Be("Dayjs");
+        decimalType.Should().Be("Decimal");
+    }
+
+    [Fact]
+    public void CompiledTypeDefaultValueUsesGuidDefault()
+    {
+        var metadata = CreateGuidIdMetadata();
+        var diagnostics = new List<GenerationDiagnostic>();
+        var document = TemplateDocument.Parse(
+            template: new TemplateFile(
+                Path: Path.Combine(path1: Path.GetTempPath(), path2: "compiled-guid-default.tst"),
+                Content: """
+                         ${
+                             Template(Settings settings)
+                             {
+                                 settings.UseStringLiteralCharacter('\'');
+                             }
+
+                             string Defaults(Type type)
+                             {
+                                 return type.Default() + "|" + type.DefaultValue;
+                             }
+                         }
+                         // output: compiled-guid-default.ts
+                         $Classes[$Properties[$name=$Type[$Defaults];]]
+                         """),
+            diagnostics: diagnostics);
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        diagnostics.Should().BeEmpty();
+        output.Should().Contain("id='00000000-0000-0000-0000-000000000000'|'00000000-0000-0000-0000-000000000000';");
+    }
+
+    [Fact]
+    public void TemplateOverrideUsesConfiguredGuidType()
+    {
+        var metadata = CreateGuidIdMetadata();
+        var diagnostics = new List<GenerationDiagnostic>();
+        var document = TemplateDocument.Parse(
+            template: new TemplateFile(
+                Path: Path.Combine(path1: Path.GetTempPath(), path2: "configured-guid.tst"),
+                Content: """
+                         ${
+                             Template(Settings settings)
+                             {
+                                 settings.UseGuidType("UUID");
+                             }
+                         }
+                         // output: configured-guid.ts
+                         $Classes[$Properties[$name: $Type;]]
+                         """),
+            diagnostics: diagnostics);
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        diagnostics.Should().BeEmpty();
+        output.Should().Contain("id: UUID;");
+    }
+
+    [Fact]
+    public void RenderUsesConfiguredDateTypeForDefaults()
+    {
+        var metadata = CreateDateMetadata();
+        var document = new TemplateDocument(Path: "models.tst", Content: "$Classes[$Properties[$name: $Type = $Type[$Default];]]", OutputPath: "models.ts");
+        var diagnostics = new List<GenerationDiagnostic>();
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+        var defaults = TemplateRenderDefaults.FromConfiguration(
+            configuration: CreateConfiguration(strictNull: true, dateType: "Dayjs", dateInitializer: "dayjs()"));
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics, defaults: defaults);
+
+        diagnostics.Should().BeEmpty();
+        output.Should().Contain("createdAt: Dayjs = dayjs();");
+    }
+
+    [Fact]
+    public void TemplateOverrideUsesConfiguredDateTypeAndInitializer()
     {
         var metadata = CreateDateMetadata();
         var diagnostics = new List<GenerationDiagnostic>();
@@ -184,10 +305,11 @@ public sealed class ConfigurationDefaultsTests
                              Template(Settings settings)
                              {
                                  settings.UseDateType("DateTime");
+                                 settings.UseDateInitializer("DateTime.now()");
                              }
                          }
                          // output: configured-date.ts
-                         $Classes[$Properties[$name: $Type;]]
+                         $Classes[$Properties[$name: $Type = $Type[$Default];]]
                          """),
             diagnostics: diagnostics);
         var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
@@ -195,7 +317,128 @@ public sealed class ConfigurationDefaultsTests
         var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
 
         diagnostics.Should().BeEmpty();
-        output.Should().Contain("createdAt: DateTime;");
+        output.Should().Contain("createdAt: DateTime = DateTime.now();");
+    }
+
+    [Fact]
+    public void ConfiguredDateInitializerFlowsIntoCompiledTypeDefaultHelper()
+    {
+        var metadata = CreateDateMetadata();
+        var diagnostics = new List<GenerationDiagnostic>();
+        var document = TemplateDocument.Parse(
+            template: new TemplateFile(
+                Path: Path.Combine(path1: Path.GetTempPath(), path2: "compiled-date-default.tst"),
+                Content: """
+                         ${
+                             Template(Settings settings)
+                             {
+                                 settings.UseDateType("Dayjs");
+                                 settings.UseDateInitializer("dayjs()");
+                             }
+
+                             string Initializer(Type type)
+                             {
+                                 return type.Default();
+                             }
+                         }
+                         // output: compiled-date-default.ts
+                         $Classes[$Properties[$name: $Type = $Type[$Initializer];]]
+                         """),
+            diagnostics: diagnostics);
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        diagnostics.Should().BeEmpty();
+        output.Should().Contain("createdAt: Dayjs = dayjs();");
+    }
+
+    [Fact]
+    public void TemplateOverrideUsesConfiguredDateOnlyAndTimeOnlyTypesAndInitializers()
+    {
+        var metadata = CreateDateOnlyTimeOnlyMetadata();
+        var diagnostics = new List<GenerationDiagnostic>();
+        var document = TemplateDocument.Parse(
+            template: new TemplateFile(
+                Path: Path.Combine(path1: Path.GetTempPath(), path2: "configured-date-only-time-only.tst"),
+                Content: """
+                         ${
+                             Template(Settings settings)
+                             {
+                                 settings.UseDateOnlyType("Temporal.PlainDate");
+                                 settings.UseDateOnlyInitializer("Temporal.Now.plainDateISO()");
+                                 settings.UseTimeOnlyType("Temporal.PlainTime");
+                                 settings.UseTimeOnlyInitializer("Temporal.Now.plainTimeISO()");
+                             }
+
+                             string Initializer(Type type)
+                             {
+                                 return type.Default();
+                             }
+                         }
+                         // output: configured-date-only-time-only.ts
+                         $Classes[$Properties[$name: $Type = $Type[$Initializer];]]
+                         """),
+            diagnostics: diagnostics);
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        diagnostics.Should().BeEmpty();
+        output.Should().Contain("birthDate: Temporal.PlainDate = Temporal.Now.plainDateISO();");
+        output.Should().Contain("startsAt: Temporal.PlainTime = Temporal.Now.plainTimeISO();");
+        output.Should().Contain("localDate: Temporal.PlainDate = Temporal.Now.plainDateISO();");
+        output.Should().Contain("localTime: Temporal.PlainTime = Temporal.Now.plainTimeISO();");
+    }
+
+    [Fact]
+    public void RenderUsesConfiguredQuoteStyleForDefaultTimeOnlyInitializer()
+    {
+        var metadata = CreateDateOnlyTimeOnlyMetadata();
+        var document = new TemplateDocument(Path: "models.tst", Content: "$Classes[$Properties[$name = $Type[$Default];]]", OutputPath: "models.ts");
+        var diagnostics = new List<GenerationDiagnostic>();
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+        var defaults = TemplateRenderDefaults.FromConfiguration(
+            configuration: CreateConfiguration(strictNull: true, quoteStyle: QuoteStyle.Single));
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics, defaults: defaults);
+
+        diagnostics.Should().BeEmpty();
+        output.Should().Contain("startsAt = '00:00:00';");
+        output.Should().Contain("localTime = '00:00:00';");
+    }
+
+    [Fact]
+    public void CompiledTypeDefaultUsesConfiguredQuoteStyleForDefaultTimeOnlyInitializer()
+    {
+        var metadata = CreateDateOnlyTimeOnlyMetadata();
+        var diagnostics = new List<GenerationDiagnostic>();
+        var document = TemplateDocument.Parse(
+            template: new TemplateFile(
+                Path: Path.Combine(path1: Path.GetTempPath(), path2: "compiled-time-only-default.tst"),
+                Content: """
+                         ${
+                             Template(Settings settings)
+                             {
+                                 settings.UseStringLiteralCharacter('\'');
+                             }
+
+                             string Defaults(Type type)
+                             {
+                                 return type.Default() + "|" + type.DefaultValue;
+                             }
+                         }
+                         // output: compiled-time-only-default.ts
+                         $Classes[$Properties[$name=$Type[$Defaults];]]
+                         """),
+            diagnostics: diagnostics);
+        var renderer = new TemplateRenderer(typeMapper: new TypeScriptTypeMapper());
+
+        var output = renderer.Render(template: document, metadata: metadata, diagnostics: diagnostics);
+
+        diagnostics.Should().BeEmpty();
+        output.Should().Contain("startsAt='00:00:00'|'00:00:00';");
+        output.Should().Contain("localTime='00:00:00'|'00:00:00';");
     }
 
     [Fact]
@@ -381,6 +624,12 @@ public sealed class ConfigurationDefaultsTests
         string encoding = "utf-8",
         QuoteStyle quoteStyle = QuoteStyle.Double,
         string dateType = "Date",
+        string dateInitializer = "new Date()",
+        string dateOnlyType = "Date",
+        string dateOnlyInitializer = "new Date()",
+        string timeOnlyType = "string",
+        string timeOnlyInitializer = "\"00:00:00\"",
+        string guidType = "string",
         string decimalType = "number") =>
         TypewriterConfiguration.Default with
         {
@@ -390,6 +639,12 @@ public sealed class ConfigurationDefaultsTests
                 Encoding = encoding,
                 QuoteStyle = quoteStyle,
                 DateType = dateType,
+                DateInitializer = dateInitializer,
+                DateOnlyType = dateOnlyType,
+                DateOnlyInitializer = dateOnlyInitializer,
+                TimeOnlyType = timeOnlyType,
+                TimeOnlyInitializer = timeOnlyInitializer,
+                GuidType = guidType,
                 DecimalType = decimalType,
             },
         };
@@ -528,6 +783,76 @@ public sealed class ConfigurationDefaultsTests
                     IsNullableAware: true),
             ],
             Diagnostics: []);
+    }
+
+    private static ProjectMetadata CreateDateOnlyTimeOnlyMetadata()
+    {
+        var dateOnlyType = new TypeMetadataReference(
+            Name: "DateOnly",
+            FullName: "System.DateOnly",
+            Namespace: "System",
+            IsNullable: false,
+            IsCollection: false,
+            IsDictionary: false,
+            IsEnum: false,
+            IsPrimitive: false,
+            IsDateLike: true,
+            ElementType: null,
+            TypeArguments: []);
+        var timeOnlyType = dateOnlyType with
+        {
+            Name = "TimeOnly",
+            FullName = "System.TimeOnly",
+        };
+        var localDateType = dateOnlyType with
+        {
+            Name = "LocalDate",
+            FullName = "NodaTime.LocalDate",
+            Namespace = "NodaTime",
+        };
+        var localTimeType = dateOnlyType with
+        {
+            Name = "LocalTime",
+            FullName = "NodaTime.LocalTime",
+            Namespace = "NodaTime",
+        };
+        return new ProjectMetadata(
+            ProjectPath: "Sample.csproj",
+            SourceFiles: [],
+            Types:
+            [
+                new TypeMetadata(
+                    Name: "Schedule",
+                    FullName: "Sample.Schedule",
+                    Namespace: "Sample",
+                    Kind: TypeMetadataKind.Class,
+                    Accessibility: MetadataAccessibility.Public,
+                    Properties:
+                    [
+                        CreateProperty(name: "BirthDate", type: dateOnlyType),
+                        CreateProperty(name: "StartsAt", type: timeOnlyType),
+                        CreateProperty(name: "LocalDate", type: localDateType),
+                        CreateProperty(name: "LocalTime", type: localTimeType),
+                    ],
+                    Attributes: [],
+                    BaseTypes: [],
+                    EnumValues: [],
+                    IsNullableAware: true),
+            ],
+            Diagnostics: []);
+
+        static PropertyMetadata CreateProperty(
+            string name,
+            TypeMetadataReference type) =>
+            new(
+                Name: name,
+                FullName: "Sample.Schedule." + name,
+                Type: type,
+                Accessibility: MetadataAccessibility.Public,
+                HasGetter: true,
+                HasSetter: true,
+                IsRequired: false,
+                Attributes: []);
     }
 
     private static ProjectMetadata CreateDecimalMetadata()

--- a/tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/TemplateRendererTests.cs
@@ -2409,6 +2409,49 @@ public sealed class TemplateRendererTests
     }
 
     [Fact]
+    public void TypeScriptMapperUsesSeparateDateOnlyAndTimeOnlyOverrides()
+    {
+        var mapper = new TypeScriptTypeMapper();
+        var dateOnlyType = TypeReference(name: "DateOnly", fullName: "System.DateOnly", isNullable: false, isPrimitive: false, isDateLike: true);
+        var timeOnlyType = TypeReference(name: "TimeOnly", fullName: "System.TimeOnly", isNullable: false, isPrimitive: false, isDateLike: true);
+        var localDateType = TypeReference(name: "LocalDate", fullName: "NodaTime.LocalDate", isNullable: false, isPrimitive: false);
+        var localTimeType = TypeReference(name: "LocalTime", fullName: "NodaTime.LocalTime", isNullable: false, isPrimitive: false);
+
+        mapper.Map(type: dateOnlyType).Should().Be("Date");
+        mapper.Map(type: timeOnlyType).Should().Be("string");
+        mapper.Map(type: dateOnlyType, strictNull: true, dateType: "DateTime", dateOnlyType: "LocalDate", timeOnlyType: "LocalTime").Should().Be("LocalDate");
+        mapper.Map(type: timeOnlyType, strictNull: true, dateType: "DateTime", dateOnlyType: "LocalDate", timeOnlyType: "LocalTime").Should().Be("LocalTime");
+        mapper.Map(type: localDateType, strictNull: true, dateType: "DateTime", dateOnlyType: "LocalDate", timeOnlyType: "LocalTime").Should().Be("LocalDate");
+        mapper.Map(type: localTimeType, strictNull: true, dateType: "DateTime", dateOnlyType: "LocalDate", timeOnlyType: "LocalTime").Should().Be("LocalTime");
+    }
+
+    [Fact]
+    public void TypeScriptMapperUsesStringForGuidByDefaultAndAllowsGuidTypeOverride()
+    {
+        var mapper = new TypeScriptTypeMapper();
+        var guidType = TypeReference(name: "Guid", fullName: "System.Guid", isNullable: false);
+        var nullableGuidType = guidType with
+        {
+            IsNullable = true,
+        };
+
+        mapper.Map(type: guidType).Should().Be("string");
+        mapper.Map(type: guidType, strictNull: true, dateType: "Date", guidType: "uuid").Should().Be("uuid");
+        mapper.Map(type: nullableGuidType, strictNull: true, dateType: "Date", guidType: "uuid").Should().Be("uuid | null");
+
+        var dictionaryType = TypeReference(
+            name: "Dictionary",
+            fullName: "System.Collections.Generic.Dictionary",
+            isNullable: false,
+            isPrimitive: false,
+            isCollection: true,
+            isDictionary: true,
+            elementType: TypeReference(name: "KeyValuePair", fullName: "System.Collections.Generic.KeyValuePair", isNullable: false, isPrimitive: false),
+            typeArguments: [guidType, TypeReference(name: "String", fullName: "System.String", isNullable: false)]);
+        mapper.Map(type: dictionaryType, strictNull: true, dateType: "Date", guidType: "uuid").Should().Be("Record<uuid, string>");
+    }
+
+    [Fact]
     public void TypeScriptMapperMapsNumericPrimitivesToNumberAndAllowsDecimalOverride()
     {
         var mapper = new TypeScriptTypeMapper();

--- a/tests/unit/Typewriter.Engine.Tests/TypewriterConfigurationLoaderTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/TypewriterConfigurationLoaderTests.cs
@@ -75,6 +75,12 @@ public sealed class TypewriterConfigurationLoaderTests
                               "trimTrailingWhitespace": true,
                               "quoteStyle": "backtick",
                               "dateType": "Dayjs",
+                              "dateInitializer": "dayjs()",
+                              "dateOnlyType": "LocalDate",
+                              "dateOnlyInitializer": "LocalDate.now()",
+                              "timeOnlyType": "LocalTime",
+                              "timeOnlyInitializer": "LocalTime.now()",
+                              "guidType": "uuid",
                               "decimalType": "Decimal"
                             }
                           }
@@ -91,6 +97,12 @@ public sealed class TypewriterConfigurationLoaderTests
             configuration.Output.TrimTrailingWhitespace.Should().BeTrue();
             configuration.Output.QuoteStyle.Should().Be(QuoteStyle.Backtick);
             configuration.Output.DateType.Should().Be("Dayjs");
+            configuration.Output.DateInitializer.Should().Be("dayjs()");
+            configuration.Output.DateOnlyType.Should().Be("LocalDate");
+            configuration.Output.DateOnlyInitializer.Should().Be("LocalDate.now()");
+            configuration.Output.TimeOnlyType.Should().Be("LocalTime");
+            configuration.Output.TimeOnlyInitializer.Should().Be("LocalTime.now()");
+            configuration.Output.GuidType.Should().Be("uuid");
             configuration.Output.DecimalType.Should().Be("Decimal");
         }
         finally

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typewriter-vscode",
-  "version": "4.5.4",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typewriter-vscode",
-      "version": "4.5.4",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^10.0.1"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typewriter-vscode",
   "displayName": "Typewriter",
   "description": "VS Code adapter for Typewriter .tst templates.",
-  "version": "4.5.4",
+  "version": "4.6.0",
   "publisher": "adaskothebeast",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
This pull request updates the project to version 4.6.0 and introduces significant improvements to type mapping, especially for temporal types (dates and times) and GUIDs. The documentation (`README.md`) is extensively updated to describe the new configuration options, recommended mappings, and usage patterns. Build and packaging scripts are also updated to reflect the new version.

**Type Mapping and Documentation Improvements**

* Added configurable type and initializer mappings for `DateTime`, `DateOnly`, `TimeOnly`, NodaTime types, `Guid`, and `decimal` in generated TypeScript models, with new config options and detailed documentation/examples in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R95) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R116-R118) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R130-R134) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R317-R322) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L337-R366) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L359-R393) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R403-R424) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R498-R508) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R518) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L530-R584) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R596-R618)
* Added recommended semantic mappings and runtime conversion guidance for temporal types, including a new table for C#/NodaTime to TypeScript shape recommendations and best practices.

**Configuration and Environment Variables**

* Documented new configuration properties and environment variables for date/time/guid type and initializer settings, including `output.dateType`, `output.dateInitializer`, `output.dateOnlyType`, `output.dateOnlyInitializer`, `output.timeOnlyType`, `output.timeOnlyInitializer`, and `output.guidType`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L337-R366) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R720-R725)

**Build and Packaging Updates**

* Bumped the project version to `4.6.0` in `Directory.Build.props` and updated the artifact/package naming in the CI workflow to match the new version. (.github/workflows/ci.yml, [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL14-R14) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL94-R95)

**General Documentation Enhancements**

* Added guidance on uninstalling previous Visual Studio extensions before installing the new VSIX, and clarified installation steps.
* Improved changelog and feature highlights, including new post-4.0 upgrades and reliability fixes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R130-R134)

These changes collectively make type mapping more flexible and explicit, improve onboarding for new users, and ensure the documentation reflects the latest capabilities.