### PR TITLE
Feature/better intellisense

### DIFF
--- a/Build-RiderPluginWithTools.ps1
+++ b/Build-RiderPluginWithTools.ps1
@@ -117,12 +117,17 @@ function Add-DirectoryToZip {
         [string] $SourceDirectory,
 
         [Parameter(Mandatory = $true)]
-        [string] $EntryPrefix
+        [string] $EntryPrefix,
+
+        [switch] $KeepTypewriterXmlDocFiles
     )
 
     $resolvedSourceDirectory = (Resolve-Path -LiteralPath $SourceDirectory).Path
     $files = Get-ChildItem -LiteralPath $resolvedSourceDirectory -Recurse -File |
-        Where-Object { $_.Extension -notin @(".pdb", ".xml") }
+        Where-Object {
+            $_.Extension -notin @(".pdb", ".xml") -or
+            ($KeepTypewriterXmlDocFiles -and $_.Name -like "Typewriter.*.xml")
+        }
 
     foreach ($file in $files) {
         $relativePath = [System.IO.Path]::GetRelativePath($resolvedSourceDirectory, $file.FullName).Replace("\", "/")
@@ -182,7 +187,8 @@ try {
     }
 
     Add-DirectoryToZip $zip $cliPublishDir "typewriter-rider/tools/typewriter-cli"
-    Add-DirectoryToZip $zip $languageServerPublishDir "typewriter-rider/tools/typewriter-lsp"
+    # XML doc files are required so Roslyn hover in .tst C# blocks can show doc comments.
+    Add-DirectoryToZip $zip $languageServerPublishDir "typewriter-rider/tools/typewriter-lsp" -KeepTypewriterXmlDocFiles
 }
 finally {
     $zip.Dispose()
@@ -211,6 +217,8 @@ try {
         "typewriter-rider/tools/typewriter-lsp/Typewriter.LanguageServer.dll",
         "typewriter-rider/tools/typewriter-lsp/Typewriter.LanguageServer.deps.json",
         "typewriter-rider/tools/typewriter-lsp/Typewriter.LanguageServer.runtimeconfig.json",
+        "typewriter-rider/tools/typewriter-lsp/Typewriter.Engine.xml",
+        "typewriter-rider/tools/typewriter-lsp/Typewriter.Abstractions.xml",
         "typewriter-rider/tools/typewriter-lsp/Buildalyzer.Logger.dll",
         "typewriter-rider/tools/typewriter-lsp/Buildalyzer.Logger/net472/Buildalyzer.Logger.dll"
     )) {

--- a/Build-VSCodeExtension.ps1
+++ b/Build-VSCodeExtension.ps1
@@ -108,12 +108,17 @@ function Add-DirectoryToZip {
         [string] $SourceDirectory,
 
         [Parameter(Mandatory = $true)]
-        [string] $EntryPrefix
+        [string] $EntryPrefix,
+
+        [switch] $KeepTypewriterXmlDocFiles
     )
 
     $resolvedSourceDirectory = (Resolve-Path -LiteralPath $SourceDirectory).Path
     $files = Get-ChildItem -LiteralPath $resolvedSourceDirectory -Recurse -File |
-        Where-Object { $_.Extension -notin @(".pdb", ".xml") }
+        Where-Object {
+            $_.Extension -notin @(".pdb", ".xml") -or
+            ($KeepTypewriterXmlDocFiles -and $_.Name -like "Typewriter.*.xml")
+        }
 
     foreach ($file in $files) {
         $relativePath = [System.IO.Path]::GetRelativePath($resolvedSourceDirectory, $file.FullName).Replace("\", "/")
@@ -192,7 +197,8 @@ try {
     }
 
     Add-DirectoryToZip $packageArchive $cliPublishDir "extension/tools/typewriter-cli"
-    Add-DirectoryToZip $packageArchive $languageServerPublishDir "extension/tools/typewriter-lsp"
+    # XML doc files are required so Roslyn hover in .tst C# blocks can show doc comments.
+    Add-DirectoryToZip $packageArchive $languageServerPublishDir "extension/tools/typewriter-lsp" -KeepTypewriterXmlDocFiles
 }
 finally {
     $packageArchive.Dispose()
@@ -213,6 +219,8 @@ try {
         "extension/tools/typewriter-lsp/Typewriter.LanguageServer.dll",
         "extension/tools/typewriter-lsp/Typewriter.LanguageServer.deps.json",
         "extension/tools/typewriter-lsp/Typewriter.LanguageServer.runtimeconfig.json",
+        "extension/tools/typewriter-lsp/Typewriter.Engine.xml",
+        "extension/tools/typewriter-lsp/Typewriter.Abstractions.xml",
         "extension/tools/typewriter-lsp/Buildalyzer.Logger.dll",
         "extension/tools/typewriter-lsp/Buildalyzer.Logger/net472/Buildalyzer.Logger.dll"
     )) {

--- a/Build-VisualStudioVsix.ps1
+++ b/Build-VisualStudioVsix.ps1
@@ -97,6 +97,8 @@ try {
         "tools/typewriter-lsp/Typewriter.LanguageServer.dll",
         "tools/typewriter-lsp/Typewriter.LanguageServer.deps.json",
         "tools/typewriter-lsp/Typewriter.LanguageServer.runtimeconfig.json",
+        "tools/typewriter-lsp/Typewriter.Engine.xml",
+        "tools/typewriter-lsp/Typewriter.Abstractions.xml",
         "tools/typewriter-lsp/Buildalyzer.Logger.dll",
         "tools/typewriter-lsp/Buildalyzer.Logger/net472/Buildalyzer.Logger.dll"
     )) {

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
   - [✨ Why Typewriter?](#-why-typewriter)
   - [🚀 Why This Version Beats the Classic VS Extension](#-why-this-version-beats-the-classic-vs-extension)
     - [New goodies at a glance](#new-goodies-at-a-glance)
+  - [🧠 Template IntelliSense: What Changed and Where It Works](#-template-intellisense-what-changed-and-where-it-works)
+    - [IDE support matrix](#ide-support-matrix)
   - [📦 What Is in the Box](#-what-is-in-the-box)
   - [🚦 Quick Start (5 Minutes to Generated Code)](#-quick-start-5-minutes-to-generated-code)
     - [1️⃣ Choose your IDE plugin or dotnet tool](#1️⃣-choose-your-ide-plugin-or-dotnet-tool)
@@ -136,6 +138,32 @@ The previous [`AdaskoTheBeAsT/Typewriter`](https://github.com/AdaskoTheBeAsT/Typ
 - **Modern C# metadata**: Roslyn metadata covers records, nullable reference types, generics, tuples, doc comments, attributes, static constants, static readonly fields, events, delegates, nested types, and Web API helpers.
 - **Web API hardening**: route helpers ignore named-only HTTP attribute arguments, honor `Template = "..."`, and safely encode nullable string/date query values.
 - **Recipe-backed compatibility**: real Angular/React recipes from `NetCoreTypewriterRecipes` are snapshot-tested so old-template support improves against production templates, not toy examples.
+
+---
+
+## 🧠 Template IntelliSense: What Changed and Where It Works
+
+The classic VS extension offered basic completion inside `.tst` files. This version moves all template intelligence into the shared Language Server, then layers real compiler services on top. Concretely, editing a `.tst` file now gives you:
+
+- **Documented template members.** Completion and hover for `$Classes`, `$Properties`, `$BaseClass`, `$Fields`, `$DocComment`, `$IsNullable`, filters, and the rest of the template dialect include a description of what each member returns, so you no longer need to guess what `$BaseClass` or `$Value` means for the current context.
+- **Real Roslyn IntelliSense inside `${ ... }` C# helper blocks.** Helper code is projected into a virtual C# document analyzed by an in-process Roslyn workspace: member completion, hover, and go-to-definition work against the actual `Typewriter.CodeModel` API. The whole code model is XML-documented, so hovering `.BaseClass` on a `Class` explains "the direct base class this class inherits from, or null when the class inherits only from object" instead of showing a bare signature.
+- **Workspace-aware completions.** Type names, properties, methods, constants, and enum values from *your* loaded C# projects are offered while writing template blocks and lambda filters, with details such as `Property UserModel.CreatedAt: DateTime`.
+- **Forwarding to full language services (VS Code).** Through virtual documents (`typewriter/embeddedDocument`, `typewriter/embeddedPosition`, `typewriter/templateRange` LSP requests), C# helper blocks are forwarded to the installed C# extension and TypeScript output regions to the built-in TypeScript service, and results are mapped back to `.tst` positions. Controlled by `typewriter.embeddedLanguages.forwarding` (`"auto"` by default, `"off"` to keep only the built-in Typewriter IntelliSense).
+- **Live everything.** Diagnostics, semantic highlighting for Typewriter/C#/TypeScript regions, go-to-definition into your C# sources, and go-to-generated-file all update as you type, backed by the same engine that generates the output.
+
+### IDE support matrix
+
+| Capability                                                            | 💜 VS Code | 🟣 Visual Studio 2026 | 🧠 Rider |
+| --------------------------------------------------------------------- | :--------: | :-------------------: | :------: |
+| Template member completion, hover, and docs (`$BaseClass`, ...)       |     ✅      |    ✅ (LSP client)     |    ✅ (LSP client) |
+| Roslyn IntelliSense in `${ ... }` C# helper blocks (built-in)          |     ✅      |           ✅           |    ✅ (LSP client) |
+| Project-aware IntelliSense (your types in helper blocks)               |     ✅      |           ✅           |    ✅ (LSP client) |
+| Forwarding to installed C# / TypeScript language services              |     ✅      |          🚧           |    🚧     |
+| Semantic highlighting of template / C# / TypeScript regions            |     ✅      |   ✅ (classification)  |    ✅ (LSP) |
+| Live diagnostics in the editor                                        |     ✅      |    ✅ (Error List)     |    ✅ (LSP) |
+| Generate / validate on save                                           |     ✅      |           ✅           |    ✅     |
+
+**Will this work in VS, VS Code, and Rider?** Yes. All three IDEs now share the same language server, so template member IntelliSense (documented completions and hover for `$BaseClass`, `$Properties`, ...), real Roslyn IntelliSense inside `${ ... }` C# helper blocks (with XML doc tooltips and project-aware type completions), live diagnostics, and go-to-definition work identically in VS Code, Visual Studio 2026, and Rider. VS Code additionally forwards to the installed C# extension and built-in TypeScript service through virtual documents (`typewriter.embeddedLanguages.forwarding`), which is VS Code client-side code that could be replicated in VS and Rider later. Rider enables the LSP client via the built-in IntelliJ Platform LSP API; toggle it in Settings under Typewriter.
 
 ---
 
@@ -1080,6 +1108,8 @@ Diagnostics land in the **Error List**, logs in the **Output** window, and `.tst
 ### 🧠 JetBrains Rider
 
 Frontend plugin in [`rider/`](rider) ([plugin README](rider/README.md)). It is an IntelliJ Platform plugin written in Kotlin for Rider UI concerns: `.tst` file recognition, syntax highlighting, **Tools → Typewriter** actions, project settings, and save-time generation/validation through the CLI.
+
+The plugin also registers the Typewriter language server through the IntelliJ Platform LSP API, giving Rider the same IntelliSense as VS Code and Visual Studio: template member completion and hover with documentation, real Roslyn IntelliSense inside `${ ... }` C# helper blocks (including project-aware type completions), live diagnostics, and go-to-definition. Toggle it under **Settings → Typewriter → Enable language server IntelliSense** (enabled by default).
 
 This is not a ReSharper backend plugin. Deep C# semantic loading remains in the shared Typewriter CLI/Roslyn engine, so the Rider plugin can stay thin unless future Rider-native inspections or refactorings require a C# backend.
 

--- a/plan2026-07-02.md
+++ b/plan2026-07-02.md
@@ -1,0 +1,345 @@
+# Typewriter Development Plan 2026-07-02
+
+Scope: the four verified gaps from the 2026-07-02 code audit (points 2-5), plus a
+gap analysis against the legacy codebase preserved on branch `feature/master-origin`.
+
+All statements below were verified against code on `master` as of 2026-07-02, not
+only against the markdown roadmap files.
+
+---
+
+## Point 2: Embedded C#/TypeScript Language-Service Forwarding
+
+### Current state (verified)
+
+- `src/Typewriter.LanguageServer` already has an embedded-region model:
+  `TemplateEmbeddedLanguage.cs`, `EmbeddedLanguageKind.cs`, `EmbeddedLanguageRegion.cs`,
+  `EmbeddedSpanMapping.cs`, `EmbeddedCSharpDocument.cs`, and
+  `EmbeddedCSharpLanguageService.cs` (own Roslyn-based completions for helper blocks).
+- Semantic tokens for Typewriter/C#/TypeScript regions exist
+  (`TemplateSemanticTokenService.cs`).
+- `vscode/src/extension.js` has no `TextDocumentContentProvider`, no virtual
+  documents, and no forwarding to the C# extension or the built-in TypeScript
+  service.
+
+### Goal
+
+Full IntelliSense (completion, hover, signature help, diagnostics, definitions,
+semantic tokens) inside `${ ... }` C# helper blocks and TypeScript output regions,
+by forwarding to real language services through virtual documents, never by
+reimplementing C# or TypeScript analysis.
+
+### Implementation steps
+
+1. Harden the region model (language server).
+   - Extend `TemplateEmbeddedLanguage` to emit stable virtual-document snapshots
+     per open `.tst` file: one C# virtual document (helper blocks stitched into
+     the existing `EmbeddedCSharpDocument` shadow class) and one TypeScript
+     virtual document (template output text with Typewriter `$...` expressions
+     replaced by placeholder identifiers of identical length to keep columns stable).
+   - Reuse `EmbeddedSpanMapping` for bidirectional position translation; add
+     round-trip unit tests in `Typewriter.LanguageServer.Tests` for multi-block
+     templates, CRLF content, and `${env.x}` TypeScript template-literal
+     interpolation (must stay TypeScript, not C#).
+
+2. Add custom LSP requests to expose virtual content.
+   - New requests in `LanguageServerHost`: `typewriter/embeddedDocument`
+     (returns virtual content + version for a `.tst` URI and kind) and
+     `typewriter/mapPosition` (tst position -> virtual position and back).
+   - Push `typewriter/embeddedDocumentChanged` notifications on didChange so the
+     client can refresh virtual docs incrementally.
+
+3. VS Code virtual-document providers (client side).
+   - Register `workspace.registerTextDocumentContentProvider` for two schemes,
+     e.g. `typewriter-cs:` and `typewriter-ts:`, backed by the new LSP request.
+   - Give virtual docs proper extensions (`...tst.g.cs`, `...tst.g.ts`) so the
+     C# extension and built-in TypeScript features pick them up automatically.
+
+4. Forward requests via `vscode.commands.executeCommand`.
+   - In middleware for the `.tst` language client (or plain provider
+     registrations), translate the position with `typewriter/mapPosition`, then call:
+     `vscode.executeCompletionItemProvider`, `vscode.executeHoverProvider`,
+     `vscode.executeSignatureHelpProvider`, `vscode.executeDefinitionProvider`
+     against the virtual URI, and map ranges in results back to the `.tst` document.
+   - Merge results: Typewriter template completions stay authoritative for
+     `$...` expressions; embedded results are used only when the cursor maps
+     into a C# helper block or TypeScript output region
+     (`EmbeddedLanguageKind` decides).
+
+5. Diagnostics mapping.
+   - Subscribe to `vscode.languages.onDidChangeDiagnostics` for the virtual URIs,
+     translate ranges back, and publish merged diagnostics under the `.tst` URI
+     (drop diagnostics that map into synthesized glue code).
+
+6. Fallback behavior.
+   - If no C# extension or TS provider responds, keep the current
+     `EmbeddedCSharpLanguageService` results (already working today). Guard with a
+     setting `typewriter.embeddedLanguages.forwarding: "auto" | "off"`.
+
+7. Visual Studio and Rider.
+   - Out of scope for the first PR; keep the LSP-side requests host-neutral so
+     the Rider plugin and a future VS LSP client can reuse them.
+
+### Tests / acceptance
+
+- Round-trip mapping unit tests; completion/hover/diagnostic integration tests
+  in `vscode` (extension test host) for one sample template.
+- Embedded diagnostics point at correct `.tst` line/column.
+- `${environment.apiBaseUrl}` output remains untouched by C# forwarding.
+
+Estimated size: 3-4 PRs (region hardening, LSP requests, VS Code providers +
+forwarding, diagnostics merge).
+
+---
+
+## Point 3: Performance - Metadata Cache Validation and Syntax-Tree Reuse
+
+### Current state (verified in `src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs`)
+
+- `MetadataCache` (`ConcurrentDictionary<ProjectMetadataCacheKey, ProjectMetadataCacheEntry>`)
+  stores results, but every cache hit recomputes a full fingerprint hash over all
+  tracked paths and directories (`ProjectMetadataCacheEntry.IsValid` calls
+  `ComputeFingerprintHash(paths, directories)` around line 1820). Large repos pay
+  a big stat/hash cost just to prove nothing changed.
+- On any miss, all sources are re-read and re-parsed serially:
+  `CSharpSyntaxTree.ParseText(...)` in a loop (~line 188-196). No `SourceText` or
+  `SyntaxTree` reuse exists.
+- `perf-opt.md` marks these as Pending: "Metadata cache validation" (P0) and
+  "Source text and syntax-tree reuse" (P1); measured numbers show metadata load
+  dominates cold runs (2,293 ms of 2,313 ms on SimpleApi).
+
+### Implementation steps
+
+1. Precise per-file stamps instead of one broad hash.
+   - Replace the single fingerprint hash with a manifest:
+     `IReadOnlyDictionary<string, FileStamp>` (path -> length + lastWriteTimeUtc)
+     for sources, project files, props/targets, assets/lock files, and
+     additional inputs; plus a small set of directory stamps only where globs
+     require them.
+   - Validation compares stamps per file and short-circuits on first difference;
+     record the invalidation reason for the perf counters requested by
+     perf-opt Phase 0.
+
+2. Watcher-driven dirty paths.
+   - Add `IMetadataCacheInvalidation` (in `Typewriter.Roslyn` or Abstractions):
+     `MarkDirty(string fullPath)`.
+   - CLI watch (`typewriter watch`) and the language-server workspace generation
+     service feed changed paths into it. A cache entry with no dirty paths since
+     last validation is accepted without any filesystem stat; entries with dirty
+     paths validate only those paths.
+   - Non-watch invocations (one-shot CLI) fall back to the per-file stamp
+     manifest check.
+
+3. `SourceText`/`SyntaxTree` cache.
+   - New bounded cache keyed by `(fullPath, parseOptionsChecksum, length, lastWriteTimeUtc)`
+     storing the parsed `SyntaxTree`.
+   - On metadata rebuild, reuse trees for unchanged files and parse only changed
+     files; rebuild the `CSharpCompilation` from the mixed tree set
+     (`compilation.ReplaceSyntaxTree` when an existing compilation is cached,
+     otherwise `Create` with reused trees).
+   - Parse changed files in parallel (`Parallel.ForEachAsync`), preserving the
+     current deterministic ordering of `syntaxTrees` by source path.
+
+4. Type-reference graph cache (perf-opt P1, same file).
+   - Per-compilation `Dictionary<(ITypeSymbol, NullableAnnotation), TypeMetadataReference>`
+     with an in-progress sentinel to break cycles (the pooled
+     `TypeReferenceVisitedSymbolSets` guard stays as a backstop).
+
+5. Guardrails.
+   - Keep `TrimMetadataCache` bounds; add counters (hits, misses, stat-validated
+     hits, dirty-path-validated hits) behind `TYPEWRITER_TRACE_PERF`.
+   - Snapshot tests must produce byte-identical output before/after; add a
+     regression test that edits one file in a two-file project and asserts only
+     one file is re-parsed (via an injectable parse hook or counter).
+
+### Acceptance
+
+- Repeated watch/LSP generation with no changes performs zero source re-parsing
+  and no full-tree stat storm.
+- One-file change re-parses exactly one file.
+- All 265 existing tests and snapshots pass unchanged.
+
+Estimated size: 3 PRs (stamp manifest + counters, watcher dirty-path feed,
+syntax-tree reuse + type-reference cache).
+
+---
+
+## Point 4: Shared WebApi/Service Helper Extension Library
+
+### Current state (verified)
+
+- `src/Typewriter.Engine/Extensions/` contains only `Documentation`, `Types`
+  (`ClassName()`, `Default()`, `Unwrap()`), and `WebApi` (`HttpMethodExtensions`,
+  `UrlExtensions`, `RequestDataExtensions`).
+- No shared implementations exist for the recipe helpers repeated across
+  `NetCoreTypewriterRecipes` templates: `MethodName`, `ReturnType`, `Imports`,
+  `SkipParameters`, `GetPropertyName`, discriminator/JsonDerivedType helpers,
+  enum helpers, naming helpers.
+
+### Implementation steps
+
+Add new static extension classes under `src/Typewriter.Engine/Extensions/`,
+namespaced to match the legacy convention (`Typewriter.Extensions.*`) so template
+`using` lines work in compiled helper blocks. Recommended grouping and order
+(each family lands with recipe-backed snapshot tests before templates are
+migrated):
+
+1. `Extensions/Naming/NamingExtensions.cs`
+   - `ServiceName(Class)`, `ConstName(Class)`, `ParentServiceName(Method)`,
+     `ParentConstName(Method)`, `UrlFieldName(Class)`, `UrlFieldName(Method)`,
+     `MethodName(Method)` (CustomName* attributes + non-CancellationToken
+     parameter type suffixes), `HookNameQuery(Method)`, `HookNameMutation(Method)`.
+   - Backed by existing `NameCaseFormatter`; add acronym-aware camel casing from
+     Point 5 first so names like `URLValue` match legacy output.
+
+2. `Extensions/WebApi/ActionExtensions.cs`
+   - `GetActionNameByAttribute(Method, string)`, per-verb
+     `Http{Get,Post,Put,Delete}ActionNameByAttribute(Method)`,
+     `Is{Get,Post,Put,Delete}Method(Method)`, `IsPostMethodWithResult`,
+     `IsPutMethodWithResult`, `IsGetOrDeleteMethod(Class)`, `GetRouteValue(Class)`
+     (controller placeholder replacement, class-level Route fallback).
+   - Reuse route logic already in `UrlExtensions`/`HttpMethodExtensions`; do not
+     duplicate verb detection.
+
+3. `Extensions/WebApi/ParameterExtensions.cs`
+   - `GetParameterValue(Parameter)`, `SkipParameters(Method)`,
+     `SkipParametersForBody(Method)`, `ContainsSkipParameters`,
+     `NotContainsSkipParameters`, `ContainsOneSkipParameters`,
+     `ContainsMoreSkipParameters`, `IsPrimitive(Parameter)`,
+     `IsDictionary(Parameter)`, `IsDictionary(string)`, `NameOfType(Type)`.
+   - Return `ParameterCollection` so results feed nested template blocks
+     (`$SkipParameters[$name: $Type][, ]` already works with CodeModel
+     collections returned from helpers).
+
+4. `Extensions/WebApi/ReturnTypeExtensions.cs`
+   - `ReturnType(Method)` with `ProducesResponseType` parsing and
+     `Task`/`ActionResult`/`IActionResult` unwrapping (reuse `Unwrap()`),
+     `SkipReturnType(string)`, `Imports(Class)` (model import discovery from
+     return types, ProducesResponseType attributes, parameters, dictionaries,
+     enums). Introduce a small shared result record if structured data is needed
+     (legacy `AdvancedTypeInfo`/`NullParam` shape).
+
+5. `Extensions/Serialization/SerializationExtensions.cs`
+   - `GetPropertyName(Property)` (`JsonPropertyName`,
+     `JsonProperty(PropertyName = ...)`, `nameof(...)` parsing),
+     `GetDiscriminator(IAttributeCollection)`,
+     `GenerateTypeForInterfaceByClass/Record`, `GenerateTypeForClass/Record`,
+     `GenerateTypeForClass2/Record2` + `GenerateTypeInitFor*2`
+     (JsonDerivedType/JsonPolymorphic chains), `SanitizeDefault(Type)`,
+     `Sep(...)` overloads, `LoudName(Constant)`.
+
+6. `Extensions/Enums/EnumExtensions.cs`
+   - `IsEnumAsNumber(Enum)`, `GetAttributeValueOrReturnEnumNameIfNoAttribute(EnumValue)`,
+     `GetEnumAsStringIfItsStringable(EnumValue)`.
+
+7. Wire-up.
+   - Expose the new namespaces to compiled template helpers the same way
+     `Typewriter.Extensions.WebApi` is exposed today (verify the implicit-usings /
+     reference list in `TemplateRuntimeCompiler`).
+   - Add unit tests per family plus recipe-backed snapshots (external
+     `NetCoreTypewriterRecipes` snapshots when the sibling checkout exists,
+     mirroring the existing conditional snapshot pattern in
+     `Typewriter.SnapshotTests`).
+   - Only after snapshots are green, migrate recipe templates to the shared
+     helpers (separate repo, out of scope here).
+
+Estimated size: 5-6 PRs, one per helper family, tests-first.
+
+---
+
+## Point 5: `Typewriter.CodeModel.Helpers` Facade and `ContextAttribute` Shim
+
+### Current state (verified)
+
+- New engine already uses `namespace Typewriter.CodeModel` for the parity surface
+  (`src/Typewriter.Engine/CodeModel/*`), but there is no `static class Helpers`,
+  no `GetTypeScriptName`, `GetOriginalName`, `IsPrimitive`, and no
+  `Typewriter.CodeModel.Attributes.ContextAttribute` anywhere in `src`.
+- Legacy source of truth exists on `feature/master-origin`:
+  - `src/Typewriter/CodeModel/Helpers.cs` (acronym-aware `CamelCase`,
+    `GetTypeScriptName(ITypeMetadata, Settings)`, `GetOriginalName`, `IsPrimitive`,
+    `_primitiveTypes` map).
+  - `src/CodeModel/Attributes/ContextAttribute.cs`
+    (`[AttributeUsage(AttributeTargets.Class)]`, `Name`, `CollectionName`).
+- Current `NameCaseFormatter.ToLegacyCamelCase` only lowercases the first
+  character; legacy `Helpers.CamelCase` lowercases leading acronyms
+  (`URLValue` -> `urlValue`, `IPAddress` -> `ipAddress`).
+
+### Implementation steps
+
+1. Acronym-aware camel case first (behavioral risk).
+   - Port the legacy `CamelCase` loop into `NameCaseFormatter` as
+     `NameCase.LegacyCamelCase` (or a new `NameCase.LegacyAcronymCamelCase` if
+     changing `$name` output is deemed too risky; decide via snapshot diff).
+   - Before switching `$name`, add snapshot coverage for `URLValue`, `IPAddress`,
+     `XMLDocument` per the to_implement.md note, and diff all existing checked-in
+     snapshots. If any external recipe output changes, gate the behavior behind
+     `TypewriterConfiguration` (default legacy-accurate).
+
+2. `Typewriter.CodeModel.Helpers` facade.
+   - New file `src/Typewriter.Engine/CodeModel/Helpers.cs`:
+     `public static class Helpers` with `CamelCase(string)` delegating to the
+     acronym-aware implementation, and `GetTypeScriptName`, `GetOriginalName`,
+     `IsPrimitive` delegating to the existing TypeScript mapping
+     (`TypeScriptTypeMapper`-backed logic already used for `$Type` rendering).
+   - Signature compatibility: legacy takes `ITypeMetadata` + `Settings`; the new
+     facade should accept the parity `Typewriter.CodeModel.Type` (implicit
+     conversions already exist for compiled helpers) and the parity `Settings`.
+     Verify against legacy call sites in recipe templates before finalizing.
+   - Add compile-time and reflection tests mirroring the existing
+     "original public Typewriter.CodeModel surface" test pattern.
+
+3. `ContextAttribute` shim.
+   - New file `src/Typewriter.Engine/CodeModel/Attributes/ContextAttribute.cs`,
+     copied 1:1 from the legacy branch (sealed, class-target, `Name`,
+     `CollectionName`). Pure compile/reflection compatibility; no runtime wiring
+     unless a real template needs it.
+
+4. Consistency check.
+   - Ensure `Helpers.GetTypeScriptName` and the renderer's `$Type` output agree
+     (single shared implementation, no duplicated mapping tables). Legacy
+     `_primitiveTypes` map goes into one shared internal location.
+
+Estimated size: 2 PRs (camel-case + snapshots, facade + shim + tests).
+
+---
+
+## Gap Analysis vs `feature/master-origin` (legacy codebase)
+
+`feature/master-origin` is a strict git ancestor of `master` and holds the last
+legacy Typewriter codebase (`Typewriter.sln`, old VSIX). Nothing on that branch
+is "ahead" in git terms; the meaningful comparison is legacy features not yet
+reimplemented in the rewrite. Verified deltas:
+
+| Legacy feature (feature/master-origin) | Status in rewrite | Action |
+| --- | --- | --- |
+| `Typewriter.CodeModel.Helpers` static facade | Missing | Point 5 |
+| `Typewriter.CodeModel.Attributes.ContextAttribute` | Missing | Point 5 |
+| Acronym-aware `CamelCase` (`URLValue` -> `urlValue`) | Missing (`ToLegacyCamelCase` is lower-first only) | Point 5, step 1 |
+| VS item templates (`src/ItemTemplates`: Angular WebApiController.tst, Empty Template.tst, Models.tst + .vstemplate files) | Missing; no ItemTemplates anywhere in the new repo | Backlog: add "New Typewriter template" item templates to the VSIX (and equivalent VS Code/Rider file templates) |
+| Editor: signature help (`SignatureHelpController`) | Missing in LSP (`TemplateFeatureService` has no signatureHelp) | Add `textDocument/signatureHelp` for helper methods and template functions; cheap once Point 2 forwarding exists for C# blocks |
+| Editor: outlining/folding (`OutliningController`) | Missing (no foldingRange support) | Add `textDocument/foldingRange` for `$Collection[...]` blocks and `${ ... }` helper blocks |
+| Editor: document formatting (`FormattingController`) | Missing | Optional backlog; low demand, do after folding |
+| Editor: brace matching (`BraceMatchingController`) | Partially covered (VS Code language-configuration bracket pairs; VS classification only) | Acceptable; no LSP work needed |
+| Editor: quick info, completion, classification, syntax errors | Covered (LSP hover, completion, semantic tokens, diagnostics; VS native fallback) | None |
+| `docs/` folder (user documentation) | New repo has README-level docs only | Backlog: docs site per to_implement.md Milestone 10 |
+| Legacy generation internals (Parser, SingleFileParser, ItemFilter, GenerationController, SolutionMonitor) | Reimplemented in `Typewriter.Engine` + adapters | None; remaining edge cases tracked as recipe-driven hardening |
+| Legacy Roslyn metadata (`RoslynVoidTaskMetadata` etc.) | Reimplemented; parity verified by existing tests | None |
+
+Recommended ordering for the extra gaps: item templates (small, visible win for
+VS users), then folding + signature help (pairs naturally with Point 2), then
+formatting and docs.
+
+---
+
+## Suggested Overall Sequence
+
+1. Point 5 (small, unblocks Point 4 naming parity)          ~2 PRs
+2. Point 4 helper families, tests-first                     ~5-6 PRs
+3. Point 3 perf (stamps -> dirty paths -> tree reuse)       ~3 PRs
+4. Point 2 embedded forwarding (LS requests -> VS Code)     ~3-4 PRs
+5. Legacy extras: item templates, foldingRange, signatureHelp
+
+Each PR: full `dotnet build`/`dotnet test` (currently 265 tests), snapshot
+byte-parity, `npm --prefix vscode run lint && bundle`, and Rider `verifyPlugin`
+where touched, per the verified commands in implemented.md.

--- a/rider/build.gradle.kts
+++ b/rider/build.gradle.kts
@@ -36,7 +36,7 @@ intellijPlatform {
         version = providers.gradleProperty("pluginVersion")
         description = """
             <p>JetBrains Rider adapter for Typewriter .tst templates.</p>
-            <p>Provides file recognition, syntax highlighting, CLI-backed generation and validation actions, and save-time generation.</p>
+            <p>Provides file recognition, syntax highlighting, language-server IntelliSense (completion, hover, diagnostics, go-to-definition), CLI-backed generation and validation actions, and save-time generation.</p>
         """.trimIndent()
 
         ideaVersion {

--- a/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterConfigurable.kt
+++ b/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterConfigurable.kt
@@ -3,6 +3,7 @@ package com.adaskothebeast.typewriter.rider
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
+import com.intellij.platform.lsp.api.LspServerManager
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.awt.Insets
@@ -23,6 +24,7 @@ class TypewriterConfigurable(private val project: Project) : SearchableConfigura
     private lateinit var allProjectsCheckBox: JCheckBox
     private lateinit var generateOnSaveCheckBox: JCheckBox
     private lateinit var validateOnSaveCheckBox: JCheckBox
+    private lateinit var languageServerEnabledCheckBox: JCheckBox
 
     override fun getId(): String = "typewriter"
 
@@ -38,6 +40,7 @@ class TypewriterConfigurable(private val project: Project) : SearchableConfigura
         allProjectsCheckBox = JCheckBox("Generate all projects")
         generateOnSaveCheckBox = JCheckBox("Generate on save for files matched by typewriter.json inputExtensions")
         validateOnSaveCheckBox = JCheckBox("Validate on save for files matched by typewriter.json inputExtensions")
+        languageServerEnabledCheckBox = JCheckBox("Enable language server IntelliSense for .tst files (completion, hover, diagnostics)")
 
         val createdPanel = JPanel(GridBagLayout())
         var row = 0
@@ -50,6 +53,7 @@ class TypewriterConfigurable(private val project: Project) : SearchableConfigura
         addCheckBox(createdPanel, row++, allProjectsCheckBox)
         addCheckBox(createdPanel, row++, generateOnSaveCheckBox)
         addCheckBox(createdPanel, row++, validateOnSaveCheckBox)
+        addCheckBox(createdPanel, row++, languageServerEnabledCheckBox)
         addFiller(createdPanel, row)
 
         panel = createdPanel
@@ -67,11 +71,17 @@ class TypewriterConfigurable(private val project: Project) : SearchableConfigura
             frameworkField.text != state.framework ||
             allProjectsCheckBox.isSelected != state.allProjects ||
             generateOnSaveCheckBox.isSelected != state.generateOnSave ||
-            validateOnSaveCheckBox.isSelected != state.validateOnSave
+            validateOnSaveCheckBox.isSelected != state.validateOnSave ||
+            languageServerEnabledCheckBox.isSelected != state.languageServerEnabled
     }
 
     override fun apply() {
         val state = project.service<TypewriterSettingsState>().settings
+        val languageServerSettingsChanged = state.languageServerEnabled != languageServerEnabledCheckBox.isSelected ||
+            state.workspacePath != workspacePathField.text.trim() ||
+            state.projectPath != projectPathField.text.trim() ||
+            state.framework != frameworkField.text.trim() ||
+            state.allProjects != allProjectsCheckBox.isSelected
         state.cliPath = cliPathField.text.trim()
         state.cliArguments = cliArgumentsField.text.trim()
         state.workspacePath = workspacePathField.text.trim()
@@ -81,6 +91,11 @@ class TypewriterConfigurable(private val project: Project) : SearchableConfigura
         state.allProjects = allProjectsCheckBox.isSelected
         state.generateOnSave = generateOnSaveCheckBox.isSelected
         state.validateOnSave = validateOnSaveCheckBox.isSelected
+        state.languageServerEnabled = languageServerEnabledCheckBox.isSelected
+        if (languageServerSettingsChanged) {
+            LspServerManager.getInstance(project)
+                .stopAndRestartIfNeeded(TypewriterLspServerSupportProvider::class.java)
+        }
     }
 
     override fun reset() {
@@ -94,6 +109,7 @@ class TypewriterConfigurable(private val project: Project) : SearchableConfigura
         allProjectsCheckBox.isSelected = state.allProjects
         generateOnSaveCheckBox.isSelected = state.generateOnSave
         validateOnSaveCheckBox.isSelected = state.validateOnSave
+        languageServerEnabledCheckBox.isSelected = state.languageServerEnabled
     }
 
     override fun disposeUIResources() {

--- a/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterLanguageServerClient.kt
+++ b/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterLanguageServerClient.kt
@@ -3,18 +3,14 @@ package com.adaskothebeast.typewriter.rider
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.EOFException
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicLong
 
@@ -209,66 +205,8 @@ class TypewriterLanguageServerClient(private val project: Project) : Disposable 
         }
     }
 
-    private fun resolveLanguageServerInvocation(workingDirectory: String): ServerInvocation {
-        val localProject = findLocalLanguageServerProject(project.basePath)
-            ?: findLocalLanguageServerProject(workingDirectory)
-        if (localProject != null) {
-            val assembly = findBuiltLanguageServerAssembly(localProject)
-            return if (assembly != null) {
-                ServerInvocation("dotnet", listOf(assembly))
-            } else {
-                ServerInvocation("dotnet", listOf("run", "--project", localProject, "--no-launch-profile", "--"))
-            }
-        }
-
-        val plugin = PluginManagerCore.getPlugin(PluginId.getId(PluginIdValue))
-        val packagedAssembly = plugin?.pluginPath
-            ?.resolve("tools")
-            ?.resolve("typewriter-lsp")
-            ?.resolve("Typewriter.LanguageServer.dll")
-        return if (packagedAssembly != null && Files.isRegularFile(packagedAssembly)) {
-            ServerInvocation("dotnet", listOf(packagedAssembly.toString()))
-        } else {
-            ServerInvocation("typewriter-lsp", emptyList())
-        }
-    }
-
-    private fun findLocalLanguageServerProject(startPath: String?): String? {
-        if (startPath.isNullOrBlank()) {
-            return null
-        }
-
-        var directory: Path? = if (Files.isDirectory(Paths.get(startPath))) {
-            Paths.get(startPath)
-        } else {
-            Paths.get(startPath).parent
-        }
-        while (directory != null) {
-            val candidate = directory.resolve("src/Typewriter.LanguageServer/Typewriter.LanguageServer.csproj")
-            if (Files.isRegularFile(candidate)) {
-                return candidate.normalize().toString()
-            }
-
-            directory = directory.parent
-        }
-
-        return null
-    }
-
-    private fun findBuiltLanguageServerAssembly(projectPath: String): String? {
-        val outputRoot = Paths.get(projectPath).parent?.resolve("bin") ?: return null
-        if (!Files.isDirectory(outputRoot)) {
-            return null
-        }
-
-        return Files.walk(outputRoot).use { paths ->
-            paths
-                .filter { Files.isRegularFile(it) && it.fileName.toString() == "Typewriter.LanguageServer.dll" }
-                .max(compareBy { Files.getLastModifiedTime(it).toMillis() })
-                .orElse(null)
-                ?.toString()
-        }
-    }
+    private fun resolveLanguageServerInvocation(workingDirectory: String): TypewriterServerInvocation =
+        TypewriterLanguageServerLocator.resolveInvocation(project.basePath, workingDirectory)
 
     private fun reset() {
         input?.runCatching { close() }
@@ -296,10 +234,7 @@ class TypewriterLanguageServerClient(private val project: Project) : Disposable 
         val allProjects: Boolean,
     )
 
-    private data class ServerInvocation(val command: String, val arguments: List<String>)
-
     private companion object {
-        const val PluginIdValue = "com.adaskothebeast.typewriter"
         const val PollDelayMillis = 10L
         const val RequestTimeoutMillis = 300_000L
         val logger: Logger = Logger.getInstance(TypewriterLanguageServerClient::class.java)

--- a/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterLanguageServerLocator.kt
+++ b/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterLanguageServerLocator.kt
@@ -1,0 +1,74 @@
+package com.adaskothebeast.typewriter.rider
+
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+internal data class TypewriterServerInvocation(val command: String, val arguments: List<String>)
+
+internal object TypewriterLanguageServerLocator {
+    private const val PLUGIN_ID = "com.adaskothebeast.typewriter"
+
+    fun resolveInvocation(projectBasePath: String?, workingDirectory: String): TypewriterServerInvocation {
+        val localProject = findLocalLanguageServerProject(projectBasePath)
+            ?: findLocalLanguageServerProject(workingDirectory)
+        if (localProject != null) {
+            val assembly = findBuiltLanguageServerAssembly(localProject)
+            return if (assembly != null) {
+                TypewriterServerInvocation("dotnet", listOf(assembly))
+            } else {
+                TypewriterServerInvocation("dotnet", listOf("run", "--project", localProject, "--no-launch-profile", "--"))
+            }
+        }
+
+        val plugin = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))
+        val packagedAssembly = plugin?.pluginPath
+            ?.resolve("tools")
+            ?.resolve("typewriter-lsp")
+            ?.resolve("Typewriter.LanguageServer.dll")
+        return if (packagedAssembly != null && Files.isRegularFile(packagedAssembly)) {
+            TypewriterServerInvocation("dotnet", listOf(packagedAssembly.toString()))
+        } else {
+            TypewriterServerInvocation("typewriter-lsp", emptyList())
+        }
+    }
+
+    private fun findLocalLanguageServerProject(startPath: String?): String? {
+        if (startPath.isNullOrBlank()) {
+            return null
+        }
+
+        var directory: Path? = if (Files.isDirectory(Paths.get(startPath))) {
+            Paths.get(startPath)
+        } else {
+            Paths.get(startPath).parent
+        }
+        while (directory != null) {
+            val candidate = directory.resolve("src/Typewriter.LanguageServer/Typewriter.LanguageServer.csproj")
+            if (Files.isRegularFile(candidate)) {
+                return candidate.normalize().toString()
+            }
+
+            directory = directory.parent
+        }
+
+        return null
+    }
+
+    private fun findBuiltLanguageServerAssembly(projectPath: String): String? {
+        val outputRoot = Paths.get(projectPath).parent?.resolve("bin") ?: return null
+        if (!Files.isDirectory(outputRoot)) {
+            return null
+        }
+
+        return Files.walk(outputRoot).use { paths ->
+            paths
+                .filter { Files.isRegularFile(it) && it.fileName.toString() == "Typewriter.LanguageServer.dll" }
+                .max(compareBy { Files.getLastModifiedTime(it).toMillis() })
+                .orElse(null)
+                ?.toString()
+        }
+    }
+}

--- a/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterLspServerSupportProvider.kt
+++ b/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterLspServerSupportProvider.kt
@@ -1,0 +1,72 @@
+package com.adaskothebeast.typewriter.rider
+
+import com.google.gson.JsonObject
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.lsp.api.LspServerSupportProvider
+import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
+
+class TypewriterLspServerSupportProvider : LspServerSupportProvider {
+    override fun fileOpened(
+        project: Project,
+        file: VirtualFile,
+        serverStarter: LspServerSupportProvider.LspServerStarter,
+    ) {
+        if (!isTypewriterTemplate(file)) {
+            return
+        }
+
+        if (!project.service<TypewriterSettingsState>().settings.languageServerEnabled) {
+            return
+        }
+
+        serverStarter.ensureServerStarted(TypewriterLspServerDescriptor(project))
+    }
+
+    internal companion object {
+        fun isTypewriterTemplate(file: VirtualFile): Boolean =
+            file.extension?.equals("tst", ignoreCase = true) == true
+    }
+}
+
+private class TypewriterLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor(project, "Typewriter") {
+    override fun isSupportedFile(file: VirtualFile): Boolean =
+        TypewriterLspServerSupportProvider.isTypewriterTemplate(file)
+
+    override fun createCommandLine(): GeneralCommandLine {
+        val workingDirectory = resolveWorkingDirectory()
+        val invocation = TypewriterLanguageServerLocator.resolveInvocation(project.basePath, workingDirectory)
+        return GeneralCommandLine(listOf(invocation.command) + invocation.arguments)
+            .withWorkDirectory(workingDirectory)
+    }
+
+    override fun createInitializationOptions(): Any {
+        val settings = project.service<TypewriterSettingsState>().settings
+        val options = JsonObject()
+        val workspacePath = settings.workspacePath.ifBlank { project.basePath.orEmpty() }
+        if (workspacePath.isNotBlank()) {
+            options.addProperty("workspacePath", workspacePath)
+        }
+
+        if (settings.projectPath.isNotBlank()) {
+            options.addProperty("projectPath", settings.projectPath)
+        }
+
+        if (settings.framework.isNotBlank()) {
+            options.addProperty("framework", settings.framework)
+        }
+
+        if (settings.allProjects) {
+            options.addProperty("allProjects", true)
+        }
+
+        return options
+    }
+
+    private fun resolveWorkingDirectory(): String {
+        val settings = project.service<TypewriterSettingsState>().settings
+        return settings.workspacePath.ifBlank { project.basePath ?: System.getProperty("user.dir") }
+    }
+}

--- a/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterSettingsState.kt
+++ b/rider/src/main/kotlin/com/adaskothebeast/typewriter/rider/TypewriterSettingsState.kt
@@ -25,5 +25,6 @@ class TypewriterSettingsState : PersistentStateComponent<TypewriterSettingsState
         var allProjects: Boolean = false,
         var generateOnSave: Boolean = true,
         var validateOnSave: Boolean = true,
+        var languageServerEnabled: Boolean = true,
     )
 }

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,8 @@
         <projectService serviceImplementation="com.adaskothebeast.typewriter.rider.TypewriterSettingsState" />
         <projectService serviceImplementation="com.adaskothebeast.typewriter.rider.TypewriterCliService" />
         <projectService serviceImplementation="com.adaskothebeast.typewriter.rider.TypewriterLanguageServerClient" />
+        <platform.lsp.serverSupportProvider
+            implementation="com.adaskothebeast.typewriter.rider.TypewriterLspServerSupportProvider" />
         <projectConfigurable
             id="typewriter"
             displayName="Typewriter"

--- a/src/Typewriter.Engine/CodeModel/Attribute.cs
+++ b/src/Typewriter.Engine/CodeModel/Attribute.cs
@@ -1,12 +1,32 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// An attribute applied to a code model item, enumerated in templates with
+/// <c>$Attributes[...]</c>. Attribute filters use the short name, for example
+/// <c>$Classes([Serializable])[...]</c>.
+/// </summary>
 public class Attribute : Item
 {
+    /// <summary>
+    /// Gets the constructor and named arguments of the attribute.
+    /// Template shorthand: <c>$Arguments[...]</c>.
+    /// </summary>
     public virtual IAttributeArgumentCollection Arguments { get; init; } = new AttributeArgumentCollection();
 
+    /// <summary>
+    /// Gets the type of the attribute class.
+    /// </summary>
     public virtual Type? Type { get; init; }
 
+    /// <summary>
+    /// Gets the raw argument list of the attribute as written in source, for example
+    /// <c>"users", Order = 1</c> for <c>[Route("users", Order = 1)]</c>.
+    /// Template shorthand: <c>$Value</c>.
+    /// </summary>
     public virtual string Value { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Converts the attribute to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Attribute? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/AttributeArgument.cs
+++ b/src/Typewriter.Engine/CodeModel/AttributeArgument.cs
@@ -1,10 +1,24 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A single argument of an <see cref="Attribute"/>, enumerated in templates with
+/// <c>$Arguments[...]</c>. Named arguments expose the argument name through <c>Name</c>.
+/// </summary>
 public class AttributeArgument : Item
 {
+    /// <summary>
+    /// Gets the declared type of the argument value.
+    /// </summary>
     public virtual Type? Type { get; init; }
 
+    /// <summary>
+    /// Gets the referenced type when the argument is a <c>typeof(...)</c> expression,
+    /// otherwise <c>null</c>.
+    /// </summary>
     public virtual Type? TypeValue { get; init; }
 
+    /// <summary>
+    /// Gets the constant value of the argument. Template shorthand: <c>$Value</c>.
+    /// </summary>
     public virtual object? Value { get; init; }
 }

--- a/src/Typewriter.Engine/CodeModel/Class.cs
+++ b/src/Typewriter.Engine/CodeModel/Class.cs
@@ -1,56 +1,152 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A C# class made available to templates through <c>$Classes[...]</c>.
+/// Exposes the members, base type, interfaces, and nested types of the class.
+/// </summary>
 public class Class : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the class, for example <c>[Serializable]</c>.
+    /// Template shorthand: <c>$Attributes[...]</c>.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the direct base class this class inherits from, or <c>null</c> when the class
+    /// inherits only from <c>object</c>. The base class exposes the same members
+    /// (<c>Name</c>, <c>Properties</c>, ...), so <c>$BaseClass[...]</c> can walk inheritance chains,
+    /// for example <c>export class $Name$BaseClass[ extends $Name]</c>.
+    /// </summary>
     public virtual Class? BaseClass { get; init; }
 
+    /// <summary>
+    /// Gets the <c>const</c> members declared on the class.
+    /// Template shorthand: <c>$Constants[...]</c>.
+    /// </summary>
     public virtual IConstantCollection Constants { get; init; } = new ConstantCollection();
 
+    /// <summary>
+    /// Gets the class this class is nested inside, or <c>null</c> for top-level classes.
+    /// </summary>
     public virtual Class? ContainingClass { get; init; }
 
+    /// <summary>
+    /// Gets the delegates declared inside the class.
+    /// </summary>
     public virtual IDelegateCollection Delegates { get; init; } = new DelegateCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the class, or <c>null</c> when the class
+    /// has no doc comment. Use <c>$DocComment.Summary</c> in templates.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets the events declared on the class.
+    /// </summary>
     public virtual IEventCollection Events { get; init; } = new EventCollection();
 
+    /// <summary>
+    /// Gets the instance fields declared on the class.
+    /// Template shorthand: <c>$Fields[...]</c>.
+    /// </summary>
     public virtual IFieldCollection Fields { get; init; } = new FieldCollection();
 
+    /// <summary>
+    /// Gets the interfaces implemented by the class.
+    /// </summary>
     public virtual IInterfaceCollection Interfaces { get; init; } = new InterfaceCollection();
 
+    /// <summary>
+    /// Gets a value indicating whether the class is declared <c>abstract</c>.
+    /// </summary>
     public virtual bool IsAbstract { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the class declares generic type parameters,
+    /// for example <c>Result&lt;T&gt;</c>.
+    /// </summary>
     public virtual bool IsGeneric { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the class is declared <c>static</c>.
+    /// </summary>
     public virtual bool IsStatic { get; init; }
 
+    /// <summary>
+    /// Gets the methods declared on the class.
+    /// Template shorthand: <c>$Methods[...]</c>.
+    /// </summary>
     public virtual IMethodCollection Methods { get; init; } = new MethodCollection();
 
+    /// <summary>
+    /// Gets the namespace that contains the class, for example <c>MyApp.Models</c>.
+    /// Template shorthand: <c>$Namespace</c>.
+    /// </summary>
     public virtual string Namespace { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the classes nested inside the class.
+    /// </summary>
     public virtual IClassCollection NestedClasses { get; init; } = new ClassCollection();
 
+    /// <summary>
+    /// Gets the enums nested inside the class.
+    /// </summary>
     public virtual IEnumCollection NestedEnums { get; init; } = new EnumCollection();
 
+    /// <summary>
+    /// Gets the interfaces nested inside the class.
+    /// </summary>
     public virtual IInterfaceCollection NestedInterfaces { get; init; } = new InterfaceCollection();
 
+    /// <summary>
+    /// Gets the records nested inside the class.
+    /// </summary>
     public virtual IRecordCollection NestedRecords { get; init; } = new RecordCollection();
 
+    /// <summary>
+    /// Gets the structs nested inside the class.
+    /// </summary>
     public virtual IStructCollection NestedStructs { get; init; } = new StructCollection();
 
+    /// <summary>
+    /// Gets the properties declared on the class, including indexers.
+    /// Template shorthand: <c>$Properties[...]</c>.
+    /// </summary>
     public virtual IPropertyCollection Properties { get; init; } = new PropertyCollection();
 
+    /// <summary>
+    /// Gets the <c>static readonly</c> fields declared on the class.
+    /// </summary>
     public virtual IStaticReadOnlyFieldCollection StaticReadOnlyFields { get; init; } = new StaticReadOnlyFieldCollection();
 
+    /// <summary>
+    /// Gets the type reference for the class, exposing type-level information such as
+    /// <c>IsNullable</c>, <c>IsEnumerable</c>, and the TypeScript rendering of the type.
+    /// </summary>
     public virtual Type Type { get; init; } = new();
 
+    /// <summary>
+    /// Gets the generic type arguments of the class when it is a constructed generic type,
+    /// for example <c>string</c> in <c>Result&lt;string&gt;</c>.
+    /// </summary>
     public virtual ITypeCollection TypeArguments { get; init; } = new TypeCollection();
 
+    /// <summary>
+    /// Gets the generic type parameters declared by the class,
+    /// for example <c>T</c> in <c>Result&lt;T&gt;</c>.
+    /// </summary>
     public virtual ITypeParameterCollection TypeParameters { get; init; } = new TypeParameterCollection();
 
+    /// <summary>
+    /// Converts the class to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Class? instance) => instance?.ToString() ?? string.Empty;
 
+    /// <summary>
+    /// Converts the class to its <see cref="Type"/> reference.
+    /// </summary>
     public static implicit operator Type?(Class? instance) => instance?.Type;
 }

--- a/src/Typewriter.Engine/CodeModel/Constant.cs
+++ b/src/Typewriter.Engine/CodeModel/Constant.cs
@@ -1,14 +1,33 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A <c>const</c> member declared on a type, enumerated in templates with <c>$Constants[...]</c>.
+/// </summary>
 public class Constant : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the constant.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the constant, or <c>null</c> when it has none.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets the type of the constant.
+    /// </summary>
     public virtual Type? Type { get; init; }
 
+    /// <summary>
+    /// Gets the compile-time value of the constant, for example <c>Admin</c> for
+    /// <c>public const string Role = "Admin";</c>. Template shorthand: <c>$Value</c>.
+    /// </summary>
     public virtual string Value { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Converts the constant to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Constant? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/Delegate.cs
+++ b/src/Typewriter.Engine/CodeModel/Delegate.cs
@@ -1,18 +1,43 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A C# delegate made available to templates through <c>$Delegates[...]</c>.
+/// </summary>
 public class Delegate : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the delegate.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the delegate, or <c>null</c> when it has none.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the delegate declares generic type parameters.
+    /// </summary>
     public virtual bool IsGeneric { get; init; }
 
+    /// <summary>
+    /// Gets the parameters of the delegate signature.
+    /// Template shorthand: <c>$Parameters[...]</c>.
+    /// </summary>
     public virtual IParameterCollection Parameters { get; init; } = new ParameterCollection();
 
+    /// <summary>
+    /// Gets the return type of the delegate.
+    /// </summary>
     public virtual Type? Type { get; init; }
 
+    /// <summary>
+    /// Gets the generic type parameters declared by the delegate.
+    /// </summary>
     public virtual ITypeParameterCollection TypeParameters { get; init; } = new TypeParameterCollection();
 
+    /// <summary>
+    /// Converts the delegate to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Delegate? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/DocComment.cs
+++ b/src/Typewriter.Engine/CodeModel/DocComment.cs
@@ -1,16 +1,36 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// The XML documentation comment of a code model item. Access it in templates through
+/// <c>$DocComment.Summary</c>, <c>$DocComment.Returns</c>, and <c>$DocComment.Parameters</c>.
+/// </summary>
 public class DocComment : Item
 {
+    /// <summary>
+    /// Gets the text of the <c>&lt;summary&gt;</c> element.
+    /// </summary>
     public virtual string Summary { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the text of the <c>&lt;returns&gt;</c> element.
+    /// </summary>
     public virtual string Returns { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the <c>&lt;param&gt;</c> element descriptions.
+    /// </summary>
     public virtual IParameterCommentCollection Parameters { get; init; } = new ParameterCommentCollection();
 
+    /// <summary>
+    /// Gets the summary text. Alias for <see cref="Summary"/> kept for legacy templates.
+    /// </summary>
     public virtual string Text => Summary;
 
+    /// <summary>
+    /// Converts the doc comment to its summary text.
+    /// </summary>
     public static implicit operator string(DocComment? instance) => instance?.ToString() ?? string.Empty;
 
+    /// <inheritdoc/>
     public override string ToString() => Summary;
 }

--- a/src/Typewriter.Engine/CodeModel/Enum.cs
+++ b/src/Typewriter.Engine/CodeModel/Enum.cs
@@ -1,22 +1,57 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A C# enum made available to templates through <c>$Enums[...]</c>.
+/// Enumerate its members with <c>$Values[...]</c>.
+/// </summary>
 public class Enum : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the enum, for example <c>[Flags]</c>.
+    /// Template shorthand: <c>$Attributes[...]</c>.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the class this enum is nested inside, or <c>null</c> for top-level enums.
+    /// </summary>
     public virtual Class? ContainingClass { get; init; }
 
+    /// <summary>
+    /// Gets the XML documentation comment of the enum, or <c>null</c> when the enum
+    /// has no doc comment. Use <c>$DocComment.Summary</c> in templates.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the enum is decorated with <c>[Flags]</c>.
+    /// </summary>
     public virtual bool IsFlags { get; init; }
 
+    /// <summary>
+    /// Gets the namespace that contains the enum.
+    /// Template shorthand: <c>$Namespace</c>.
+    /// </summary>
     public virtual string Namespace { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the type reference for the enum.
+    /// </summary>
     public virtual Type Type { get; init; } = new();
 
+    /// <summary>
+    /// Gets the values declared on the enum.
+    /// Template shorthand: <c>$Values[...]</c> or <c>$EnumValues[...]</c>.
+    /// </summary>
     public virtual IEnumValueCollection Values { get; init; } = new EnumValueCollection();
 
+    /// <summary>
+    /// Converts the enum to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Enum? instance) => instance?.ToString() ?? string.Empty;
 
+    /// <summary>
+    /// Converts the enum to its <see cref="Type"/> reference.
+    /// </summary>
     public static implicit operator Type?(Enum? instance) => instance?.Type;
 }

--- a/src/Typewriter.Engine/CodeModel/EnumValue.cs
+++ b/src/Typewriter.Engine/CodeModel/EnumValue.cs
@@ -1,12 +1,28 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A single member of an <see cref="Enum"/>, enumerated in templates with
+/// <c>$Values[...]</c> or <c>$EnumValues[...]</c>.
+/// </summary>
 public class EnumValue : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the enum member, for example <c>[EnumMember(Value = "...")]</c>.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the enum member, or <c>null</c> when it has none.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets the numeric value of the enum member. Template shorthand: <c>$Value</c>.
+    /// </summary>
     public virtual long Value { get; init; }
 
+    /// <summary>
+    /// Converts the enum value to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(EnumValue? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/Event.cs
+++ b/src/Typewriter.Engine/CodeModel/Event.cs
@@ -1,12 +1,27 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// An event declared on a type, enumerated in templates with <c>$Events[...]</c>.
+/// </summary>
 public class Event : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the event.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the event, or <c>null</c> when it has none.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets the delegate type of the event, for example <c>EventHandler&lt;TArgs&gt;</c>.
+    /// </summary>
     public virtual Type? Type { get; init; }
 
+    /// <summary>
+    /// Converts the event to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Event? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/Field.cs
+++ b/src/Typewriter.Engine/CodeModel/Field.cs
@@ -1,14 +1,33 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// An instance field declared on a type, enumerated in templates with <c>$Fields[...]</c>.
+/// </summary>
 public class Field : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the field.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the field, or <c>null</c> when it has none.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets the type of the field. Rendering it (<c>$Type</c>) produces the mapped TypeScript type.
+    /// </summary>
     public virtual Type? Type { get; init; }
 
+    /// <summary>
+    /// Gets the field initializer value, for example <c>42</c> for <c>private int count = 42;</c>.
+    /// Template shorthand: <c>$Value</c>.
+    /// </summary>
     public virtual string Value { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Converts the field to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Field? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/File.cs
+++ b/src/Typewriter.Engine/CodeModel/File.cs
@@ -1,20 +1,50 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// The root of the code model for one rendered source file. Templates receive it through
+/// <c>Template(Settings settings, File file)</c> and <c>OnRenderComplete(File file)</c>,
+/// and the top-level collections (<c>$Classes</c>, <c>$Enums</c>, ...) come from here.
+/// </summary>
 public class File : Item
 {
+    /// <summary>
+    /// Gets the classes declared in the file. Template shorthand: <c>$Classes[...]</c>.
+    /// </summary>
     public virtual IClassCollection Classes { get; init; } = new ClassCollection();
 
+    /// <summary>
+    /// Gets the delegates declared in the file. Template shorthand: <c>$Delegates[...]</c>.
+    /// </summary>
     public virtual IDelegateCollection Delegates { get; init; } = new DelegateCollection();
 
+    /// <summary>
+    /// Gets the enums declared in the file. Template shorthand: <c>$Enums[...]</c>.
+    /// </summary>
     public virtual IEnumCollection Enums { get; init; } = new EnumCollection();
 
+    /// <summary>
+    /// Gets the interfaces declared in the file. Template shorthand: <c>$Interfaces[...]</c>.
+    /// </summary>
     public virtual IInterfaceCollection Interfaces { get; init; } = new InterfaceCollection();
 
+    /// <summary>
+    /// Gets the full path of the source file.
+    /// </summary>
     public virtual string Path { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the records declared in the file. Template shorthand: <c>$Records[...]</c>.
+    /// </summary>
     public virtual IRecordCollection Records { get; init; } = new RecordCollection();
 
+    /// <summary>
+    /// Gets the structs declared in the file. Template shorthand: <c>$Structs[...]</c>.
+    /// </summary>
     public virtual IStructCollection Structs { get; init; } = new StructCollection();
 
+    /// <summary>
+    /// Gets all types declared in the file. Template shorthand: <c>$Types[...]</c>,
+    /// optionally filtered like <c>$Types(Class)[...]</c>.
+    /// </summary>
     public virtual ITypeCollection Types { get; init; } = new TypeCollection();
 }

--- a/src/Typewriter.Engine/CodeModel/Interface.cs
+++ b/src/Typewriter.Engine/CodeModel/Interface.cs
@@ -1,34 +1,88 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A C# interface made available to templates through <c>$Interfaces[...]</c>.
+/// Exposes the members and base interfaces of the interface.
+/// </summary>
 public class Interface : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the interface.
+    /// Template shorthand: <c>$Attributes[...]</c>.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the class this interface is nested inside, or <c>null</c> for top-level interfaces.
+    /// </summary>
     public virtual Class? ContainingClass { get; init; }
 
+    /// <summary>
+    /// Gets the XML documentation comment of the interface, or <c>null</c> when the interface
+    /// has no doc comment. Use <c>$DocComment.Summary</c> in templates.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets the events declared on the interface.
+    /// </summary>
     public virtual IEventCollection Events { get; init; } = new EventCollection();
 
+    /// <summary>
+    /// Gets the interfaces this interface extends.
+    /// </summary>
     public virtual IInterfaceCollection Interfaces { get; init; } = new InterfaceCollection();
 
+    /// <summary>
+    /// Gets a value indicating whether the interface declares generic type parameters.
+    /// </summary>
     public virtual bool IsGeneric { get; init; }
 
+    /// <summary>
+    /// Gets the methods declared on the interface.
+    /// Template shorthand: <c>$Methods[...]</c>.
+    /// </summary>
     public virtual IMethodCollection Methods { get; init; } = new MethodCollection();
 
+    /// <summary>
+    /// Gets the namespace that contains the interface.
+    /// Template shorthand: <c>$Namespace</c>.
+    /// </summary>
     public virtual string Namespace { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the structs nested inside the interface.
+    /// </summary>
     public virtual IStructCollection NestedStructs { get; init; } = new StructCollection();
 
+    /// <summary>
+    /// Gets the properties declared on the interface.
+    /// Template shorthand: <c>$Properties[...]</c>.
+    /// </summary>
     public virtual IPropertyCollection Properties { get; init; } = new PropertyCollection();
 
+    /// <summary>
+    /// Gets the type reference for the interface.
+    /// </summary>
     public virtual Type Type { get; init; } = new();
 
+    /// <summary>
+    /// Gets the generic type arguments of the interface when it is a constructed generic type.
+    /// </summary>
     public virtual ITypeCollection TypeArguments { get; init; } = new TypeCollection();
 
+    /// <summary>
+    /// Gets the generic type parameters declared by the interface.
+    /// </summary>
     public virtual ITypeParameterCollection TypeParameters { get; init; } = new TypeParameterCollection();
 
+    /// <summary>
+    /// Converts the interface to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Interface? instance) => instance?.ToString() ?? string.Empty;
 
+    /// <summary>
+    /// Converts the interface to its <see cref="Type"/> reference.
+    /// </summary>
     public static implicit operator Type?(Interface? instance) => instance?.Type;
 }

--- a/src/Typewriter.Engine/CodeModel/Item.cs
+++ b/src/Typewriter.Engine/CodeModel/Item.cs
@@ -1,20 +1,51 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// Base class for all Typewriter code model items. Every metadata object
+/// available in a <c>.tst</c> template (classes, properties, methods, ...)
+/// derives from this type.
+/// </summary>
 public class Item
 {
+    /// <summary>
+    /// Gets the name of the assembly that declares this item, for example <c>MyApp.Contracts</c>.
+    /// </summary>
     public virtual string AssemblyName { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the fully qualified name of the item including its namespace,
+    /// for example <c>MyApp.Models.UserModel</c>. Template shorthand: <c>$FullName</c>.
+    /// </summary>
     public virtual string FullName { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the declared C# name of the item, for example <c>UserModel</c> or <c>CreatedAt</c>.
+    /// Template shorthand: <c>$Name</c>.
+    /// </summary>
     public virtual string Name { get; init; } = string.Empty;
 
 #pragma warning disable SA1300 // Element should begin with upper-case letter
+    /// <summary>
+    /// Gets the camel-cased name of the item, for example <c>userModel</c> or <c>createdAt</c>.
+    /// Template shorthand: <c>$name</c>.
+    /// </summary>
     public virtual string name => GetName(nameCase: NameCase.LegacyCamelCase);
 #pragma warning restore SA1300 // Element should begin with upper-case letter
 
+    /// <summary>
+    /// Gets the parent code model item, for example the <see cref="Class"/> that declares
+    /// the current <see cref="Property"/>. Template shorthand: <c>$Parent</c>.
+    /// </summary>
     public virtual Item? Parent { get; init; }
 
+    /// <summary>
+    /// Formats <see cref="Name"/> with the requested casing convention
+    /// (camel, pascal, kebab, snake, ...).
+    /// </summary>
+    /// <param name="nameCase">The casing convention to apply.</param>
+    /// <returns>The formatted name.</returns>
     public virtual string GetName(NameCase nameCase) => NameCaseFormatter.Format(value: Name, nameCase: nameCase);
 
+    /// <inheritdoc/>
     public override string ToString() => Name;
 }

--- a/src/Typewriter.Engine/CodeModel/Method.cs
+++ b/src/Typewriter.Engine/CodeModel/Method.cs
@@ -1,20 +1,52 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A method declared on a class, record, struct, or interface, enumerated in
+/// templates with <c>$Methods[...]</c>.
+/// </summary>
 public class Method : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the method, for example <c>[HttpGet]</c> or <c>[Route("...")]</c>.
+    /// Template shorthand: <c>$Attributes[...]</c>.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the method, or <c>null</c> when it has none.
+    /// Use <c>$DocComment.Summary</c> in templates.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the method is declared <c>abstract</c>.
+    /// </summary>
     public virtual bool IsAbstract { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the method declares generic type parameters.
+    /// </summary>
     public virtual bool IsGeneric { get; init; }
 
+    /// <summary>
+    /// Gets the parameters of the method.
+    /// Template shorthand: <c>$Parameters[...]</c>.
+    /// </summary>
     public virtual IParameterCollection Parameters { get; init; } = new ParameterCollection();
 
+    /// <summary>
+    /// Gets the return type of the method. <c>Task&lt;T&gt;</c> is exposed through
+    /// <see cref="CodeModel.Type.IsTask"/>. Template shorthand: <c>$Type</c> or <c>$ReturnType</c>.
+    /// </summary>
     public virtual Type Type { get; init; } = new();
 
+    /// <summary>
+    /// Gets the generic type parameters declared by the method.
+    /// </summary>
     public virtual ITypeParameterCollection TypeParameters { get; init; } = new TypeParameterCollection();
 
+    /// <summary>
+    /// Converts the method to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Method? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/Parameter.cs
+++ b/src/Typewriter.Engine/CodeModel/Parameter.cs
@@ -1,14 +1,35 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A parameter of a method or indexer, enumerated in templates with <c>$Parameters[...]</c>.
+/// </summary>
 public class Parameter : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the parameter, for example <c>[FromBody]</c> or <c>[FromQuery]</c>.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the default value of an optional parameter, or an empty string when there is none.
+    /// Template shorthand: <c>$DefaultValue</c>.
+    /// </summary>
     public virtual string DefaultValue { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets a value indicating whether the parameter declares a default value.
+    /// Template shorthand: <c>$HasDefaultValue[...][...]</c>.
+    /// </summary>
     public virtual bool HasDefaultValue { get; init; }
 
+    /// <summary>
+    /// Gets the type of the parameter. Rendering it (<c>$Type</c>) produces the mapped
+    /// TypeScript type.
+    /// </summary>
     public virtual Type Type { get; init; } = new();
 
+    /// <summary>
+    /// Converts the parameter to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Parameter? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/ParameterComment.cs
+++ b/src/Typewriter.Engine/CodeModel/ParameterComment.cs
@@ -1,10 +1,21 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// The <c>&lt;param&gt;</c> documentation of a single parameter, exposed through
+/// <see cref="DocComment.Parameters"/>.
+/// </summary>
 public class ParameterComment : Item
 {
+    /// <summary>
+    /// Gets the description text of the <c>&lt;param&gt;</c> element.
+    /// </summary>
     public virtual string Description { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Converts the parameter comment to the parameter name.
+    /// </summary>
     public static implicit operator string(ParameterComment? instance) => instance?.ToString() ?? string.Empty;
 
+    /// <inheritdoc/>
     public override string ToString() => Name;
 }

--- a/src/Typewriter.Engine/CodeModel/Property.cs
+++ b/src/Typewriter.Engine/CodeModel/Property.cs
@@ -1,28 +1,77 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A property declared on a class, record, struct, or interface, enumerated in
+/// templates with <c>$Properties[...]</c>. Indexers are included and flagged
+/// with <see cref="IsIndexer"/>.
+/// </summary>
 public class Property : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the property, for example <c>[JsonPropertyName("...")]</c>.
+    /// Template shorthand: <c>$Attributes[...]</c>.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the property, or <c>null</c> when it has none.
+    /// Use <c>$DocComment.Summary</c> in templates.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the property has a getter.
+    /// Template shorthand: <c>$HasGetter[...][...]</c>.
+    /// </summary>
     public virtual bool HasGetter { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the property has a setter (including <c>init</c>).
+    /// Template shorthand: <c>$HasSetter[...][...]</c>.
+    /// </summary>
     public virtual bool HasSetter { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the property is declared <c>abstract</c>.
+    /// </summary>
     public virtual bool IsAbstract { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the property is an indexer, for example
+    /// <c>this[string key]</c>. Template shorthand: <c>$IsIndexer[...][...]</c>.
+    /// </summary>
     public virtual bool IsIndexer { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the property is declared <c>required</c>.
+    /// </summary>
     public virtual bool IsRequired { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the property is declared <c>virtual</c>.
+    /// </summary>
     public virtual bool IsVirtual { get; init; }
 
+    /// <summary>
+    /// Gets the indexer parameters. Empty for normal properties.
+    /// Template shorthand: <c>$Parameters[...]</c>.
+    /// </summary>
     public virtual IParameterCollection Parameters { get; init; } = new ParameterCollection();
 
+    /// <summary>
+    /// Gets the type of the property. Rendering it (<c>$Type</c>) produces the mapped
+    /// TypeScript type, for example <c>number</c> for C# <c>int</c>.
+    /// </summary>
     public virtual Type Type { get; init; } = new();
 
+    /// <summary>
+    /// Gets the property initializer value, for example <c>"text"</c> for
+    /// <c>public string Name { get; set; } = "text";</c>. Template shorthand: <c>$Value</c>.
+    /// </summary>
     public virtual string Value { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Converts the property to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Property? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/Record.cs
+++ b/src/Typewriter.Engine/CodeModel/Record.cs
@@ -1,54 +1,142 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A C# record made available to templates through <c>$Records[...]</c>.
+/// Exposes the members, base record, interfaces, and nested types of the record.
+/// </summary>
 public class Record : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the record.
+    /// Template shorthand: <c>$Attributes[...]</c>.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the direct base record this record inherits from, or <c>null</c> when there is none.
+    /// The base record exposes the same members, so <c>$BaseRecord[...]</c> can walk
+    /// inheritance chains.
+    /// </summary>
     public virtual Record? BaseRecord { get; init; }
 
+    /// <summary>
+    /// Gets the <c>const</c> members declared on the record.
+    /// Template shorthand: <c>$Constants[...]</c>.
+    /// </summary>
     public virtual IConstantCollection Constants { get; init; } = new ConstantCollection();
 
+    /// <summary>
+    /// Gets the record this record is nested inside, or <c>null</c> for top-level records.
+    /// </summary>
     public virtual Record? ContainingRecord { get; init; }
 
+    /// <summary>
+    /// Gets the delegates declared inside the record.
+    /// </summary>
     public virtual IDelegateCollection Delegates { get; init; } = new DelegateCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the record, or <c>null</c> when the record
+    /// has no doc comment. Use <c>$DocComment.Summary</c> in templates.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets the events declared on the record.
+    /// </summary>
     public virtual IEventCollection Events { get; init; } = new EventCollection();
 
+    /// <summary>
+    /// Gets the instance fields declared on the record.
+    /// </summary>
     public virtual IFieldCollection Fields { get; init; } = new FieldCollection();
 
+    /// <summary>
+    /// Gets the interfaces implemented by the record.
+    /// </summary>
     public virtual IInterfaceCollection Interfaces { get; init; } = new InterfaceCollection();
 
+    /// <summary>
+    /// Gets a value indicating whether the record is declared <c>abstract</c>.
+    /// </summary>
     public virtual bool IsAbstract { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the record declares generic type parameters.
+    /// </summary>
     public virtual bool IsGeneric { get; init; }
 
+    /// <summary>
+    /// Gets the methods declared on the record.
+    /// Template shorthand: <c>$Methods[...]</c>.
+    /// </summary>
     public virtual IMethodCollection Methods { get; init; } = new MethodCollection();
 
+    /// <summary>
+    /// Gets the namespace that contains the record.
+    /// Template shorthand: <c>$Namespace</c>.
+    /// </summary>
     public virtual string Namespace { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the classes nested inside the record.
+    /// </summary>
     public virtual IClassCollection NestedClasses { get; init; } = new ClassCollection();
 
+    /// <summary>
+    /// Gets the enums nested inside the record.
+    /// </summary>
     public virtual IEnumCollection NestedEnums { get; init; } = new EnumCollection();
 
+    /// <summary>
+    /// Gets the interfaces nested inside the record.
+    /// </summary>
     public virtual IInterfaceCollection NestedInterfaces { get; init; } = new InterfaceCollection();
 
+    /// <summary>
+    /// Gets the records nested inside the record.
+    /// </summary>
     public virtual IRecordCollection NestedRecords { get; init; } = new RecordCollection();
 
+    /// <summary>
+    /// Gets the structs nested inside the record.
+    /// </summary>
     public virtual IStructCollection NestedStructs { get; init; } = new StructCollection();
 
+    /// <summary>
+    /// Gets the properties declared on the record, including positional parameters.
+    /// Template shorthand: <c>$Properties[...]</c>.
+    /// </summary>
     public virtual IPropertyCollection Properties { get; init; } = new PropertyCollection();
 
+    /// <summary>
+    /// Gets the <c>static readonly</c> fields declared on the record.
+    /// </summary>
     public virtual IStaticReadOnlyFieldCollection StaticReadOnlyFields { get; init; } = new StaticReadOnlyFieldCollection();
 
+    /// <summary>
+    /// Gets the type reference for the record, exposing type-level information such as
+    /// <c>IsNullable</c>, <c>IsEnumerable</c>, and the TypeScript rendering of the type.
+    /// </summary>
     public virtual Type Type { get; init; } = new();
 
+    /// <summary>
+    /// Gets the generic type arguments of the record when it is a constructed generic type.
+    /// </summary>
     public virtual ITypeCollection TypeArguments { get; init; } = new TypeCollection();
 
+    /// <summary>
+    /// Gets the generic type parameters declared by the record.
+    /// </summary>
     public virtual ITypeParameterCollection TypeParameters { get; init; } = new TypeParameterCollection();
 
+    /// <summary>
+    /// Converts the record to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Record? instance) => instance?.ToString() ?? string.Empty;
 
+    /// <summary>
+    /// Converts the record to its <see cref="Type"/> reference.
+    /// </summary>
     public static implicit operator Type?(Record? instance) => instance?.Type;
 }

--- a/src/Typewriter.Engine/CodeModel/StaticReadOnlyField.cs
+++ b/src/Typewriter.Engine/CodeModel/StaticReadOnlyField.cs
@@ -1,14 +1,33 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A <c>static readonly</c> field declared on a type, enumerated in templates with
+/// <c>$StaticReadOnlyFields[...]</c>.
+/// </summary>
 public class StaticReadOnlyField : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the field.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the field, or <c>null</c> when it has none.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets the type of the field.
+    /// </summary>
     public virtual Type? Type { get; init; }
 
+    /// <summary>
+    /// Gets the field initializer value. Template shorthand: <c>$Value</c>.
+    /// </summary>
     public virtual string Value { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Converts the field to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(StaticReadOnlyField? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.Engine/CodeModel/Struct.cs
+++ b/src/Typewriter.Engine/CodeModel/Struct.cs
@@ -1,54 +1,140 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A C# struct made available to templates through <c>$Structs[...]</c>.
+/// Exposes the members, interfaces, and nested types of the struct.
+/// </summary>
 public class Struct : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the struct.
+    /// Template shorthand: <c>$Attributes[...]</c>.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the <c>const</c> members declared on the struct.
+    /// Template shorthand: <c>$Constants[...]</c>.
+    /// </summary>
     public virtual IConstantCollection Constants { get; init; } = new ConstantCollection();
 
+    /// <summary>
+    /// Gets the class this struct is nested inside, or <c>null</c> when not nested in a class.
+    /// </summary>
     public virtual Class? ContainingClass { get; init; }
 
+    /// <summary>
+    /// Gets the struct this struct is nested inside, or <c>null</c> when not nested in a struct.
+    /// </summary>
     public virtual Struct? ContainingStruct { get; init; }
 
+    /// <summary>
+    /// Gets the delegates declared inside the struct.
+    /// </summary>
     public virtual IDelegateCollection Delegates { get; init; } = new DelegateCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the struct, or <c>null</c> when the struct
+    /// has no doc comment. Use <c>$DocComment.Summary</c> in templates.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets the events declared on the struct.
+    /// </summary>
     public virtual IEventCollection Events { get; init; } = new EventCollection();
 
+    /// <summary>
+    /// Gets the instance fields declared on the struct.
+    /// </summary>
     public virtual IFieldCollection Fields { get; init; } = new FieldCollection();
 
+    /// <summary>
+    /// Gets the interfaces implemented by the struct.
+    /// </summary>
     public virtual IInterfaceCollection Interfaces { get; init; } = new InterfaceCollection();
 
+    /// <summary>
+    /// Gets a value indicating whether the struct declares generic type parameters.
+    /// </summary>
     public virtual bool IsGeneric { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the struct is declared <c>static</c>.
+    /// </summary>
     public virtual bool IsStatic { get; init; }
 
+    /// <summary>
+    /// Gets the methods declared on the struct.
+    /// Template shorthand: <c>$Methods[...]</c>.
+    /// </summary>
     public virtual IMethodCollection Methods { get; init; } = new MethodCollection();
 
+    /// <summary>
+    /// Gets the namespace that contains the struct.
+    /// Template shorthand: <c>$Namespace</c>.
+    /// </summary>
     public virtual string Namespace { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the classes nested inside the struct.
+    /// </summary>
     public virtual IClassCollection NestedClasses { get; init; } = new ClassCollection();
 
+    /// <summary>
+    /// Gets the enums nested inside the struct.
+    /// </summary>
     public virtual IEnumCollection NestedEnums { get; init; } = new EnumCollection();
 
+    /// <summary>
+    /// Gets the interfaces nested inside the struct.
+    /// </summary>
     public virtual IInterfaceCollection NestedInterfaces { get; init; } = new InterfaceCollection();
 
+    /// <summary>
+    /// Gets the records nested inside the struct.
+    /// </summary>
     public virtual IRecordCollection NestedRecords { get; init; } = new RecordCollection();
 
+    /// <summary>
+    /// Gets the structs nested inside the struct.
+    /// </summary>
     public virtual IStructCollection NestedStructs { get; init; } = new StructCollection();
 
+    /// <summary>
+    /// Gets the properties declared on the struct, including indexers.
+    /// Template shorthand: <c>$Properties[...]</c>.
+    /// </summary>
     public virtual IPropertyCollection Properties { get; init; } = new PropertyCollection();
 
+    /// <summary>
+    /// Gets the <c>static readonly</c> fields declared on the struct.
+    /// </summary>
     public virtual IStaticReadOnlyFieldCollection StaticReadOnlyFields { get; init; } = new StaticReadOnlyFieldCollection();
 
+    /// <summary>
+    /// Gets the type reference for the struct, exposing type-level information such as
+    /// <c>IsStruct</c>, <c>IsNullable</c>, and the TypeScript rendering of the type.
+    /// </summary>
     public virtual Type Type { get; init; } = new();
 
+    /// <summary>
+    /// Gets the generic type arguments of the struct when it is a constructed generic type.
+    /// </summary>
     public virtual ITypeCollection TypeArguments { get; init; } = new TypeCollection();
 
+    /// <summary>
+    /// Gets the generic type parameters declared by the struct.
+    /// </summary>
     public virtual ITypeParameterCollection TypeParameters { get; init; } = new TypeParameterCollection();
 
+    /// <summary>
+    /// Converts the struct to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(Struct? instance) => instance?.ToString() ?? string.Empty;
 
+    /// <summary>
+    /// Converts the struct to its <see cref="Type"/> reference.
+    /// </summary>
     public static implicit operator Type?(Struct? instance) => instance?.Type;
 }

--- a/src/Typewriter.Engine/CodeModel/Type.cs
+++ b/src/Typewriter.Engine/CodeModel/Type.cs
@@ -2,86 +2,227 @@ using Typewriter.Configuration;
 
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A type reference in the code model, for example the type of a property, parameter,
+/// or method return value. Rendering it (template shorthand <c>$Type</c>) produces the
+/// mapped TypeScript type, for example <c>number</c> for C# <c>int</c>.
+/// </summary>
 public class Type : Item
 {
+    /// <summary>
+    /// Gets the attributes applied to the type declaration.
+    /// </summary>
     public virtual IAttributeCollection Attributes { get; init; } = new AttributeCollection();
 
+    /// <summary>
+    /// Gets the direct base class of the type, or <c>null</c> when the type inherits
+    /// only from <c>object</c>. Useful for walking inheritance chains, for example
+    /// <c>$BaseClass[ extends $Name]</c>.
+    /// </summary>
     public virtual Class? BaseClass { get; init; }
 
+    /// <summary>
+    /// Gets the <c>const</c> members declared on the type.
+    /// </summary>
     public virtual IConstantCollection Constants { get; init; } = new ConstantCollection();
 
+    /// <summary>
+    /// Gets the class this type is nested inside, or <c>null</c> for top-level types.
+    /// </summary>
     public virtual Class? ContainingClass { get; init; }
 
+    /// <summary>
+    /// Gets the delegates declared inside the type.
+    /// </summary>
     public virtual IDelegateCollection Delegates { get; init; } = new DelegateCollection();
 
+    /// <summary>
+    /// Gets the XML documentation comment of the type, or <c>null</c> when the type
+    /// has no doc comment. Use <c>$DocComment.Summary</c> in templates.
+    /// </summary>
     public virtual DocComment? DocComment { get; init; }
 
+    /// <summary>
+    /// Gets the element type of arrays and enumerable types, for example <c>string</c>
+    /// for <c>string[]</c> or <c>List&lt;string&gt;</c>; <c>null</c> for non-enumerable types.
+    /// </summary>
     public virtual Type? ElementType { get; init; }
 
+    /// <summary>
+    /// Gets the instance fields declared on the type.
+    /// </summary>
     public virtual IFieldCollection Fields { get; init; } = new FieldCollection();
 
+    /// <summary>
+    /// Gets the source file paths where the type is declared (multiple for partial types).
+    /// </summary>
     public virtual IEnumerable<string> FileLocations { get; init; } = [];
 
+    /// <summary>
+    /// Gets the interfaces implemented by the type.
+    /// </summary>
     public virtual IInterfaceCollection Interfaces { get; init; } = new InterfaceCollection();
 
+    /// <summary>
+    /// Gets a value indicating whether the type represents date or time data,
+    /// for example <c>DateTime</c>, <c>DateTimeOffset</c>, <c>DateOnly</c>, or NodaTime types.
+    /// </summary>
     public virtual bool IsDate { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is defined in the loaded workspace source
+    /// (as opposed to a referenced assembly or framework type).
+    /// </summary>
     public virtual bool IsDefined { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is a dictionary,
+    /// for example <c>Dictionary&lt;string, int&gt;</c>.
+    /// </summary>
     public virtual bool IsDictionary { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is <c>dynamic</c>.
+    /// </summary>
     public virtual bool IsDynamic { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is an enum.
+    /// </summary>
     public virtual bool IsEnum { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is enumerable (arrays, <c>List&lt;T&gt;</c>,
+    /// <c>IEnumerable&lt;T&gt;</c>, ...). <c>string</c> is not treated as enumerable.
+    /// </summary>
     public virtual bool IsEnumerable { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is generic.
+    /// </summary>
     public virtual bool IsGeneric { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is <c>System.Guid</c>.
+    /// </summary>
     public virtual bool IsGuid { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is nullable (<c>T?</c> or
+    /// <c>Nullable&lt;T&gt;</c>). Template shorthand: <c>$IsNullable[...][...]</c>.
+    /// </summary>
     public virtual bool IsNullable { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type maps to a primitive TypeScript type
+    /// (<c>string</c>, <c>number</c>, <c>boolean</c>, ...).
+    /// </summary>
     public virtual bool IsPrimitive { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is a struct (value type).
+    /// </summary>
     public virtual bool IsStruct { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is <c>Task</c> or <c>Task&lt;T&gt;</c>.
+    /// Await-unwrapped rendering uses the inner type.
+    /// </summary>
     public virtual bool IsTask { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is <c>System.TimeSpan</c>.
+    /// </summary>
     public virtual bool IsTimeSpan { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether the type is a value tuple, for example <c>(int, string)</c>.
+    /// </summary>
     public virtual bool IsValueTuple { get; init; }
 
+    /// <summary>
+    /// Gets the methods declared on the type.
+    /// </summary>
     public virtual IMethodCollection Methods { get; init; } = new MethodCollection();
 
+    /// <summary>
+    /// Gets the namespace that contains the type.
+    /// </summary>
     public virtual string Namespace { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the classes nested inside the type.
+    /// </summary>
     public virtual IClassCollection NestedClasses { get; init; } = new ClassCollection();
 
+    /// <summary>
+    /// Gets the enums nested inside the type.
+    /// </summary>
     public virtual IEnumCollection NestedEnums { get; init; } = new EnumCollection();
 
+    /// <summary>
+    /// Gets the interfaces nested inside the type.
+    /// </summary>
     public virtual IInterfaceCollection NestedInterfaces { get; init; } = new InterfaceCollection();
 
+    /// <summary>
+    /// Gets the records nested inside the type.
+    /// </summary>
     public virtual IRecordCollection NestedRecords { get; init; } = new RecordCollection();
 
+    /// <summary>
+    /// Gets the structs nested inside the type.
+    /// </summary>
     public virtual IStructCollection NestedStructs { get; init; } = new StructCollection();
 
+    /// <summary>
+    /// Gets the original C# name of the type before TypeScript mapping,
+    /// for example <c>Int32</c> when <see cref="Item.Name"/> renders <c>number</c>.
+    /// Template shorthand: <c>$OriginalName</c>.
+    /// </summary>
     public virtual string OriginalName { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Gets the properties declared on the type.
+    /// </summary>
     public virtual IPropertyCollection Properties { get; init; } = new PropertyCollection();
 
+    /// <summary>
+    /// Gets the <c>static readonly</c> fields declared on the type.
+    /// </summary>
     public virtual IStaticReadOnlyFieldCollection StaticReadOnlyFields { get; init; } = new StaticReadOnlyFieldCollection();
 
+    /// <summary>
+    /// Gets the generic type arguments of the type, for example <c>string</c> and <c>int</c>
+    /// in <c>Dictionary&lt;string, int&gt;</c>. Template shorthand: <c>$TypeArguments[...]</c>.
+    /// </summary>
     public virtual ITypeCollection TypeArguments { get; init; } = new TypeCollection();
 
+    /// <summary>
+    /// Gets the generic type parameters declared by the type.
+    /// </summary>
     public virtual ITypeParameterCollection TypeParameters { get; init; } = new TypeParameterCollection();
 
+    /// <summary>
+    /// Gets the elements of a value tuple type, for example <c>Item1</c> and <c>Item2</c>.
+    /// </summary>
     public virtual IFieldCollection TupleElements { get; init; } = new FieldCollection();
 
+    /// <summary>
+    /// Gets the default TypeScript value for the type, for example <c>0</c> for <c>number</c>
+    /// and <c>null</c> for nullable types. Template shorthand: <c>$Type[$Default]</c>.
+    /// </summary>
     public virtual string DefaultValue { get; init; } = "null";
 
+    /// <summary>
+    /// Gets the template settings in effect for the current render, or <c>null</c> outside rendering.
+    /// </summary>
     public virtual Settings? Settings { get; init; }
 
+    /// <summary>
+    /// Converts the type to its rendered TypeScript name, with strict-null suffixes,
+    /// parentheses, and array brackets removed.
+    /// </summary>
     public static implicit operator string(Type? type) => NormalizeName(name: type?.ToString());
 
     private static string NormalizeName(string? name)

--- a/src/Typewriter.Engine/CodeModel/TypeParameter.cs
+++ b/src/Typewriter.Engine/CodeModel/TypeParameter.cs
@@ -1,8 +1,18 @@
 namespace Typewriter.CodeModel;
 
+/// <summary>
+/// A generic type parameter declared by a type or method, for example <c>T</c> in
+/// <c>Result&lt;T&gt;</c>, enumerated in templates with <c>$TypeParameters[...]</c>.
+/// </summary>
 public class TypeParameter : Item
 {
+    /// <summary>
+    /// Gets the generic constraints of the type parameter, for example <c>where T : class</c>.
+    /// </summary>
     public virtual string Constraints { get; init; } = string.Empty;
 
+    /// <summary>
+    /// Converts the type parameter to its name so it can be used directly in string contexts.
+    /// </summary>
     public static implicit operator string(TypeParameter? instance) => instance?.ToString() ?? string.Empty;
 }

--- a/src/Typewriter.LanguageServer/EmbeddedCSharpLanguageService.cs
+++ b/src/Typewriter.LanguageServer/EmbeddedCSharpLanguageService.cs
@@ -239,7 +239,7 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
             cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
         if (symbol is not null)
         {
-            return symbol;
+            return UnwrapAlias(symbol: symbol);
         }
 
         var semanticModel = await document.GetSemanticModelAsync(cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
@@ -255,19 +255,22 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
             var declared = semanticModel.GetDeclaredSymbol(declaration: node, cancellationToken: cancellationToken);
             if (declared is not null)
             {
-                return declared;
+                return UnwrapAlias(symbol: declared);
             }
 
             var symbolInfo = semanticModel.GetSymbolInfo(node: node, cancellationToken: cancellationToken);
             var resolved = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
             if (resolved is not null)
             {
-                return resolved;
+                return UnwrapAlias(symbol: resolved);
             }
         }
 
         return null;
     }
+
+    private static ISymbol UnwrapAlias(ISymbol symbol) =>
+        symbol is IAliasSymbol alias ? alias.Target : symbol;
 
     private static DocumentCacheEntry CreateDocumentCacheEntry(
         TextDocumentState document,

--- a/src/Typewriter.LanguageServer/EmbeddedCSharpLanguageService.cs
+++ b/src/Typewriter.LanguageServer/EmbeddedCSharpLanguageService.cs
@@ -26,13 +26,15 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
     public async Task<EmbeddedCSharpCompletions?> GetCompletionsAsync(
         TextDocumentState document,
         int templateOffset,
-        CancellationToken cancellationToken)
+        IReadOnlyList<Compilation>? projectCompilations = null,
+        CancellationToken cancellationToken = default)
     {
         try
         {
             return await UseDocumentAsync<EmbeddedCSharpCompletions?>(
                 document: document,
                 templateOffset: templateOffset,
+                projectCompilations: projectCompilations ?? [],
                 fallback: null,
                 action: async (entry, virtualOffset, token) =>
                 {
@@ -65,7 +67,7 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
                                 Label: symbol.Name,
                                 Kind: GetCompletionKind(symbol: symbol),
                                 Detail: symbol.ToDisplayString(format: SymbolDisplayFormat.MinimallyQualifiedFormat),
-                                Documentation: null));
+                                Documentation: isMemberAccess ? GetDocumentationSummary(symbol: symbol) : null));
                     }
 
                     var ordered = items
@@ -89,13 +91,15 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
     public async Task<LspHover?> GetHoverAsync(
         TextDocumentState document,
         int templateOffset,
-        CancellationToken cancellationToken)
+        IReadOnlyList<Compilation>? projectCompilations = null,
+        CancellationToken cancellationToken = default)
     {
         try
         {
             return await UseDocumentAsync<LspHover?>(
                 document: document,
                 templateOffset: templateOffset,
+                projectCompilations: projectCompilations ?? [],
                 fallback: null,
                 action: async (entry, virtualOffset, token) =>
                 {
@@ -136,13 +140,15 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
     public async Task<IReadOnlyList<LspLocation>> GetDefinitionsAsync(
         TextDocumentState document,
         int templateOffset,
-        CancellationToken cancellationToken)
+        IReadOnlyList<Compilation>? projectCompilations = null,
+        CancellationToken cancellationToken = default)
     {
         try
         {
             return await UseDocumentAsync<IReadOnlyList<LspLocation>>(
                 document: document,
                 templateOffset: templateOffset,
+                projectCompilations: projectCompilations ?? [],
                 fallback: [],
                 action: async (entry, virtualOffset, token) =>
                 {
@@ -153,8 +159,24 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
                     }
 
                     var locations = new List<LspLocation>();
-                    foreach (var sourceSpan in symbol.Locations.Where(predicate: location => location.IsInSource).Select(selector: location => location.SourceSpan))
+                    foreach (var location in symbol.Locations.Where(predicate: location => location.IsInSource))
                     {
+                        var sourceFilePath = location.SourceTree?.FilePath;
+                        if (!string.IsNullOrWhiteSpace(value: sourceFilePath)
+                            && Path.IsPathRooted(path: sourceFilePath)
+                            && System.IO.File.Exists(path: sourceFilePath))
+                        {
+                            var lineSpan = location.GetLineSpan();
+                            locations.Add(
+                                item: new LspLocation(
+                                    Uri: new Uri(uriString: Path.GetFullPath(path: sourceFilePath)).AbsoluteUri,
+                                    Range: new LspRange(
+                                        Start: new LspPosition(Line: lineSpan.StartLinePosition.Line, Character: lineSpan.StartLinePosition.Character),
+                                        End: new LspPosition(Line: lineSpan.EndLinePosition.Line, Character: lineSpan.EndLinePosition.Character))));
+                            continue;
+                        }
+
+                        var sourceSpan = location.SourceSpan;
                         var range = TryCreateTemplateRange(
                             document: document,
                             virtualDocument: entry.VirtualDocument,
@@ -249,7 +271,8 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
 
     private static DocumentCacheEntry CreateDocumentCacheEntry(
         TextDocumentState document,
-        EmbeddedCSharpDocument virtualDocument)
+        EmbeddedCSharpDocument virtualDocument,
+        IReadOnlyList<Compilation> projectCompilations)
     {
 #pragma warning disable IDISP001 // Dispose ownership transfers to DocumentCacheEntry
         var workspace = new AdhocWorkspace();
@@ -267,7 +290,7 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
                         outputKind: OutputKind.DynamicallyLinkedLibrary,
                         nullableContextOptions: NullableContextOptions.Disable))
                 .WithParseOptions(parseOptions: CSharpParseOptions.Default.WithLanguageVersion(version: LanguageVersion.Preview))
-                .WithMetadataReferences(metadataReferences: SharedReferences.Value);
+                .WithMetadataReferences(metadataReferences: CreateWorkspaceReferences(projectCompilations: projectCompilations));
             var project = workspace.AddProject(projectInfo: projectInfo);
             var roslynDocument = workspace.AddDocument(
                 projectId: project.Id,
@@ -277,6 +300,7 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
                 uri: document.Uri,
                 text: document.Text,
                 virtualDocument: virtualDocument,
+                projectCompilations: projectCompilations,
                 workspace: workspace,
                 document: roslynDocument);
         }
@@ -285,6 +309,76 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
             workspace.Dispose();
             throw;
         }
+    }
+
+    private static IReadOnlyList<MetadataReference> CreateWorkspaceReferences(IReadOnlyList<Compilation> projectCompilations)
+    {
+        if (projectCompilations.Count == 0)
+        {
+            return SharedReferences.Value;
+        }
+
+        var references = new Dictionary<string, MetadataReference>(comparer: StringComparer.OrdinalIgnoreCase);
+        foreach (var reference in SharedReferences.Value)
+        {
+            var key = GetReferenceKey(reference: reference);
+            if (key is not null)
+            {
+                references[key: key] = reference;
+            }
+        }
+
+        foreach (var compilation in projectCompilations)
+        {
+            foreach (var reference in compilation.References)
+            {
+                var key = GetReferenceKey(reference: reference);
+                if (key is null
+                    || (key.StartsWith(value: "Typewriter.", comparisonType: StringComparison.OrdinalIgnoreCase) && references.ContainsKey(key: key)))
+                {
+                    continue;
+                }
+
+                references[key: key] = reference;
+            }
+
+            var assemblyName = compilation.AssemblyName;
+            if (!string.IsNullOrWhiteSpace(value: assemblyName))
+            {
+                references[key: assemblyName] = compilation.ToMetadataReference();
+            }
+        }
+
+        return references.Values.ToArray();
+    }
+
+    private static string? GetReferenceKey(MetadataReference reference) =>
+        reference switch
+        {
+            CompilationReference compilationReference => compilationReference.Compilation.AssemblyName,
+            PortableExecutableReference executableReference when !string.IsNullOrWhiteSpace(value: executableReference.FilePath) =>
+                Path.GetFileNameWithoutExtension(path: executableReference.FilePath),
+            _ => reference.Display,
+        };
+
+    private static bool CompilationsEqual(
+        IReadOnlyList<Compilation> first,
+        IReadOnlyList<Compilation> second)
+    {
+        if (first.Count != second.Count)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < first.Count; index++)
+        {
+            if (!ReferenceEquals(objA: first[index: index], objB: second[index: index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static IReadOnlyList<MetadataReference> CreateMetadataReferences()
@@ -301,8 +395,16 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
             .Where(predicate: path => !string.IsNullOrWhiteSpace(value: path))
             .Distinct(comparer: StringComparer.OrdinalIgnoreCase)
             .Where(predicate: System.IO.File.Exists)
-            .Select(selector: path => (MetadataReference)MetadataReference.CreateFromFile(path: path))
+            .Select(selector: CreateMetadataReference)
             .ToArray();
+    }
+
+    private static MetadataReference CreateMetadataReference(string path)
+    {
+        var xmlDocumentationPath = Path.ChangeExtension(path: path, extension: ".xml");
+        return System.IO.File.Exists(path: xmlDocumentationPath)
+            ? MetadataReference.CreateFromFile(path: path, documentation: XmlDocumentationProvider.CreateFromFile(xmlDocCommentFilePath: xmlDocumentationPath))
+            : MetadataReference.CreateFromFile(path: path);
     }
 
     private static (string Prefix, bool IsMemberAccess) GetCompletionContext(
@@ -432,6 +534,7 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
     private async Task<TResult> UseDocumentAsync<TResult>(
         TextDocumentState document,
         int templateOffset,
+        IReadOnlyList<Compilation> projectCompilations,
         TResult fallback,
         Func<DocumentCacheEntry, int, CancellationToken, Task<TResult>> action,
         CancellationToken cancellationToken)
@@ -440,7 +543,7 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
         DocumentCacheEntry? entry = null;
         try
         {
-            entry = GetOrCreateDocument(document: document);
+            entry = GetOrCreateDocument(document: document, projectCompilations: projectCompilations);
             if (entry is null
                 || !entry.VirtualDocument.TryMapToVirtual(templateOffset: templateOffset, virtualOffset: out var virtualOffset))
             {
@@ -458,7 +561,9 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
         }
     }
 
-    private DocumentCacheEntry? GetOrCreateDocument(TextDocumentState document)
+    private DocumentCacheEntry? GetOrCreateDocument(
+        TextDocumentState document,
+        IReadOnlyList<Compilation> projectCompilations)
     {
         DocumentCacheEntry? entryToDispose = null;
         DocumentCacheEntry? entry;
@@ -471,7 +576,8 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
 
             if (_cache is not null
                 && string.Equals(a: _cache.Uri, b: document.Uri, comparisonType: StringComparison.OrdinalIgnoreCase)
-                && string.Equals(a: _cache.Text, b: document.Text, comparisonType: StringComparison.Ordinal))
+                && string.Equals(a: _cache.Text, b: document.Text, comparisonType: StringComparison.Ordinal)
+                && CompilationsEqual(first: _cache.ProjectCompilations, second: projectCompilations))
             {
                 _cache.UseCount++;
                 return _cache;
@@ -483,7 +589,7 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
                 return null;
             }
 
-            entry = CreateDocumentCacheEntry(document: document, virtualDocument: virtualDocument);
+            entry = CreateDocumentCacheEntry(document: document, virtualDocument: virtualDocument, projectCompilations: projectCompilations);
             entry.UseCount++;
             if (_cache is not null)
             {
@@ -540,12 +646,14 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
             string uri,
             string text,
             EmbeddedCSharpDocument virtualDocument,
+            IReadOnlyList<Compilation> projectCompilations,
             AdhocWorkspace workspace,
             Document document)
         {
             Uri = uri;
             Text = text;
             VirtualDocument = virtualDocument;
+            ProjectCompilations = projectCompilations;
             Workspace = workspace;
             Document = document;
         }
@@ -555,6 +663,8 @@ internal sealed class EmbeddedCSharpLanguageService : IDisposable
         public string Text { get; }
 
         public EmbeddedCSharpDocument VirtualDocument { get; }
+
+        public IReadOnlyList<Compilation> ProjectCompilations { get; }
 
         public AdhocWorkspace Workspace { get; }
 

--- a/src/Typewriter.LanguageServer/EmbeddedDocumentService.cs
+++ b/src/Typewriter.LanguageServer/EmbeddedDocumentService.cs
@@ -1,0 +1,104 @@
+namespace Typewriter.LanguageServer;
+
+/// <summary>
+/// Builds virtual embedded-language documents for .tst templates and translates
+/// positions and ranges between the template and each virtual document.
+/// </summary>
+internal static class EmbeddedDocumentService
+{
+    public const string TemplateKind = "template";
+    public const string CSharpKind = "csharp";
+    public const string TypeScriptKind = "typescript";
+
+    public static EmbeddedDocumentSnapshot? GetSnapshot(
+        TextDocumentState document,
+        string kind)
+    {
+        if (IsCSharpKind(kind: kind))
+        {
+            var virtualDocument = EmbeddedCSharpDocument.Create(templateText: document.Text);
+            return virtualDocument is null
+                ? null
+                : new EmbeddedDocumentSnapshot(
+                    Kind: CSharpKind,
+                    LanguageId: "csharp",
+                    Content: virtualDocument.Source,
+                    Version: document.Version);
+        }
+
+        if (IsTypeScriptKind(kind: kind))
+        {
+            return new EmbeddedDocumentSnapshot(
+                Kind: TypeScriptKind,
+                LanguageId: "typescript",
+                Content: EmbeddedTypeScriptDocument.Create(templateText: document.Text),
+                Version: document.Version);
+        }
+
+        return null;
+    }
+
+    public static EmbeddedPositionInfo GetPositionInfo(
+        TextDocumentState document,
+        LspPosition position)
+    {
+        var kind = TemplateEmbeddedLanguage.GetKindAt(document: document, position: position);
+        if (kind == EmbeddedLanguageKind.CSharp)
+        {
+            var virtualDocument = EmbeddedCSharpDocument.Create(templateText: document.Text);
+            if (virtualDocument is not null
+                && virtualDocument.TryMapToVirtual(
+                    templateOffset: document.GetOffset(position: position),
+                    virtualOffset: out var virtualOffset))
+            {
+                return new EmbeddedPositionInfo(
+                    Kind: CSharpKind,
+                    VirtualPosition: TextPositions.GetPosition(text: virtualDocument.Source, offset: virtualOffset));
+            }
+
+            return new EmbeddedPositionInfo(Kind: CSharpKind, VirtualPosition: null);
+        }
+
+        return kind == EmbeddedLanguageKind.TypeScript
+            ? new EmbeddedPositionInfo(Kind: TypeScriptKind, VirtualPosition: position)
+            : new EmbeddedPositionInfo(Kind: TemplateKind, VirtualPosition: null);
+    }
+
+    public static LspRange? MapRangeToTemplate(
+        TextDocumentState document,
+        string kind,
+        LspRange range)
+    {
+        if (IsTypeScriptKind(kind: kind))
+        {
+            return range;
+        }
+
+        if (!IsCSharpKind(kind: kind))
+        {
+            return null;
+        }
+
+        var virtualDocument = EmbeddedCSharpDocument.Create(templateText: document.Text);
+        if (virtualDocument is null
+            || !virtualDocument.TryMapToTemplate(
+                virtualOffset: TextPositions.GetOffset(text: virtualDocument.Source, position: range.Start),
+                templateOffset: out var templateStart)
+            || !virtualDocument.TryMapToTemplate(
+                virtualOffset: TextPositions.GetOffset(text: virtualDocument.Source, position: range.End),
+                templateOffset: out var templateEnd))
+        {
+            return null;
+        }
+
+        return new LspRange(
+            Start: TextPositions.GetPosition(text: document.Text, offset: templateStart),
+            End: TextPositions.GetPosition(text: document.Text, offset: templateEnd));
+    }
+
+    private static bool IsCSharpKind(string kind) =>
+        string.Equals(a: kind, b: CSharpKind, comparisonType: StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsTypeScriptKind(string kind) =>
+        string.Equals(a: kind, b: TypeScriptKind, comparisonType: StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Typewriter.LanguageServer/EmbeddedDocumentSnapshot.cs
+++ b/src/Typewriter.LanguageServer/EmbeddedDocumentSnapshot.cs
@@ -1,0 +1,7 @@
+namespace Typewriter.LanguageServer;
+
+internal sealed record EmbeddedDocumentSnapshot(
+    string Kind,
+    string LanguageId,
+    string Content,
+    int? Version);

--- a/src/Typewriter.LanguageServer/EmbeddedPositionInfo.cs
+++ b/src/Typewriter.LanguageServer/EmbeddedPositionInfo.cs
@@ -1,0 +1,5 @@
+namespace Typewriter.LanguageServer;
+
+internal sealed record EmbeddedPositionInfo(
+    string Kind,
+    LspPosition? VirtualPosition);

--- a/src/Typewriter.LanguageServer/EmbeddedTypeScriptDocument.cs
+++ b/src/Typewriter.LanguageServer/EmbeddedTypeScriptDocument.cs
@@ -1,0 +1,44 @@
+namespace Typewriter.LanguageServer;
+
+/// <summary>
+/// Projects a .tst template into a TypeScript view with identical offsets by
+/// blanking C# helper blocks, so template and virtual positions map one-to-one.
+/// TypeScript template-literal interpolation such as ${environment.apiBaseUrl}
+/// is preserved because it is not recognized as a C# helper block.
+/// </summary>
+internal static class EmbeddedTypeScriptDocument
+{
+    public static string Create(string templateText)
+    {
+        var buffer = templateText.ToCharArray();
+        var index = 0;
+        while (index < templateText.Length)
+        {
+            if (templateText[index: index] != '$'
+                || !TemplateEmbeddedLanguage.TryReadCSharpBlock(text: templateText, dollarIndex: index, allowUnclosed: true, region: out var region))
+            {
+                index++;
+                continue;
+            }
+
+            BlankRegion(buffer: buffer, start: region.Start, end: region.End);
+            index = Math.Max(val1: region.End, val2: index + 1);
+        }
+
+        return new string(value: buffer);
+    }
+
+    private static void BlankRegion(
+        char[] buffer,
+        int start,
+        int end)
+    {
+        for (var index = start; index < end && index < buffer.Length; index++)
+        {
+            if (buffer[index] is not '\r' and not '\n')
+            {
+                buffer[index] = ' ';
+            }
+        }
+    }
+}

--- a/src/Typewriter.LanguageServer/LanguageServerHost.cs
+++ b/src/Typewriter.LanguageServer/LanguageServerHost.cs
@@ -94,6 +94,7 @@ internal sealed class LanguageServerHost
                 experimental = new
                 {
                     typewriterGenerationProvider = true,
+                    typewriterEmbeddedLanguageProvider = true,
                 },
             },
             serverInfo = new
@@ -168,6 +169,45 @@ internal sealed class LanguageServerHost
                && property.TryGetInt32(value: out value);
     }
 
+    private static bool TryReadRange(
+        JsonElement parameters,
+        out LspRange range)
+    {
+        range = default!;
+#pragma warning disable CC0021 // Use nameof
+        if (parameters.ValueKind != JsonValueKind.Object
+            || !parameters.TryGetProperty(propertyName: "range", value: out var rangeElement)
+            || !TryReadPosition(element: rangeElement, propertyName: "start", position: out var start)
+            || !TryReadPosition(element: rangeElement, propertyName: "end", position: out var end))
+        {
+            return false;
+        }
+#pragma warning restore CC0021 // Use nameof
+
+        range = new LspRange(Start: start, End: end);
+        return true;
+    }
+
+    private static bool TryReadPosition(
+        JsonElement element,
+        string propertyName,
+        out LspPosition position)
+    {
+        position = new LspPosition(Line: 0, Character: 0);
+#pragma warning disable CC0021 // Use nameof
+        if (element.ValueKind != JsonValueKind.Object
+            || !element.TryGetProperty(propertyName: propertyName, value: out var positionElement)
+            || !TryReadInt(element: positionElement, propertyName: "line", value: out var line)
+            || !TryReadInt(element: positionElement, propertyName: "character", value: out var character))
+        {
+            return false;
+        }
+#pragma warning restore CC0021 // Use nameof
+
+        position = new LspPosition(Line: line, Character: character);
+        return true;
+    }
+
     private static string PathFromUri(string uri)
     {
         return FileUriPath.TryGetPath(uri: uri) ?? uri;
@@ -237,6 +277,15 @@ internal sealed class LanguageServerHost
             case "textDocument/semanticTokens/full":
                 await WriteSemanticTokensResponseAsync(id: id, parameters: parameters, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
                 break;
+            case "typewriter/embeddedDocument":
+                await WriteEmbeddedDocumentResponseAsync(id: id, parameters: parameters, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+                break;
+            case "typewriter/embeddedPosition":
+                await WriteEmbeddedPositionResponseAsync(id: id, parameters: parameters, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+                break;
+            case "typewriter/templateRange":
+                await WriteTemplateRangeResponseAsync(id: id, parameters: parameters, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+                break;
             default:
                 await _connection.WriteErrorResponseAsync(
                     id: id,
@@ -263,6 +312,7 @@ internal sealed class LanguageServerHost
                 {
                     _documents[key: openedDocument.Uri] = openedDocument;
                     ScheduleValidation(uri: openedDocument.Uri, immediate: true, cancellationToken: cancellationToken);
+                    await NotifyEmbeddedDocumentChangedAsync(uri: openedDocument.Uri, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
                 }
 
                 break;
@@ -270,6 +320,7 @@ internal sealed class LanguageServerHost
                 if (TryApplyDocumentChange(parameters: parameters, uri: out var changedUri))
                 {
                     ScheduleValidation(uri: changedUri, immediate: false, cancellationToken: cancellationToken);
+                    await NotifyEmbeddedDocumentChangedAsync(uri: changedUri, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
                 }
 
                 break;
@@ -277,6 +328,7 @@ internal sealed class LanguageServerHost
                 if (TryApplyDocumentSave(parameters: parameters, uri: out var savedUri))
                 {
                     ScheduleValidation(uri: savedUri, immediate: true, cancellationToken: cancellationToken);
+                    await NotifyEmbeddedDocumentChangedAsync(uri: savedUri, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
                 }
 
                 break;
@@ -367,6 +419,79 @@ internal sealed class LanguageServerHost
             id: id,
             result: _semanticTokenService.GetSemanticTokens(document: document),
             cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+    }
+
+    private async Task WriteEmbeddedDocumentResponseAsync(
+        JsonElement id,
+        JsonElement parameters,
+        CancellationToken cancellationToken)
+    {
+        if (!TryReadTextDocumentUri(parameters: parameters, uri: out var uri)
+            || !_documents.TryGetValue(key: uri, value: out var document)
+            || !TryReadString(element: parameters, propertyName: "kind", value: out var kind))
+        {
+            await _connection.WriteResponseAsync(id: id, result: null, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+            return;
+        }
+
+        await _connection.WriteResponseAsync(
+            id: id,
+            result: EmbeddedDocumentService.GetSnapshot(document: document, kind: kind),
+            cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+    }
+
+    private async Task WriteEmbeddedPositionResponseAsync(
+        JsonElement id,
+        JsonElement parameters,
+        CancellationToken cancellationToken)
+    {
+        if (!TryReadDocumentAndPosition(parameters: parameters, document: out var document, position: out var position))
+        {
+            await _connection.WriteResponseAsync(id: id, result: null, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+            return;
+        }
+
+        await _connection.WriteResponseAsync(
+            id: id,
+            result: EmbeddedDocumentService.GetPositionInfo(document: document, position: position),
+            cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+    }
+
+    private async Task WriteTemplateRangeResponseAsync(
+        JsonElement id,
+        JsonElement parameters,
+        CancellationToken cancellationToken)
+    {
+        if (!TryReadTextDocumentUri(parameters: parameters, uri: out var uri)
+            || !_documents.TryGetValue(key: uri, value: out var document)
+            || !TryReadString(element: parameters, propertyName: "kind", value: out var kind)
+            || !TryReadRange(parameters: parameters, range: out var range))
+        {
+            await _connection.WriteResponseAsync(id: id, result: null, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+            return;
+        }
+
+        await _connection.WriteResponseAsync(
+            id: id,
+            result: EmbeddedDocumentService.MapRangeToTemplate(document: document, kind: kind, range: range),
+            cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+    }
+
+    private Task NotifyEmbeddedDocumentChangedAsync(
+        string uri,
+        CancellationToken cancellationToken)
+    {
+        var version = _documents.TryGetValue(key: uri, value: out var document)
+            ? document.Version
+            : null;
+        return _connection.WriteNotificationAsync(
+            method: "typewriter/embeddedDocumentChanged",
+            parameters: new
+            {
+                uri,
+                version,
+            },
+            cancellationToken: cancellationToken);
     }
 
     private async Task WriteGenerationResponseAsync(

--- a/src/Typewriter.LanguageServer/TemplateFeatureService.cs
+++ b/src/Typewriter.LanguageServer/TemplateFeatureService.cs
@@ -149,6 +149,8 @@ internal sealed class TemplateFeatureService : IDisposable
 
     private readonly EmbeddedCSharpLanguageService _embeddedCSharpService = new();
 
+    private ProjectCompilationsCacheEntry? _projectCompilationsCache;
+
     public async Task<LspCompletionList> GetCompletionsAsync(
         TextDocumentState document,
         LanguageServerSettings settings,
@@ -1034,6 +1036,57 @@ internal sealed class TemplateFeatureService : IDisposable
 
     private static string UriFromPath(string path) => new Uri(uriString: Path.GetFullPath(path: path)).AbsoluteUri;
 
+    private static async Task<IReadOnlyList<Compilation>> LoadProjectCompilationsCoreAsync(
+        TextDocumentState document,
+        LanguageServerSettings settings,
+        string workspacePath,
+        CancellationToken cancellationToken)
+    {
+        var projectPaths = ResolveProjectPaths(settings: settings, workspacePath: workspacePath, templatePath: document.Path);
+        if (projectPaths.Count == 0)
+        {
+            return [];
+        }
+
+        var metadataProvider = new CSharpProjectMetadataProvider();
+        var compilations = new List<Compilation>();
+        foreach (var projectPath in projectPaths)
+        {
+            var compilation = await metadataProvider.GetCompilationAsync(
+                project: new ProjectContext(
+                    ProjectPath: projectPath,
+                    WorkspacePath: workspacePath,
+                    TargetFramework: settings.Framework),
+                cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+            if (compilation is not null)
+            {
+                compilations.Add(item: compilation);
+            }
+        }
+
+        return compilations;
+    }
+
+    private static string? CreateProjectCompilationsCacheKey(
+        TextDocumentState document,
+        LanguageServerSettings settings,
+        string workspacePath)
+    {
+        if (document.Version is null)
+        {
+            return null;
+        }
+
+        return string.Join(
+            separator: '\u001F',
+            document.Uri,
+            document.Version.Value.ToString(provider: CultureInfo.InvariantCulture),
+            workspacePath,
+            settings.Framework ?? string.Empty,
+            settings.ProjectPath ?? string.Empty,
+            settings.AllProjects ? "all" : string.Empty);
+    }
+
     private async Task<IReadOnlyList<TemplateAnalysisItem>> GetAnalysisItemsAsync(
         TextDocumentState document,
         LanguageServerSettings settings,
@@ -1052,36 +1105,29 @@ internal sealed class TemplateFeatureService : IDisposable
         return items;
     }
 
-#pragma warning disable CC0091,S2325
     private async Task<IReadOnlyList<Compilation>> LoadProjectCompilationsAsync(
         TextDocumentState document,
         LanguageServerSettings settings,
         CancellationToken cancellationToken)
-#pragma warning restore CC0091,S2325
     {
         try
         {
             var workspacePath = settings.ResolveWorkspacePath(documentPath: document.Path);
-            var projectPaths = ResolveProjectPaths(settings: settings, workspacePath: workspacePath, templatePath: document.Path);
-            if (projectPaths.Count == 0)
+            var cacheKey = CreateProjectCompilationsCacheKey(document: document, settings: settings, workspacePath: workspacePath);
+            var cached = _projectCompilationsCache;
+            if (cacheKey is not null && cached is not null && string.Equals(a: cached.CacheKey, b: cacheKey, comparisonType: StringComparison.Ordinal))
             {
-                return [];
+                return cached.Compilations;
             }
 
-            var metadataProvider = new CSharpProjectMetadataProvider();
-            var compilations = new List<Compilation>();
-            foreach (var projectPath in projectPaths)
+            var compilations = await LoadProjectCompilationsCoreAsync(
+                document: document,
+                settings: settings,
+                workspacePath: workspacePath,
+                cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+            if (cacheKey is not null)
             {
-                var compilation = await metadataProvider.GetCompilationAsync(
-                    project: new ProjectContext(
-                        ProjectPath: projectPath,
-                        WorkspacePath: workspacePath,
-                        TargetFramework: settings.Framework),
-                    cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
-                if (compilation is not null)
-                {
-                    compilations.Add(item: compilation);
-                }
+                _projectCompilationsCache = new ProjectCompilationsCacheEntry(CacheKey: cacheKey, Compilations: compilations);
             }
 
             return compilations;
@@ -1197,4 +1243,8 @@ internal sealed class TemplateFeatureService : IDisposable
     {
         public const int Snippet = 2;
     }
+
+    private sealed record ProjectCompilationsCacheEntry(
+        string CacheKey,
+        IReadOnlyList<Compilation> Compilations);
 }

--- a/src/Typewriter.LanguageServer/TemplateFeatureService.cs
+++ b/src/Typewriter.LanguageServer/TemplateFeatureService.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
 using Typewriter.Abstractions;
 using Typewriter.Engine;
 using Typewriter.Roslyn;
@@ -160,6 +161,7 @@ internal sealed class TemplateFeatureService : IDisposable
             var embedded = await _embeddedCSharpService.GetCompletionsAsync(
                 document: document,
                 templateOffset: document.GetOffset(position: position),
+                projectCompilations: await LoadProjectCompilationsAsync(document: document, settings: settings, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false),
                 cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             if (embedded is not null && embedded.Items.Count > 0)
             {
@@ -207,6 +209,7 @@ internal sealed class TemplateFeatureService : IDisposable
             var embeddedHover = await _embeddedCSharpService.GetHoverAsync(
                 document: document,
                 templateOffset: document.GetOffset(position: position),
+                projectCompilations: await LoadProjectCompilationsAsync(document: document, settings: settings, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false),
                 cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             if (embeddedHover is not null)
             {
@@ -243,6 +246,7 @@ internal sealed class TemplateFeatureService : IDisposable
             var embeddedDefinitions = await _embeddedCSharpService.GetDefinitionsAsync(
                 document: document,
                 templateOffset: document.GetOffset(position: position),
+                projectCompilations: await LoadProjectCompilationsAsync(document: document, settings: settings, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false),
                 cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             if (embeddedDefinitions.Count > 0)
             {
@@ -306,6 +310,16 @@ internal sealed class TemplateFeatureService : IDisposable
         AddTemplateMember(items: items, label: "Values", detail: "Collection", documentation: "Values on the current enum.", insertText: "Values[$0]");
         AddTemplateMember(items: items, label: "EnumValues", detail: "Collection", documentation: "Values on the current enum.", insertText: "EnumValues[$0]");
         AddTemplateMember(items: items, label: "TypeArguments", detail: "Collection", documentation: "Generic type arguments for the current type reference.", insertText: "TypeArguments[$0]");
+        AddTemplateMember(items: items, label: "Fields", detail: "Collection", documentation: "Instance fields on the current type.", insertText: "Fields[$0]");
+        AddTemplateMember(items: items, label: "StaticReadOnlyFields", detail: "Collection", documentation: "Static readonly fields on the current type.", insertText: "StaticReadOnlyFields[$0]");
+        AddTemplateMember(items: items, label: "Events", detail: "Collection", documentation: "Events on the current type.", insertText: "Events[$0]");
+        AddTemplateMember(items: items, label: "Delegates", detail: "Collection", documentation: "Delegates declared in the file or on the current type.", insertText: "Delegates[$0]");
+        AddTemplateMember(items: items, label: "NestedClasses", detail: "Collection", documentation: "Classes nested inside the current type.", insertText: "NestedClasses[$0]");
+        AddTemplateMember(items: items, label: "NestedEnums", detail: "Collection", documentation: "Enums nested inside the current type.", insertText: "NestedEnums[$0]");
+        AddTemplateMember(items: items, label: "NestedInterfaces", detail: "Collection", documentation: "Interfaces nested inside the current type.", insertText: "NestedInterfaces[$0]");
+        AddTemplateMember(items: items, label: "NestedRecords", detail: "Collection", documentation: "Records nested inside the current type.", insertText: "NestedRecords[$0]");
+        AddTemplateMember(items: items, label: "NestedStructs", detail: "Collection", documentation: "Structs nested inside the current type.", insertText: "NestedStructs[$0]");
+        AddTemplateMember(items: items, label: "TupleElements", detail: "Collection", documentation: "Elements of the current value tuple type.", insertText: "TupleElements[$0]");
 
         foreach (var scalar in CreateScalarItems())
         {
@@ -348,6 +362,13 @@ internal sealed class TemplateFeatureService : IDisposable
         yield return Scalar(label: "OriginalName", documentation: "Original C# type name.");
         yield return Scalar(label: "ClassName", documentation: "TypeScript-friendly class name.");
         yield return Scalar(label: "TypeParameters", documentation: "Legacy type parameter placeholder.");
+        yield return Scalar(label: "BaseClass", documentation: "Direct base class of the current class or type; empty when the class inherits only from object. Exposes the same members as a class, for example $BaseClass[ extends $Name].");
+        yield return Scalar(label: "BaseRecord", documentation: "Direct base record of the current record; empty when there is none.");
+        yield return Scalar(label: "ContainingClass", documentation: "Class the current item is nested inside; empty for top-level items.");
+        yield return Scalar(label: "AssemblyName", documentation: "Name of the assembly that declares the current item.");
+        yield return Scalar(label: "DocComment", documentation: "XML documentation comment of the current item. Use $DocComment.Summary, $DocComment.Returns, or $DocComment.Parameters.");
+        yield return Scalar(label: "ElementType", documentation: "Element type of the current array or enumerable type reference, for example string for string[].");
+        yield return Scalar(label: "IsFlags", documentation: "Whether the current enum is decorated with [Flags].");
     }
 
     private static IEnumerable<TemplateAnalysisItem> CreateFilterItems()
@@ -1029,6 +1050,50 @@ internal sealed class TemplateFeatureService : IDisposable
         }
 
         return items;
+    }
+
+#pragma warning disable CC0091,S2325
+    private async Task<IReadOnlyList<Compilation>> LoadProjectCompilationsAsync(
+        TextDocumentState document,
+        LanguageServerSettings settings,
+        CancellationToken cancellationToken)
+#pragma warning restore CC0091,S2325
+    {
+        try
+        {
+            var workspacePath = settings.ResolveWorkspacePath(documentPath: document.Path);
+            var projectPaths = ResolveProjectPaths(settings: settings, workspacePath: workspacePath, templatePath: document.Path);
+            if (projectPaths.Count == 0)
+            {
+                return [];
+            }
+
+            var metadataProvider = new CSharpProjectMetadataProvider();
+            var compilations = new List<Compilation>();
+            foreach (var projectPath in projectPaths)
+            {
+                var compilation = await metadataProvider.GetCompilationAsync(
+                    project: new ProjectContext(
+                        ProjectPath: projectPath,
+                        WorkspacePath: workspacePath,
+                        TargetFramework: settings.Framework),
+                    cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+                if (compilation is not null)
+                {
+                    compilations.Add(item: compilation);
+                }
+            }
+
+            return compilations;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            return [];
+        }
     }
 
 #pragma warning disable CC0091,S2325

--- a/src/Typewriter.LanguageServer/TextPositions.cs
+++ b/src/Typewriter.LanguageServer/TextPositions.cs
@@ -1,0 +1,52 @@
+namespace Typewriter.LanguageServer;
+
+internal static class TextPositions
+{
+    public static LspPosition GetPosition(
+        string text,
+        int offset)
+    {
+        var line = 0;
+        var character = 0;
+        var limit = Math.Clamp(value: offset, min: 0, max: text.Length);
+        for (var index = 0; index < limit; index++)
+        {
+            if (text[index: index] == '\n')
+            {
+                line++;
+                character = 0;
+                continue;
+            }
+
+            character++;
+        }
+
+        return new LspPosition(Line: line, Character: character);
+    }
+
+    public static int GetOffset(
+        string text,
+        LspPosition position)
+    {
+        var line = 0;
+        var character = 0;
+        for (var index = 0; index < text.Length; index++)
+        {
+            if (line == position.Line && character == position.Character)
+            {
+                return index;
+            }
+
+            if (text[index: index] == '\n')
+            {
+                line++;
+                character = 0;
+                continue;
+            }
+
+            character++;
+        }
+
+        return text.Length;
+    }
+}

--- a/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
+++ b/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
@@ -50,6 +50,31 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
             cancellationToken: cancellationToken);
     }
 
+    /// <summary>
+    /// Returns the Roslyn compilation built for the project, reusing the metadata cache.
+    /// Used by editor services that need real symbol information for the loaded workspace,
+    /// for example IntelliSense inside template C# helper blocks.
+    /// </summary>
+    /// <param name="project">The project to load the compilation for.</param>
+    /// <param name="cancellationToken">Token used to cancel the load.</param>
+    /// <returns>The compilation, or <c>null</c> when the project could not be compiled.</returns>
+    public async Task<Compilation?> GetCompilationAsync(
+        ProjectContext project,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(argument: project);
+
+        var loadedProjects = new Dictionary<string, ProjectMetadataBuildResult>(comparer: StringComparer.OrdinalIgnoreCase);
+        var loadingProjects = new HashSet<string>(comparer: StringComparer.OrdinalIgnoreCase);
+        var result = await GetMetadataCoreAsync(
+            projectLoader: _projectLoader,
+            project: project,
+            loadedProjects: loadedProjects,
+            loadingProjects: loadingProjects,
+            cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+        return result.Compilation;
+    }
+
     private static async Task<ProjectMetadata> GetMergedMetadataAsync(
         IProjectWorkspaceLoader projectLoader,
         ProjectContext project,

--- a/src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj
+++ b/src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj
@@ -100,6 +100,8 @@
     <MSBuild Projects="..\Typewriter.LanguageServer\Typewriter.LanguageServer.csproj" Targets="Restore;Publish" Properties="Configuration=$(Configuration);TargetFramework=net10.0;PublishDir=$(TypewriterPackagedLanguageServerPublishDir);BaseOutputPath=$(TypewriterPackagedLanguageServerBuildOutputDir);SelfContained=false;UseAppHost=false;SatelliteResourceLanguages=en;RunAnalyzers=false;BuildingInsideVisualStudio=false;BuildProjectReferences=true" BuildInParallel="false" />
     <ItemGroup>
       <TypewriterPackagedLanguageServerFile Include="$(TypewriterPackagedLanguageServerPublishDir)**\*.*" Exclude="$(TypewriterPackagedLanguageServerPublishDir)**\*.pdb;$(TypewriterPackagedLanguageServerPublishDir)**\*.xml" />
+      <!-- Typewriter XML doc files must ship next to the DLLs so Roslyn hover in .tst C# blocks can show doc comments. -->
+      <TypewriterPackagedLanguageServerFile Include="$(TypewriterPackagedLanguageServerPublishDir)Typewriter.*.xml" />
       <Content Include="@(TypewriterPackagedLanguageServerFile)">
         <IncludeInVSIX>true</IncludeInVSIX>
         <VSIXSubPath>tools\typewriter-lsp\%(RecursiveDir)</VSIXSubPath>

--- a/tests/unit/Typewriter.Cli.Tests/CliIntegrationTests.cs
+++ b/tests/unit/Typewriter.Cli.Tests/CliIntegrationTests.cs
@@ -20,10 +20,12 @@ public sealed class CliIntegrationTests
             var configurationPath = Path.Combine(path1: directory, path2: ConfigurationFileName);
 
             var result = await RunCliRawAsync(
-                cancellationToken: CancellationToken.None,
+                args: [
                 "init",
                 "--workspace",
-                directory);
+                directory
+                ],
+                cancellationToken: CancellationToken.None);
 
             result.ExitCode.Should().Be(0);
             result.StandardError.Should().BeEmpty();
@@ -70,10 +72,12 @@ public sealed class CliIntegrationTests
             var configurationPath = Path.Combine(path1: directory, path2: ConfigurationFileName);
 
             var result = await RunCliRawAsync(
-                cancellationToken: CancellationToken.None,
+                args: [
                 "init",
                 "--workspace",
-                directory);
+                directory
+                ],
+                cancellationToken: CancellationToken.None);
 
             result.ExitCode.Should().Be(0);
 
@@ -108,10 +112,12 @@ public sealed class CliIntegrationTests
             await File.WriteAllTextAsync(path: configurationPath, contents: ExistingConfiguration);
 
             var result = await RunCliRawAsync(
-                cancellationToken: CancellationToken.None,
+                args: [
                 "init",
                 "--workspace",
-                directory);
+                directory
+                ],
+                cancellationToken: CancellationToken.None);
 
             result.ExitCode.Should().Be(1);
             result.StandardError.Should().Contain("Configuration file already exists:");
@@ -133,11 +139,13 @@ public sealed class CliIntegrationTests
             await File.WriteAllTextAsync(path: configurationPath, contents: "{}");
 
             var result = await RunCliRawAsync(
-                cancellationToken: CancellationToken.None,
+                args: [
                 "init",
                 "--workspace",
                 directory,
-                "--force");
+                "--force"
+                ],
+                cancellationToken: CancellationToken.None);
 
             result.ExitCode.Should().Be(0);
             result.StandardError.Should().BeEmpty();
@@ -267,7 +275,7 @@ public sealed class CliIntegrationTests
             var project = await CreateSimpleProjectAsync(directory: directory);
 
             var firstResult = await RunCliRawAsync(
-                cancellationToken: CancellationToken.None,
+                args: [
                 "generate",
                 "--workspace",
                 directory,
@@ -278,7 +286,9 @@ public sealed class CliIntegrationTests
                 "--framework",
                 "net10.0",
                 "--output",
-                "text");
+                "text"
+                ],
+                cancellationToken: CancellationToken.None);
 
             firstResult.ExitCode.Should().Be(0);
 
@@ -295,7 +305,7 @@ public sealed class CliIntegrationTests
                           """);
 
             var result = await RunCliRawAsync(
-                cancellationToken: CancellationToken.None,
+                args: [
                 "generate",
                 "--workspace",
                 directory,
@@ -307,7 +317,9 @@ public sealed class CliIntegrationTests
                 "net10.0",
                 "--output",
                 "text",
-                "--diff");
+                "--diff"
+                ],
+                cancellationToken: CancellationToken.None);
 
             result.ExitCode.Should().Be(0);
             result.StandardOutput.Should().Contain("updated:", because: "the file should be marked as changed");
@@ -484,7 +496,7 @@ public sealed class CliIntegrationTests
             using var cancellation = new CancellationTokenSource();
 
             var runTask = RunCliAsync(
-                cancellationToken: cancellation.Token,
+                args: [
                 "watch",
                 "--workspace",
                 directory,
@@ -495,7 +507,9 @@ public sealed class CliIntegrationTests
                 "--framework",
                 "net10.0",
                 "--output",
-                "json");
+                "json"
+                ],
+                cancellationToken: cancellation.Token);
 
             await WaitForFileAsync(path: generatedPath, cancellationToken: cancellation.Token);
             await Task.Delay(millisecondsDelay: 250, cancellationToken: CancellationToken.None);
@@ -524,7 +538,7 @@ public sealed class CliIntegrationTests
             using var cancellation = new CancellationTokenSource();
 
             var runTask = RunCliRawAsync(
-                cancellationToken: cancellation.Token,
+                args: [
                 "watch",
                 "--workspace",
                 directory,
@@ -533,7 +547,9 @@ public sealed class CliIntegrationTests
                 "--template",
                 project.TemplatePath,
                 "--framework",
-                "net10.0");
+                "net10.0"
+                ],
+                cancellationToken: cancellation.Token);
 
             await WaitForFileContentAsync(path: generatedPath, expectedContent: "name: string;", cancellationToken: cancellation.Token);
             await File.WriteAllTextAsync(
@@ -586,7 +602,7 @@ public sealed class CliIntegrationTests
             using var cancellation = new CancellationTokenSource();
 
             var runTask = RunCliRawAsync(
-                cancellationToken: cancellation.Token,
+                args: [
                 "watch",
                 "--workspace",
                 directory,
@@ -595,7 +611,9 @@ public sealed class CliIntegrationTests
                 "--template",
                 project.TemplatePath,
                 "--framework",
-                "net10.0");
+                "net10.0"
+                ],
+                cancellationToken: cancellation.Token);
 
             await WaitForFileContentAsync(path: generatedPath, expectedContent: "name: string;", cancellationToken: cancellation.Token);
             (await File.ReadAllTextAsync(path: generatedPath, cancellationToken: cancellation.Token))
@@ -658,7 +676,7 @@ public sealed class CliIntegrationTests
             using var cancellation = new CancellationTokenSource();
 
             var runTask = RunCliRawAsync(
-                cancellationToken: cancellation.Token,
+                args: [
                 "watch",
                 "--workspace",
                 directory,
@@ -667,7 +685,9 @@ public sealed class CliIntegrationTests
                 "--template",
                 project.TemplatePath,
                 "--framework",
-                "net10.0");
+                "net10.0"
+                ],
+                cancellationToken: cancellation.Token);
 
             await WaitForFileContentAsync(path: generatedPath, expectedContent: "name: string;", cancellationToken: cancellation.Token);
             (await File.ReadAllTextAsync(path: generatedPath, cancellationToken: cancellation.Token))
@@ -714,7 +734,7 @@ public sealed class CliIntegrationTests
             using var cancellation = new CancellationTokenSource();
 
             var runTask = RunCliRawAsync(
-                cancellationToken: cancellation.Token,
+                args: [
                 "watch",
                 "--workspace",
                 directory,
@@ -723,7 +743,9 @@ public sealed class CliIntegrationTests
                 "--template",
                 project.TemplatePath,
                 "--framework",
-                "net10.0");
+                "net10.0"
+                ],
+                cancellationToken: cancellation.Token);
 
             await WaitForFileContentAsync(path: generatedPath, expectedContent: "name: string;", cancellationToken: cancellation.Token);
             await File.WriteAllTextAsync(
@@ -776,7 +798,7 @@ public sealed class CliIntegrationTests
             using var cancellation = new CancellationTokenSource();
 
             var runTask = RunCliRawAsync(
-                cancellationToken: cancellation.Token,
+                args: [
                 "watch",
                 "--workspace",
                 directory,
@@ -785,7 +807,9 @@ public sealed class CliIntegrationTests
                 "--template",
                 project.TemplatePath,
                 "--framework",
-                "net10.0");
+                "net10.0"
+                ],
+                cancellationToken: cancellation.Token);
 
             await WaitForFileContentAsync(path: generatedPath, expectedContent: "name: string;", cancellationToken: cancellation.Token);
             await Task.Delay(millisecondsDelay: 500, cancellationToken: CancellationToken.None);
@@ -962,7 +986,7 @@ public sealed class CliIntegrationTests
                                  """);
 
             var result = await RunCliRawAsync(
-                cancellationToken: CancellationToken.None,
+                args: [
                 "validate",
                 "--workspace",
                 directory,
@@ -971,7 +995,9 @@ public sealed class CliIntegrationTests
                 "--template",
                 project.TemplatePath,
                 "--framework",
-                "net10.0");
+                "net10.0"
+                ],
+                cancellationToken: CancellationToken.None);
 
             result.ExitCode.Should().Be(4);
             result.StandardError.Should().Contain("Models.tst(");
@@ -1003,7 +1029,7 @@ public sealed class CliIntegrationTests
             var generatedPath = Path.Combine(path1: directory, path2: "generated", path3: "models.ts");
 
             var result = await RunCliRawAsync(
-                cancellationToken: CancellationToken.None,
+                args: [
                 "generate",
                 "--workspace",
                 directory,
@@ -1012,7 +1038,9 @@ public sealed class CliIntegrationTests
                 "--template",
                 project.TemplatePath,
                 "--framework",
-                "net10.0");
+                "net10.0"
+                ],
+                cancellationToken: CancellationToken.None);
 
             result.ExitCode.Should().Be(4);
             result.StandardError.Should().Contain("error TW0002:");
@@ -1025,8 +1053,8 @@ public sealed class CliIntegrationTests
     }
 
     private static async Task<CliRawRunResult> RunCliRawAsync(
-        CancellationToken cancellationToken,
-        params string[] args)
+        string[] args,
+        CancellationToken cancellationToken)
     {
         await ConsoleLock.WaitAsync(cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
         try
@@ -1060,11 +1088,11 @@ public sealed class CliIntegrationTests
     }
 
     private static Task<CliRunResult> RunCliAsync(params string[] args) =>
-        RunCliAsync(cancellationToken: CancellationToken.None, args: args);
+        RunCliAsync(args: args, cancellationToken: CancellationToken.None);
 
     private static async Task<CliRunResult> RunCliAsync(
-        CancellationToken cancellationToken,
-        params string[] args)
+        string[] args,
+        CancellationToken cancellationToken)
     {
         await ConsoleLock.WaitAsync().ConfigureAwait(continueOnCapturedContext: false);
         try

--- a/tests/unit/Typewriter.LanguageServer.Tests/EmbeddedDocumentServiceTests.cs
+++ b/tests/unit/Typewriter.LanguageServer.Tests/EmbeddedDocumentServiceTests.cs
@@ -1,0 +1,156 @@
+using Xunit;
+
+namespace Typewriter.LanguageServer.Tests;
+
+public sealed class EmbeddedDocumentServiceTests
+{
+    private const string Template =
+        "${\n"
+        + "    string Suffix(Typewriter.CodeModel.Class c) => c.Name;\n"
+        + "}\n"
+        + "export const url = `${environment.apiBaseUrl}/api`;\n"
+        + "export interface $Name {\n"
+        + "}\n";
+
+    [Fact]
+    public void GetSnapshotForTypeScriptBlanksCSharpBlocksAndPreservesInterpolation()
+    {
+        var document = CreateDocument(text: Template);
+
+        var snapshot = EmbeddedDocumentService.GetSnapshot(document: document, kind: "typescript");
+
+        snapshot.Should().NotBeNull();
+        snapshot!.LanguageId.Should().Be("typescript");
+        snapshot.Content.Should().HaveLength(Template.Length);
+        snapshot.Content.Should().NotContain("Suffix");
+        snapshot.Content.Should().Contain("`${environment.apiBaseUrl}/api`");
+        snapshot.Content.Should().Contain("export interface $Name {");
+        snapshot.Version.Should().Be(3);
+    }
+
+    [Fact]
+    public void GetSnapshotForCSharpProjectsHelperBlockIntoHostDocument()
+    {
+        var document = CreateDocument(text: Template);
+
+        var snapshot = EmbeddedDocumentService.GetSnapshot(document: document, kind: "csharp");
+
+        snapshot.Should().NotBeNull();
+        snapshot!.LanguageId.Should().Be("csharp");
+        snapshot.Content.Should().Contain("string Suffix(Typewriter.CodeModel.Class c) => c.Name;");
+        snapshot.Content.Should().Contain("class TypewriterTemplateHost");
+        snapshot.Content.Should().NotContain("export const url");
+    }
+
+    [Fact]
+    public void GetSnapshotForCSharpReturnsNullWithoutHelperBlocks()
+    {
+        var document = CreateDocument(text: "export interface $Name {\n}\n");
+
+        var snapshot = EmbeddedDocumentService.GetSnapshot(document: document, kind: "csharp");
+
+        snapshot.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetSnapshotForUnknownKindReturnsNull()
+    {
+        var document = CreateDocument(text: Template);
+
+        var snapshot = EmbeddedDocumentService.GetSnapshot(document: document, kind: "template");
+
+        snapshot.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPositionInfoMapsCSharpPositionToVirtualDocument()
+    {
+        var document = CreateDocument(text: Template);
+        var templatePosition = TextPositions.GetPosition(text: Template, offset: Template.IndexOf(value: "Suffix", comparisonType: StringComparison.Ordinal));
+
+        var info = EmbeddedDocumentService.GetPositionInfo(document: document, position: templatePosition);
+
+        info.Kind.Should().Be("csharp");
+        info.VirtualPosition.Should().NotBeNull();
+        var virtualSource = EmbeddedDocumentService.GetSnapshot(document: document, kind: "csharp")!.Content;
+        var virtualOffset = TextPositions.GetOffset(text: virtualSource, position: info.VirtualPosition!);
+        virtualSource.Substring(startIndex: virtualOffset, length: 6).Should().Be("Suffix");
+    }
+
+    [Fact]
+    public void GetPositionInfoReturnsIdentityPositionForTypeScript()
+    {
+        var document = CreateDocument(text: Template);
+        var templatePosition = TextPositions.GetPosition(text: Template, offset: Template.IndexOf(value: "export const", comparisonType: StringComparison.Ordinal));
+
+        var info = EmbeddedDocumentService.GetPositionInfo(document: document, position: templatePosition);
+
+        info.Kind.Should().Be("typescript");
+        info.VirtualPosition.Should().Be(templatePosition);
+    }
+
+    [Fact]
+    public void GetPositionInfoReturnsTemplateKindForTemplateToken()
+    {
+        var document = CreateDocument(text: Template);
+        var templatePosition = TextPositions.GetPosition(text: Template, offset: Template.IndexOf(value: "$Name", comparisonType: StringComparison.Ordinal) + 1);
+
+        var info = EmbeddedDocumentService.GetPositionInfo(document: document, position: templatePosition);
+
+        info.Kind.Should().Be("template");
+        info.VirtualPosition.Should().BeNull();
+    }
+
+    [Fact]
+    public void MapRangeToTemplateRoundTripsCSharpRange()
+    {
+        var document = CreateDocument(text: Template);
+        var templateStartOffset = Template.IndexOf(value: "Suffix", comparisonType: StringComparison.Ordinal);
+        var templateStart = TextPositions.GetPosition(text: Template, offset: templateStartOffset);
+        var templateEnd = TextPositions.GetPosition(text: Template, offset: templateStartOffset + 6);
+        var virtualStart = EmbeddedDocumentService.GetPositionInfo(document: document, position: templateStart).VirtualPosition!;
+        var virtualEnd = EmbeddedDocumentService.GetPositionInfo(document: document, position: templateEnd).VirtualPosition!;
+
+        var mapped = EmbeddedDocumentService.MapRangeToTemplate(
+            document: document,
+            kind: "csharp",
+            range: new LspRange(Start: virtualStart, End: virtualEnd));
+
+        mapped.Should().NotBeNull();
+        mapped!.Start.Should().Be(templateStart);
+        mapped.End.Should().Be(templateEnd);
+    }
+
+    [Fact]
+    public void MapRangeToTemplateReturnsSameRangeForTypeScript()
+    {
+        var document = CreateDocument(text: Template);
+        var range = new LspRange(
+            Start: new LspPosition(Line: 3, Character: 0),
+            End: new LspPosition(Line: 3, Character: 6));
+
+        var mapped = EmbeddedDocumentService.MapRangeToTemplate(document: document, kind: "typescript", range: range);
+
+        mapped.Should().Be(range);
+    }
+
+    [Fact]
+    public void MapRangeToTemplateReturnsNullForUnknownKind()
+    {
+        var document = CreateDocument(text: Template);
+        var range = new LspRange(
+            Start: new LspPosition(Line: 0, Character: 0),
+            End: new LspPosition(Line: 0, Character: 1));
+
+        var mapped = EmbeddedDocumentService.MapRangeToTemplate(document: document, kind: "template", range: range);
+
+        mapped.Should().BeNull();
+    }
+
+    private static TextDocumentState CreateDocument(string text) =>
+        new(
+            Uri: "file:///c%3A/templates/Models.tst",
+            Path: @"c:\templates\Models.tst",
+            Text: text,
+            Version: 3);
+}

--- a/tests/unit/Typewriter.LanguageServer.Tests/LanguageServerHostTests.cs
+++ b/tests/unit/Typewriter.LanguageServer.Tests/LanguageServerHostTests.cs
@@ -206,6 +206,171 @@ public sealed class LanguageServerHostTests
     }
 
     [Fact]
+    public async Task RunAsyncHandlesEmbeddedDocumentRequestsOverJsonRpc()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var templatePath = Path.Combine(path1: directory, path2: "Models.tst");
+            var templateUri = UriFromPath(path: templatePath);
+            const string Template = "${\n"
+                + "    string Suffix(Typewriter.CodeModel.Class c) => c.Name;\n"
+                + "}\n"
+                + "export const url = `${environment.apiBaseUrl}/api`;\n";
+
+            await using var input = CreateInput(
+                messages:
+                [
+                    CreateRequest(
+                        id: 1,
+                        method: "initialize",
+                        parameters: new
+                        {
+                            rootUri = UriFromPath(path: directory),
+                            initializationOptions = new
+                            {
+                                workspacePath = directory,
+                            },
+                        }),
+                    CreateNotification(
+                        method: "textDocument/didOpen",
+                        parameters: new
+                        {
+                            textDocument = new
+                            {
+                                uri = templateUri,
+                                languageId = "typewriter",
+                                version = 1,
+                                text = Template,
+                            },
+                        }),
+                    CreateRequest(
+                        id: 2,
+                        method: "typewriter/embeddedDocument",
+                        parameters: new
+                        {
+                            textDocument = new
+                            {
+                                uri = templateUri,
+                            },
+                            kind = "typescript",
+                        }),
+                    CreateRequest(
+                        id: 3,
+                        method: "typewriter/embeddedDocument",
+                        parameters: new
+                        {
+                            textDocument = new
+                            {
+                                uri = templateUri,
+                            },
+                            kind = "csharp",
+                        }),
+                    CreateRequest(
+                        id: 4,
+                        method: "typewriter/embeddedPosition",
+                        parameters: new
+                        {
+                            textDocument = new
+                            {
+                                uri = templateUri,
+                            },
+                            position = new
+                            {
+                                line = 1,
+                                character = 11,
+                            },
+                        }),
+                    CreateRequest(
+                        id: 5,
+                        method: "typewriter/templateRange",
+                        parameters: new
+                        {
+                            textDocument = new
+                            {
+                                uri = templateUri,
+                            },
+                            kind = "typescript",
+                            range = new
+                            {
+                                start = new
+                                {
+                                    line = 3,
+                                    character = 0,
+                                },
+                                end = new
+                                {
+                                    line = 3,
+                                    character = 6,
+                                },
+                            },
+                        }),
+                    CreateRequest(id: 6, method: "shutdown", parameters: new { }), CreateNotification(method: "exit", parameters: new { })
+                ]);
+            await using var output = new MemoryStream();
+            using var connection = new JsonRpcConnection(input: input, output: output);
+            using var templateFeatureService = new TemplateFeatureService();
+            var host = new LanguageServerHost(
+                connection: connection,
+                diagnosticService: new NoopDiagnosticService(),
+                generationService: new StubGenerationService(),
+                featureService: templateFeatureService);
+
+            await host.RunAsync(cancellationToken: CancellationToken.None);
+
+            var messages = ReadOutputMessages(output: output);
+            var typeScriptResponse = FindResponse(messages: messages, id: 2);
+            var typeScriptContent = typeScriptResponse
+                .GetProperty(propertyName: "result")
+                .GetProperty(propertyName: "content")
+                .GetString();
+            typeScriptContent.Should().NotContain("Suffix");
+            typeScriptContent.Should().Contain("`${environment.apiBaseUrl}/api`");
+            typeScriptContent.Should().HaveLength(Template.Length);
+
+            var csharpResponse = FindResponse(messages: messages, id: 3);
+            var csharpContent = csharpResponse
+                .GetProperty(propertyName: "result")
+                .GetProperty(propertyName: "content")
+                .GetString();
+            csharpContent.Should().Contain("string Suffix(Typewriter.CodeModel.Class c) => c.Name;");
+            csharpContent.Should().Contain("class TypewriterTemplateHost");
+
+            var positionResponse = FindResponse(messages: messages, id: 4);
+            positionResponse
+                .GetProperty(propertyName: "result")
+                .GetProperty(propertyName: "kind")
+                .GetString()
+                .Should()
+                .Be("csharp");
+            var virtualPosition = positionResponse
+                .GetProperty(propertyName: "result")
+                .GetProperty(propertyName: "virtualPosition");
+            virtualPosition.ValueKind.Should().Be(JsonValueKind.Object);
+
+            var rangeResponse = FindResponse(messages: messages, id: 5);
+            rangeResponse
+                .GetProperty(propertyName: "result")
+                .GetProperty(propertyName: "start")
+                .GetProperty(propertyName: "line")
+                .GetInt32()
+                .Should()
+                .Be(3);
+
+            messages
+                .Count(predicate: message => message.TryGetProperty(propertyName: "method", value: out var method)
+                                             && method.ValueKind == JsonValueKind.String
+                                             && string.Equals(a: method.GetString(), b: "typewriter/embeddedDocumentChanged", comparisonType: StringComparison.Ordinal))
+                .Should()
+                .BePositive();
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
     public void FileUriPathStripsWindowsDrivePrefixSlash()
     {
         if (!OperatingSystem.IsWindows())

--- a/tests/unit/Typewriter.LanguageServer.Tests/TemplateFeatureServiceTests.cs
+++ b/tests/unit/Typewriter.LanguageServer.Tests/TemplateFeatureServiceTests.cs
@@ -330,6 +330,68 @@ public sealed class TemplateFeatureServiceTests
     }
 
     [Fact]
+    public async Task EmbeddedCSharpHoverReturnsCodeModelXmlDocumentation()
+    {
+        const string Template = """
+            ${
+                string BaseName(Class c) => c.BaseClass?.Name ?? string.Empty;
+            }
+            """;
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var templatePath = Path.Combine(path1: directory, path2: "Test.tst");
+            var document = CreateDocument(path: templatePath, text: Template);
+            var memberIndex = Template.IndexOf(value: "BaseClass?", comparisonType: StringComparison.Ordinal);
+
+            using var service = new EmbeddedCSharpLanguageService();
+            var hover = await service.GetHoverAsync(
+                document: document,
+                templateOffset: memberIndex,
+                cancellationToken: CancellationToken.None);
+
+            hover.Should().NotBeNull();
+            hover!.Contents.Value.Should().Contain("BaseClass");
+            hover.Contents.Value.Should().Contain("direct base class");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
+    public async Task EmbeddedCSharpCompletionsIncludeProjectTypesWhenProjectIsLoaded()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var project = await CreateSimpleProjectAsync(directory: directory);
+            const string Template = """
+                ${
+                    Cust
+                }
+                """;
+            var document = CreateDocument(path: project.TemplatePath, text: Template);
+            var settings = CreateSettings(directory: directory, projectPath: project.ProjectPath);
+            var position = PositionOf(text: Template, marker: "Cust");
+
+            using var service = new TemplateFeatureService();
+            var completions = await service.GetCompletionsAsync(
+                document: document,
+                settings: settings,
+                position: position with { Character = position.Character + 4 },
+                cancellationToken: CancellationToken.None);
+
+            completions.Items.Should().Contain(item => item.Label == "Customer");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
     public async Task EmbeddedCSharpRequestsCanRunInParallel()
     {
         const string FirstTemplate = """

--- a/tests/unit/Typewriter.LanguageServer.Tests/TemplateFeatureServiceTests.cs
+++ b/tests/unit/Typewriter.LanguageServer.Tests/TemplateFeatureServiceTests.cs
@@ -198,6 +198,44 @@ public sealed class TemplateFeatureServiceTests
     }
 
     [Fact]
+    public async Task GetHoverAsyncReturnsEmbeddedCSharpRecordDocumentation()
+    {
+        const string Template = """
+            ${
+                string RecordName(Record record) => record.Name;
+            }
+            """;
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var templatePath = Path.Combine(path1: directory, path2: "Test.tst");
+            var document = CreateDocument(path: templatePath, text: Template);
+            var settings = new LanguageServerSettings(
+                RootPath: directory,
+                WorkspacePath: directory,
+                ProjectPath: null,
+                Framework: null,
+                AllProjects: false);
+
+            using var service = new TemplateFeatureService();
+            var hover = await service.GetHoverAsync(
+                document: document,
+                settings: settings,
+                position: PositionOf(text: Template, marker: "Record record"),
+                cancellationToken: CancellationToken.None);
+
+            hover.Should().NotBeNull();
+            hover!.Contents.Value.Should().NotContain("Record=Record");
+            hover.Contents.Value.Should().Contain("A C# record made available to templates");
+            hover.Contents.Value.Should().Contain("$Records[...]");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
     public async Task GetDefinitionsAsyncReturnsCSharpSourceLocation()
     {
         var directory = CreateProjectDirectory();
@@ -353,6 +391,37 @@ public sealed class TemplateFeatureServiceTests
             hover.Should().NotBeNull();
             hover!.Contents.Value.Should().Contain("BaseClass");
             hover.Contents.Value.Should().Contain("direct base class");
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
+    public async Task EmbeddedCSharpHoverOnAliasedTypeReturnsTargetTypeDocumentation()
+    {
+        const string Template = """
+            ${
+                string RecordName(Record r) => r.Name;
+            }
+            """;
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var templatePath = Path.Combine(path1: directory, path2: "Test.tst");
+            var document = CreateDocument(path: templatePath, text: Template);
+            var typeIndex = Template.IndexOf(value: "Record r", comparisonType: StringComparison.Ordinal);
+
+            using var service = new EmbeddedCSharpLanguageService();
+            var hover = await service.GetHoverAsync(
+                document: document,
+                templateOffset: typeIndex,
+                cancellationToken: CancellationToken.None);
+
+            hover.Should().NotBeNull();
+            hover!.Contents.Value.Should().NotContain("Record=Record");
+            hover.Contents.Value.Should().Contain("$Records[...]");
         }
         finally
         {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -176,6 +176,15 @@
           "default": true,
           "description": "Validate after saving files matched by typewriter.json inputExtensions. Ignored when generateOnSave is enabled."
         },
+        "typewriter.embeddedLanguages.forwarding": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "off"
+          ],
+          "default": "auto",
+          "description": "Forward IntelliSense inside C# helper blocks and TypeScript output regions of .tst files to installed C# and TypeScript language extensions through virtual documents. 'off' keeps only the built-in Typewriter template IntelliSense."
+        },
         "typewriter.languageServer.enabled": {
           "type": "boolean",
           "default": true,

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -1063,9 +1063,12 @@ function stripMarkdownCode(value) {
 }
 
 function createEmbeddedUri(documentUri, kind) {
+    // The original URI (including its scheme, e.g. git/vscode-remote/untitled) is
+    // carried in the query so parseEmbeddedUri can restore it exactly.
     return documentUri.with({
         scheme: embeddedScheme,
         path: documentUri.path + embeddedSuffixes[kind],
+        query: encodeURIComponent(documentUri.toString()),
     });
 }
 
@@ -1074,15 +1077,28 @@ function parseEmbeddedUri(uri) {
         if (uri.path.endsWith(suffix)) {
             return {
                 kind,
-                originalUri: uri.with({
-                    scheme: "file",
-                    path: uri.path.slice(0, -suffix.length),
-                }),
+                originalUri: restoreOriginalUri(uri, suffix),
             };
         }
     }
 
     return undefined;
+}
+
+function restoreOriginalUri(uri, suffix) {
+    if (uri.query) {
+        try {
+            return vscode.Uri.parse(decodeURIComponent(uri.query), true);
+        } catch {
+            // Fall back to path-based restoration below.
+        }
+    }
+
+    return uri.with({
+        scheme: "file",
+        path: uri.path.slice(0, -suffix.length),
+        query: "",
+    });
 }
 
 function refreshEmbeddedDocuments() {

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -24,6 +24,21 @@ const embeddedSuffixes = {
     csharp: ".g.cs",
     typescript: ".g.ts",
 };
+const typewriterCodeModelAliases = new Set([
+    "Attribute",
+    "Class",
+    "Constant",
+    "Delegate",
+    "Enum",
+    "EnumValue",
+    "File",
+    "Interface",
+    "Method",
+    "Parameter",
+    "Property",
+    "Record",
+    "Type",
+]);
 const embeddedDocuments = new Map();
 let embeddedContentEmitter;
 
@@ -761,7 +776,7 @@ function createEmbeddedForwardingProviders() {
                             target.virtualUri,
                             target.virtualPosition);
                         const hover = (hovers ?? []).find(candidate => candidate?.contents?.length);
-                        return hover ? new vscode.Hover(hover.contents) : undefined;
+                        return sanitizeForwardedHover(hover, target);
                     } catch {
                         return undefined;
                     }
@@ -994,6 +1009,57 @@ function sanitizeForwardedCompletionItem(item) {
     item.additionalTextEdits = undefined;
     item.command = undefined;
     return item;
+}
+
+function sanitizeForwardedHover(hover, target) {
+    if (!hover?.contents?.length) {
+        return undefined;
+    }
+
+    if (target.kind === "csharp" && isBareTypewriterCodeModelAliasHover(hover.contents)) {
+        return undefined;
+    }
+
+    return new vscode.Hover(hover.contents);
+}
+
+function isBareTypewriterCodeModelAliasHover(contents) {
+    const normalized = stripMarkdownCode(contents
+        .map(getHoverContentValue)
+        .filter(value => value.length > 0)
+        .join("\n"))
+        .replace(/\s+/g, " ")
+        .replace(/\s*=\s*/g, "=")
+        .trim();
+    if (!normalized) {
+        return false;
+    }
+
+    for (const alias of typewriterCodeModelAliases) {
+        if (normalized === alias
+            || normalized === `${alias}=${alias}`
+            || normalized === `${alias}=Typewriter.CodeModel.${alias}`
+            || normalized === `using ${alias}=Typewriter.CodeModel.${alias};`) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function getHoverContentValue(content) {
+    if (typeof content === "string") {
+        return content;
+    }
+
+    return typeof content?.value === "string" ? content.value : "";
+}
+
+function stripMarkdownCode(value) {
+    return value
+        .replace(/```[a-zA-Z0-9_-]*\s*([\s\S]*?)```/g, "$1")
+        .replace(/`([^`]+)`/g, "$1")
+        .trim();
 }
 
 function createEmbeddedUri(documentUri, kind) {

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -19,18 +19,32 @@ const saveQueue = {
     running: false,
     lastSaveAt: 0,
 };
+const embeddedScheme = "typewriter-embedded";
+const embeddedSuffixes = {
+    csharp: ".g.cs",
+    typescript: ".g.ts",
+};
+const embeddedDocuments = new Map();
+let embeddedContentEmitter;
 
 async function activate(context) {
     outputChannel = vscode.window.createOutputChannel("Typewriter");
     diagnostics = vscode.languages.createDiagnosticCollection("typewriter");
 
     context.subscriptions.push(outputChannel, diagnostics);
+    embeddedContentEmitter = new vscode.EventEmitter();
     context.subscriptions.push(
         vscode.commands.registerCommand("typewriter.generate", uri => executeCurrentTemplate(context, "generate", undefined, toFileUri(uri))),
         vscode.commands.registerCommand("typewriter.generateAll", uri => executeGenerateAll(context, toFileUri(uri))),
         vscode.commands.registerCommand("typewriter.validate", uri => executeCurrentTemplate(context, "validate", undefined, toFileUri(uri))),
         vscode.commands.registerCommand("typewriter.restartServer", () => restartLanguageServer(context)),
         createFallbackCompletionProvider(),
+        embeddedContentEmitter,
+        vscode.workspace.registerTextDocumentContentProvider(embeddedScheme, {
+            onDidChange: embeddedContentEmitter.event,
+            provideTextDocumentContent: uri => provideEmbeddedContent(uri),
+        }),
+        ...createEmbeddedForwardingProviders(),
         vscode.workspace.onDidSaveTextDocument(document => handleDocumentSaved(context, document)));
     context.subscriptions.push({
         dispose: () => {
@@ -227,6 +241,7 @@ async function startLanguageServer(context, options = {}) {
             });
         outputChannel.appendLine(formatCommand(invocation.command, invocation.args));
         await languageClient.start();
+        languageClient.onNotification("typewriter/embeddedDocumentChanged", () => refreshEmbeddedDocuments());
         if (options.notify) {
             vscode.window.setStatusBarMessage("Typewriter language server restarted.", 3000);
         }
@@ -698,6 +713,325 @@ function normalizeExtension(extension) {
 
 function toFileUri(value) {
     return value?.scheme === "file" ? value : undefined;
+}
+
+function createEmbeddedForwardingProviders() {
+    const selector = { language: "typewriter" };
+    return [
+        vscode.languages.registerCompletionItemProvider(
+            selector,
+            {
+                async provideCompletionItems(document, position, _token, completionContext) {
+                    const target = await resolveEmbeddedTarget(document, position);
+                    if (!target) {
+                        return undefined;
+                    }
+
+                    try {
+                        const list = await vscode.commands.executeCommand(
+                            "vscode.executeCompletionItemProvider",
+                            target.virtualUri,
+                            target.virtualPosition,
+                            completionContext?.triggerCharacter);
+                        const items = (list?.items ?? []).map(sanitizeForwardedCompletionItem);
+                        return new vscode.CompletionList(items, Boolean(list?.isIncomplete));
+                    } catch {
+                        return undefined;
+                    }
+                },
+            },
+            ".",
+            "\"",
+            "'",
+            "/",
+            "@",
+            "<"),
+        vscode.languages.registerHoverProvider(
+            selector,
+            {
+                async provideHover(document, position) {
+                    const target = await resolveEmbeddedTarget(document, position);
+                    if (!target) {
+                        return undefined;
+                    }
+
+                    try {
+                        const hovers = await vscode.commands.executeCommand(
+                            "vscode.executeHoverProvider",
+                            target.virtualUri,
+                            target.virtualPosition);
+                        const hover = (hovers ?? []).find(candidate => candidate?.contents?.length);
+                        return hover ? new vscode.Hover(hover.contents) : undefined;
+                    } catch {
+                        return undefined;
+                    }
+                },
+            }),
+        vscode.languages.registerSignatureHelpProvider(
+            selector,
+            {
+                async provideSignatureHelp(document, position, _token, signatureContext) {
+                    const target = await resolveEmbeddedTarget(document, position);
+                    if (!target) {
+                        return undefined;
+                    }
+
+                    try {
+                        return await vscode.commands.executeCommand(
+                            "vscode.executeSignatureHelpProvider",
+                            target.virtualUri,
+                            target.virtualPosition,
+                            signatureContext?.triggerCharacter);
+                    } catch {
+                        return undefined;
+                    }
+                },
+            },
+            "(",
+            ","),
+        vscode.languages.registerDefinitionProvider(
+            selector,
+            {
+                async provideDefinition(document, position) {
+                    const target = await resolveEmbeddedTarget(document, position);
+                    if (!target) {
+                        return undefined;
+                    }
+
+                    try {
+                        const locations = await vscode.commands.executeCommand(
+                            "vscode.executeDefinitionProvider",
+                            target.virtualUri,
+                            target.virtualPosition);
+                        if (!Array.isArray(locations)) {
+                            return undefined;
+                        }
+
+                        const mapped = [];
+                        for (const location of locations) {
+                            const resolved = await mapForwardedLocation(location);
+                            if (resolved) {
+                                mapped.push(resolved);
+                            }
+                        }
+
+                        return mapped;
+                    } catch {
+                        return undefined;
+                    }
+                },
+            }),
+    ];
+}
+
+async function resolveEmbeddedTarget(document, position) {
+    const client = languageClient;
+    if (!client || !isEmbeddedForwardingEnabled(document)) {
+        return undefined;
+    }
+
+    let info;
+    try {
+        info = await client.sendRequest("typewriter/embeddedPosition", {
+            textDocument: {
+                uri: document.uri.toString(),
+            },
+            position: {
+                line: position.line,
+                character: position.character,
+            },
+        });
+    } catch {
+        return undefined;
+    }
+
+    if (!info
+        || !embeddedSuffixes[info.kind]
+        || !info.virtualPosition
+        || typeof info.virtualPosition.line !== "number"
+        || typeof info.virtualPosition.character !== "number") {
+        return undefined;
+    }
+
+    const virtualUri = await ensureEmbeddedDocument(client, document, info.kind);
+    if (!virtualUri) {
+        return undefined;
+    }
+
+    return {
+        kind: info.kind,
+        virtualUri,
+        virtualPosition: new vscode.Position(info.virtualPosition.line, info.virtualPosition.character),
+    };
+}
+
+async function ensureEmbeddedDocument(client, document, kind) {
+    let snapshot;
+    try {
+        snapshot = await client.sendRequest("typewriter/embeddedDocument", {
+            textDocument: {
+                uri: document.uri.toString(),
+            },
+            kind,
+        });
+    } catch {
+        return undefined;
+    }
+
+    if (!snapshot || typeof snapshot.content !== "string") {
+        return undefined;
+    }
+
+    const virtualUri = createEmbeddedUri(document.uri, kind);
+    const key = virtualUri.toString();
+    const previous = embeddedDocuments.get(key);
+    embeddedDocuments.set(key, snapshot.content);
+    if (previous !== undefined && previous !== snapshot.content) {
+        embeddedContentEmitter.fire(virtualUri);
+    }
+
+    try {
+        await vscode.workspace.openTextDocument(virtualUri);
+    } catch {
+        return undefined;
+    }
+
+    await waitForEmbeddedContent(key, snapshot.content);
+    return virtualUri;
+}
+
+async function waitForEmbeddedContent(virtualUriKey, content) {
+    for (let attempt = 0; attempt < 20; attempt++) {
+        const document = vscode.workspace.textDocuments.find(candidate => candidate.uri.toString() === virtualUriKey);
+        if (document && document.getText() === content) {
+            return;
+        }
+
+        await delay(25);
+    }
+}
+
+async function provideEmbeddedContent(uri) {
+    const cached = embeddedDocuments.get(uri.toString());
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const parsed = parseEmbeddedUri(uri);
+    const client = languageClient;
+    if (!parsed || !client) {
+        return "";
+    }
+
+    try {
+        const snapshot = await client.sendRequest("typewriter/embeddedDocument", {
+            textDocument: {
+                uri: parsed.originalUri.toString(),
+            },
+            kind: parsed.kind,
+        });
+        const content = typeof snapshot?.content === "string" ? snapshot.content : "";
+        embeddedDocuments.set(uri.toString(), content);
+        return content;
+    } catch {
+        return "";
+    }
+}
+
+async function mapForwardedLocation(location) {
+    const uri = location.targetUri ?? location.uri;
+    const range = location.targetSelectionRange ?? location.targetRange ?? location.range;
+    if (!uri || !range) {
+        return undefined;
+    }
+
+    if (uri.scheme !== embeddedScheme) {
+        return new vscode.Location(uri, range);
+    }
+
+    const parsed = parseEmbeddedUri(uri);
+    const client = languageClient;
+    if (!parsed || !client) {
+        return undefined;
+    }
+
+    try {
+        const mappedRange = await client.sendRequest("typewriter/templateRange", {
+            textDocument: {
+                uri: parsed.originalUri.toString(),
+            },
+            kind: parsed.kind,
+            range: {
+                start: {
+                    line: range.start.line,
+                    character: range.start.character,
+                },
+                end: {
+                    line: range.end.line,
+                    character: range.end.character,
+                },
+            },
+        });
+        if (!mappedRange?.start || !mappedRange?.end) {
+            return undefined;
+        }
+
+        return new vscode.Location(
+            parsed.originalUri,
+            new vscode.Range(
+                mappedRange.start.line,
+                mappedRange.start.character,
+                mappedRange.end.line,
+                mappedRange.end.character));
+    } catch {
+        return undefined;
+    }
+}
+
+function sanitizeForwardedCompletionItem(item) {
+    item.range = undefined;
+    item.textEdit = undefined;
+    item.additionalTextEdits = undefined;
+    item.command = undefined;
+    return item;
+}
+
+function createEmbeddedUri(documentUri, kind) {
+    return documentUri.with({
+        scheme: embeddedScheme,
+        path: documentUri.path + embeddedSuffixes[kind],
+    });
+}
+
+function parseEmbeddedUri(uri) {
+    for (const [kind, suffix] of Object.entries(embeddedSuffixes)) {
+        if (uri.path.endsWith(suffix)) {
+            return {
+                kind,
+                originalUri: uri.with({
+                    scheme: "file",
+                    path: uri.path.slice(0, -suffix.length),
+                }),
+            };
+        }
+    }
+
+    return undefined;
+}
+
+function refreshEmbeddedDocuments() {
+    for (const key of [...embeddedDocuments.keys()]) {
+        embeddedDocuments.delete(key);
+        try {
+            embeddedContentEmitter.fire(vscode.Uri.parse(key));
+        } catch {
+            // Ignore malformed cached URIs.
+        }
+    }
+}
+
+function isEmbeddedForwardingEnabled(document) {
+    return getConfiguration(document.uri).get("embeddedLanguages.forwarding", "auto") !== "off";
 }
 
 function createFallbackCompletionProvider() {


### PR DESCRIPTION
This pull request improves the packaging and documentation for the Typewriter plugins and extensions, ensuring that XML documentation files are included where needed to enable full IntelliSense (including hover documentation) in all supported IDEs. It also updates the documentation to explain these IntelliSense improvements and how they're supported across VS Code, Visual Studio, and Rider.

**Packaging and Build Improvements:**

* Updated the `Add-DirectoryToZip` function in both `Build-RiderPluginWithTools.ps1` and `Build-VSCodeExtension.ps1` to support a `-KeepTypewriterXmlDocFiles` switch, ensuring that `Typewriter.*.xml` files are included in the packaged language server when required for Roslyn hover documentation. [[1]](diffhunk://#diff-8f0a3930f7b4dd16914aa78ecc536e3c83432991c16dc71275e89019b19b2f31L120-R130) [[2]](diffhunk://#diff-8af648611d49806d99d082591b5021be94a629a8a1f5dd75fb1c8c681bb754a4L111-R121)
* Modified the packaging steps in build scripts to pass the new switch and include the necessary XML doc files for the language server in Rider, VS Code, and Visual Studio extensions. [[1]](diffhunk://#diff-8f0a3930f7b4dd16914aa78ecc536e3c83432991c16dc71275e89019b19b2f31L185-R191) [[2]](diffhunk://#diff-8af648611d49806d99d082591b5021be94a629a8a1f5dd75fb1c8c681bb754a4L195-R201)
* Updated the list of expected files in the build outputs to include `Typewriter.Engine.xml` and `Typewriter.Abstractions.xml` for all plugin/extension targets, ensuring these are present for runtime documentation support. [[1]](diffhunk://#diff-8f0a3930f7b4dd16914aa78ecc536e3c83432991c16dc71275e89019b19b2f31R220-R221) [[2]](diffhunk://#diff-8af648611d49806d99d082591b5021be94a629a8a1f5dd75fb1c8c681bb754a4R222-R223) [[3]](diffhunk://#diff-900f21d92bd338eeb6e847c5d0519135049fd6209dd50402d47bafe8ef62bc88R100-R101)

**Documentation Updates:**

* Added a new section to the `README.md` explaining the enhancements to Template IntelliSense, including documented completions, Roslyn-powered C# IntelliSense in template blocks, and an IDE support matrix. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R144-R169)
* Clarified in the Rider section of the documentation that the plugin now registers the Typewriter language server, providing the same IntelliSense features as VS Code and Visual Studio.