### PR TITLE
Bugfix/99 on save performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Collect editor packages
         shell: pwsh
         run: |
-          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.6.1.vsix
-          Copy-Item rider/build/distributions/typewriter-rider-4.6.1.zip artifacts/packages/Typewriter-Rider-4.6.1.zip
+          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.7.0.vsix
+          Copy-Item rider/build/distributions/typewriter-rider-4.7.0.zip artifacts/packages/Typewriter-Rider-4.7.0.zip
 
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ErrorLog>$(MSBuildThisFileDirectory).sarif\$(MSBuildProjectName).json</ErrorLog>
-    <Version>4.6.1</Version>
+    <Version>4.7.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
   - [🔨 Building from Source](#-building-from-source)
   - [🗺 Project Status and Roadmap](#-project-status-and-roadmap)
   - [Changelog](#changelog)
+    - [4.7.0](#470)
     - [4.6.1](#461)
     - [4.6.0](#460)
     - [4.5.4](#454)
@@ -1271,6 +1272,19 @@ dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj --config
 ---
 
 ## Changelog
+
+### 4.7.0
+
+- Added a much richer shared Language Server experience for `.tst` templates: documented completions and hover, semantic highlighting, go-to-definition, project-aware template completions, and Roslyn-backed IntelliSense inside `${ ... }` C# helper blocks.
+- Added VS Code embedded-language forwarding through virtual C# and TypeScript documents, so the installed C# extension and TypeScript service can provide completion, hover, and definitions inside template helper/output regions. This is controlled by `typewriter.embeddedLanguages.forwarding`.
+- Added Rider LSP integration through the IntelliJ Platform LSP API, allowing Rider to use the shared Typewriter language server while retaining CLI-based generation and validation fallbacks.
+- Fixed `Settings.IncludeProject(name)` so templates can explicitly merge a named workspace project, plus its referenced projects, into the current template code model. Missing projects now raise `TW0009`, and `samples/issue98` covers the unreferenced-project scenario.
+- Improved watch mode and editor generate-on-save performance with changed-input tracking. `typewriter watch`, IDE integrations, and the language server can now pass changed paths through `--changed` / `changedInputs`, and the default `generation.incremental: "auto"` mode re-renders only affected outputs when only C# source files changed.
+- Added safe full-generation fallbacks for incremental runs when change provenance is unknown, the changed input is a template/project/config file, a file was deleted or renamed, or incremental generation is disabled with `generation.incremental: "off"`.
+- Improved Roslyn metadata caching for incremental generation with dirty-path invalidation, source-only rebuilds, syntax-tree and type-reference reuse, reverse dependency indexing, and optional metadata cache metrics in performance traces.
+- Added configuration/schema support for the new `generation.incremental` setting and CLI parsing coverage for repeated `--changed` arguments.
+- Added regression coverage for embedded-language services, LSP embedded document/range requests, `IncludeProject`, incremental rendering, dirty-path metadata refresh, and editor changed-path plumbing.
+- Added release and maintenance documentation for compatibility status, implemented work, packaging, Rider installation, and generation performance planning/progress.
 
 ### 4.6.1
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,181 @@
+The main remaining gap is full old Typewriter runtime compatibility, not the new engine/editor milestones.
+
+## Status snapshot as of 2026-07-02
+
+Recently completed:
+
+- [x] Nullable dictionary mapping keeps outer nullability even when the dictionary value type is nullable, for example `Record<string, string | null> | null`.
+- [x] Nullable list element mapping is parenthesized correctly, for example `(string | null)[]`.
+- [x] Enum defaults use the first enum member when metadata is available, for example `FirstSet.ValA`, instead of falling back to `0`.
+- [x] Enum value metadata is carried on `TypeMetadataReference`, so per-source rendering and legacy `$Type[$Default]` paths can resolve enum defaults without relying on a global lookup.
+- [x] Attribute constructor arguments with `null` and constant values, including `[AllowedValues(null, Const.Value1, Const.Value2)]`, are extracted without the old Typewriter string-slicing failure from issue 55.
+- [x] Compiled predicate helpers can receive both parent and current contexts, for example `bool Filter(Record r, Property p)` for `$Properties($Filter)`.
+
+Still left:
+
+- [ ] Full old Typewriter parser/runtime parity for edge cases not yet covered by real recipe snapshots.
+- [ ] Additional `NetCoreTypewriterRecipes` service variants and request/response edge cases.
+- [ ] More exact comparison against original Typewriter output where original output can be captured.
+- [ ] Template reference hardening around restore diagnostics, incompatible assets, floating/range versions, and long-running cache/unload stress.
+- [ ] Direct VS Code, Visual Studio, and JetBrains Marketplace publishing/signing.
+
+Latest focused validation:
+
+```text
+dotnet test tests\unit\Typewriter.Engine.Tests\Typewriter.Engine.Tests.csproj -m:1
+dotnet test tests\unit\Typewriter.Roslyn.Tests\Typewriter.Roslyn.Tests.csproj -m:1
+```
+
+## Compatibility target
+
+The current practical target is old `.tst` templates used by real projects, especially the checked sibling `NetCoreTypewriterRecipes` repository when it is available at:
+
+```text
+D:\GitHub\NetCoreTypewriterRecipes
+```
+
+Compatibility should be judged in this order:
+
+1. Existing checked-in sample snapshots.
+2. External recipe snapshots from `NetCoreTypewriterRecipes`.
+3. Real project templates that are not covered by those recipes.
+4. Exact original Typewriter output, when original output can be captured.
+
+## What is now covered
+
+### Typewriter.CodeModel public surface parity
+
+The original public `Typewriter.CodeModel` member surface is implemented for compiled template helpers and direct template rendering:
+
+- classes, records, interfaces, enums, delegates
+- properties, methods, parameters, constants
+- fields, events, static readonly fields
+- attributes and attribute arguments
+- XML doc comments and parameter comments
+- nested classes/interfaces/enums, type parameters, type arguments
+- tuple/value tuple metadata, file locations, assembly/source metadata
+- original implicit string conversions and class/record/interface/enum to `Type` conversions
+- legacy direct collection rendering for string-convertible collections such as `$TypeParameters`
+
+### Template language and helper execution
+
+The renderer covers the common old `.tst` patterns currently exercised by samples and recipe snapshots:
+
+- root collections such as `$Classes`, `$Records`, `$Interfaces`, `$Enums`, and `$Delegates`
+- member-level collections such as `$Properties`, `$Parameters`, `$Values`/`$EnumValues`, `$Fields`, `$StaticReadOnlyFields`, `$Methods`, `$Constants`, and `$Events`
+- scalar substitutions such as `$Name`, `$name`, `$FullName`, `$Namespace`, `$Type`, `$ReturnType`, and nullable/static flags
+- collection separators and direct collection rendering for common legacy cases
+- common filters, including `Class`, `Record`, `Interface`, `Enum`, `HasProperties`, `Public`, `Internal`, `Name=`, `Namespace=`, `[Attribute]`, base-type filters, and wildcard name/full-name filters
+- inline lambda filters for common name/namespace/boolean/string predicates
+- `$Type[...]` blocks, `$Parent[...]` traversal, and parent-aware CodeModel contexts
+- compiled C# helper methods from `${ ... }` blocks, including simple bool/string helpers, helpers returning CodeModel collections, and two-parameter predicate helpers such as `bool Filter(Record r, Property p)`
+- TypeScript type/default compatibility for nullable dictionaries, nullable list element types, and enum defaults in legacy `$Type[...]` rendering
+- template `Settings.OutputFilenameFactory`, including source-file fan-out and no-match suppression
+- legacy `SingleFileMode("...")` output filename detection
+- TypeScript template literal preservation, such as `${environment.apiBaseUrl}`
+
+### Metadata extraction
+
+Roslyn metadata currently covers the compatibility surface needed by the samples and recipe snapshots:
+
+- classes, records, interfaces, enums, delegates
+- properties, methods, parameters, return types, constants, fields, static readonly fields, and events
+- attributes on types, members, parameters, enum values, and attribute arguments
+- attribute argument values containing `null`, constants, `typeof(...)`, and named arguments
+- const values, parameter defaults, enum values, and static type flags
+- enum values on type references for default-value rendering during source-file fan-out
+- nullable reference/value types, nullable generic arguments, arrays, collections, dictionaries, and nullable directive regions
+- XML doc comments and parameter comments
+- base types, implemented interfaces, nested types, type parameters, type arguments, tuple/value tuple metadata
+- accessibility, assembly/source metadata, source locations, and source-file grouping
+
+### Recipe-backed coverage
+
+Checked-in snapshots and conditional external recipe snapshots cover representative compatibility paths:
+
+- simple model generation
+- nullable model generation
+- records and enums
+- multi-project/project-reference generation
+- Web API service generation
+- constants generation
+- SignalR hub generation
+- Angular and React model recipes for `System.Text.Json`
+- Angular and React model recipes for `Newtonsoft.Json`
+- Angular and React service recipes for `System.Text.Json`
+- Angular sample constants recipe
+- Angular model edge cases for nullable dictionaries, nullable lists, and enum defaults from the `AngularWebApiSample` shape
+- the `AllowedValuesAttribute` crash scenario from Typewriter issue 55
+
+### Template references and helper isolation
+
+Compiled C# template helpers now support the compatibility pieces needed for long-running CLI/editor use:
+
+- local `#r "path/to/assembly.dll"` references
+- `#r "nuget: PackageId, Version"` references from the local NuGet cache
+- restore/download for missing NuGet packages through `dotnet restore`
+- nearest `NuGet.config` discovery from the template directory upward, so private/local package sources can be used
+- compile-asset resolution from restored `project.assets.json`, including package dependencies selected by NuGet
+- generated helper assemblies loaded into collectible `AssemblyLoadContext` instances
+- helper assembly unload after render/output filename evaluation
+
+## What is still left
+
+### More exact `.tst` parser/runtime behavior
+
+We support common filters, lambdas, compiled helpers, `$Type[...]`, `$Parent[...]`, direct CodeModel blocks, and the currently snapshot-tested recipe patterns, but not every old parser/rendering edge case:
+
+- exact whitespace trimming
+- all legacy collection separator quirks
+- all filter combinations
+- more complex helper/lambda expressions
+- old quirks that real recipes may depend on
+
+Next useful work:
+
+- add focused renderer tests for each old parser/runtime quirk as it is discovered
+- prefer real recipe fixtures over synthetic behavior guesses
+- compare generated output against original Typewriter output where possible
+
+### Template reference hardening
+
+NuGet restore and isolated helper loading are implemented, but this area can still use migration hardening:
+
+- richer diagnostics for restore source/authentication failures
+- deeper tests for missing package, missing version, incompatible assets, floating versions, and version ranges
+- target framework selection beyond the current engine-oriented restore target
+- safe compiled-template caching that still preserves unloadability
+- longer stress tests that repeated watch/editor renders do not grow memory over time
+
+### More real recipe coverage
+
+Current snapshots cover representative `NetCoreTypewriterRecipes` model/service/constants paths, but still need:
+
+- additional service variants
+- deeper request body/response helper cases
+- more route, verb, query, body, cancellation-token, and response-type combinations
+- recipes that use custom helper return types not represented by current samples
+- more old recipes from real projects
+- comparison against output from original Typewriter where possible
+
+### Original Visual Studio behavior
+
+New VS/VS Code/LSP support exists, but original Visual Studio extension behavior may still differ:
+
+- project item add/update behavior
+- generated file nesting behavior
+- encoding/BOM behavior
+- settings/options parity
+- generated file tracking behavior
+- save-trigger ordering and debounce behavior
+
+## Other compatibility work worth tracking
+
+These are not pure template-runtime gaps, but they affect migration confidence:
+
+- VS Code package publishing
+- Visual Studio VSIX signing/publishing
+- JetBrains Marketplace publishing
+- automated synchronization of repository and package changelogs
+- migration tooling or diagnostics for old templates
+- a documented compatibility matrix for old Typewriter features, recipe coverage, and known deviations

--- a/docs/implemented.md
+++ b/docs/implemented.md
@@ -1,0 +1,559 @@
+# Typewriter Implemented
+
+Completed and current-state implementation record. Remaining roadmap and backlog items are tracked in [to_implement.md](to_implement.md).
+
+## Implementation Status as of 2026-07-02
+
+This section records what has already been implemented in this repository after the initial reimplementation work. It is intentionally separate from the roadmap above so the plan remains useful as a target architecture document.
+
+## Milestone Implementation Status
+
+| Milestone | Status | Notes |
+|---|---:|---|
+| Milestone 1: Clean Core Foundation | Done | Solution structure, abstractions, engine/Roslyn/Buildalyzer/CLI projects, unit test projects, diagnostics/result models, and editor-independent core are in place. |
+| Milestone 2: Roslyn Metadata | Done | Classes, records, interfaces, enums, delegates, properties, methods, parameters, constants, fields, static readonly fields, events, attributes, doc comments, enum values, base types, accessibility, collections, dictionaries, tuple/value tuple shapes, nullable metadata, generic type argument nullability, and per-declaration nullable context are implemented. Remaining old-template language compatibility work is tracked under Milestone 9. |
+| Milestone 3: First Template Execution | Done | Minimal old-style `.tst` execution works, generated files are planned safely, changed-file writes are supported, diagnostics are returned, and SimpleApi generation is snapshot-tested. |
+| Milestone 4: CLI MVP | Done | `generate`, `validate`, `list-templates`, JSON/text output, dry-run, framework, fail-on-warning, config loading, exit code mapping, and CLI integration tests are implemented. |
+| Milestone 5: Watch Mode | Done | `typewriter watch` is implemented with file watching, debounce, cancellation, continuous result output, and CLI integration coverage for initial generation and source-change regeneration. |
+| Milestone 6: VS Code MVP | Done | VS Code extension project, `.tst` language association, syntax highlighting, generate/validate commands, CLI bridge, JSON diagnostic parsing, Problems diagnostics, and save-time validation/generation settings are implemented. |
+| Milestone 7: Visual Studio MVP | Done | SDK-style VSIX adapter, VSIX/pkgdef packaging, generate/validate commands, CLI bridge, generate-on-save, Output window logging, Error List diagnostics, `.tst` classification, and native Ctrl+Space fallback completions are implemented. Focused VSIX build and full solution build/test pass; manual VS installation smoke testing is still recommended before release. |
+| Milestone 8: Language Server MVP | Done | LSP server process, JSON-RPC protocol loop, document open/change/save/close sync, live template diagnostics, completion, hover, go-to-definition, semantic tokens, VS Code language client startup, and restart command are implemented. |
+| Milestone 9: Rich Template Experience | Done; compatibility hardening ongoing | LSP completions, hover, and definition support are implemented. The renderer now also has compatibility filters, metadata substitutions, inline lambda filters, compiled C# template helpers, two-parameter predicate helper invocation, local `#r`/NuGet reference resolution, TypeScript template-literal interpolation preservation, original public Typewriter.CodeModel surface parity, richer CodeModel type/attribute/default handling, and per-source `OutputFilenameFactory` fan-out with no-match suppression. Checked snapshots cover external Angular/React System.Text.Json service recipes, Angular/React System.Text.Json model recipes, Angular/React Newtonsoft.Json model recipes, and an external Angular constants recipe when the sibling `NetCoreTypewriterRecipes` checkout is available. Recent hardening covers nullable dictionary/list mapping, enum defaults, and the `AllowedValuesAttribute` scenario from issue 55. Remaining work is old parser/runtime edge-case hardening as real recipes expose gaps. |
+| Milestone 10: Packaging and Release | Done for NuGet and GitHub release assets; marketplaces ongoing | Tag releases publish the CLI and language-server dotnet tools to NuGet and attach VS Code, Visual Studio, and Rider packages to GitHub releases. Direct marketplace publishing remains backlog work. |
+
+## PR Sequence Status
+
+```text
+PR 01: Initial solution structure                 Done
+PR 02: Abstractions and diagnostics model         Done
+PR 03: Roslyn metadata extraction                 Done
+PR 04: Template discovery and parsing skeleton    Done
+PR 05: First generation pipeline                  Done
+PR 06: Snapshot test infrastructure               Done
+PR 07: CLI generate command                       Done
+PR 08: CLI JSON output and exit codes             Done
+PR 09: Project/solution loading through Buildalyzer Done
+PR 10: Watch mode                                 Done
+PR 11: VS Code extension skeleton                 Done
+PR 12: VS Code commands and CLI bridge            Done
+PR 13: VS Code diagnostics                        Done
+PR 14: Visual Studio SDK-style VSIX skeleton      Done
+PR 15: Visual Studio commands and engine bridge   Done
+PR 16: Visual Studio generate-on-save             Done
+PR 17: Language server skeleton                   Done
+PR 18: Language server diagnostics                Done
+PR 19: Completion and hover                       Done
+```
+
+## Implemented
+
+```text
+- Initial solution structure with source and unit test projects
+- Typewriter.Abstractions project
+- Typewriter.Engine project
+- Typewriter.Roslyn project
+- Typewriter.Buildalyzer project
+- Typewriter.Cli project
+- Typewriter.LanguageServer project
+- Typewriter.VisualStudio project
+- Typewriter.Engine.Tests project
+- Typewriter.Roslyn.Tests project
+- Typewriter.Buildalyzer.Tests project
+- Typewriter.Cli.Tests project
+- Typewriter.LanguageServer.Tests project
+- Typewriter.SnapshotTests project
+- SimpleApi sample project and .tst template
+- SimpleApi checked-in generated TypeScript snapshot
+- NullableModels sample project and generated TypeScript snapshot
+- RecordsAndEnums sample project and generated TypeScript snapshot
+- MultiProjectSolution sample project and generated TypeScript snapshot
+- WebApiServices sample project with service and constants templates plus checked-in TypeScript snapshots
+- SignalRHubs sample project with SignalR hub template plus checked-in TypeScript snapshot
+```
+
+Implemented core models and contracts:
+
+```text
+- GenerationRequest
+- GenerationResult
+- GeneratedFile
+- GenerationDiagnostic
+- TypewriterConfiguration
+- ProjectMetadata
+- SourceFileMetadata
+- TypeMetadata
+- PropertyMetadata
+- AttributeMetadata
+- TypeMetadataReference
+- EnumValueMetadata
+- ITypewriterGenerator
+- ITemplateDiscovery
+- IProjectMetadataProvider
+- IGeneratedFileWriter
+```
+
+Implemented generation pipeline:
+
+```text
+- Resolve workspace and project path
+- Discover templates from explicit --template or configured template globs
+- Load project metadata
+- Parse template directives
+- Render a minimal old-style .tst template dialect
+- Plan generated output paths
+- Block output paths outside workspace
+- Refuse to overwrite existing non-generated files
+- Add generated-file header
+- Write only changed files
+- Return shared diagnostics and generated-file results
+```
+
+Implemented CLI features:
+
+```text
+- System.CommandLine-backed command and option parsing
+- typewriter generate
+- typewriter validate
+- typewriter watch
+- typewriter list-templates
+- --workspace
+- --project
+- --template (single file or directory)
+- --template-search-path
+- --framework
+- --output text|json
+- --dry-run
+- --fail-on-warning
+- --all-projects
+- --diff (unified diff output for content, line-ending, and final-newline changes in text and JSON modes)
+- Exit codes for success, generation failure, invalid arguments, project-load failure, and template parse failure
+```
+
+Implemented watch mode:
+
+```text
+- FileSystemWatcher-based CLI watcher
+- Initial generation when watch starts
+- Watches .cs, .csproj, .json, .props, .targets, .sln, .slnx, and .tst files
+- Ignores bin, obj, node_modules, and generated output directories
+- Debounces watched changes before regeneration
+- Cancels an in-flight generation when a new watched change arrives
+- Supports Ctrl+C / cancellation-token shutdown
+- Prints generation results on each run using the selected text or JSON output mode
+```
+
+Implemented VS Code MVP:
+
+```text
+- vscode/package.json extension manifest
+- .tst language association
+- basic .tst TextMate syntax highlighting
+- language configuration for comments, brackets, and auto-closing pairs
+- Typewriter: Generate Current Template command
+- Typewriter: Generate All Templates command
+- Typewriter: Validate Current Template command
+- CLI bridge that runs the local repo CLI through dotnet run when available, otherwise falls back to typewriter on PATH
+- Settings for cliPath, cliArguments, workspacePath, projectPath, templatePath, framework, allProjects, generateOnSave, and validateOnSave
+- JSON CLI result parsing
+- Problems panel diagnostics mapped from shared Typewriter diagnostics
+- Typewriter output channel with command, CLI output, generated files, and diagnostic summary
+- Save-time validation by default, with optional generate-on-save
+```
+
+Implemented Visual Studio MVP:
+
+```text
+- SDK-style Typewriter.VisualStudio VSIX project targeting net472
+- Microsoft.VSSDK.BuildTools-backed VSIX packaging with generated pkgdef metadata
+- VSIX manifest targeting Visual Studio 2022 Community, Professional, and Enterprise on amd64 and arm64
+- Tools menu commands for Typewriter: Generate Current Template, Generate All Templates, and Validate Current Template
+- CLI bridge that runs the local repo CLI through dotnet run when available, otherwise falls back to typewriter on PATH
+- Visual Studio options page for CLI path, CLI arguments, workspace/project/framework overrides, all-projects, and generate-on-save
+- Active solution/project/template discovery for command execution
+- Output window pane with command line, CLI output, generated file summary, and diagnostics summary
+- Error List diagnostics mapped from shared CLI JSON diagnostics with file/line/column navigation
+- Running Document Table save listener for .tst generate-on-save
+- .tst editor classification for directives, template members, collections, comments, strings, and C# helper blocks
+- Native Visual Studio Ctrl+Space fallback completions for Typewriter template expressions, C# helper blocks, and TypeScript output regions
+- Visual Studio language-server startup prefers an already built local Typewriter.LanguageServer.dll before falling back to dotnet run or packaged typewriter-lsp
+- VS project is included in AdaskoTheBeAsT.Typewriter.slnx
+```
+
+Implemented Language Server MVP:
+
+```text
+- Typewriter.LanguageServer executable project targeting net10.0
+- Content-Length framed JSON-RPC transport over standard input/output
+- initialize/shutdown/exit request lifecycle
+- textDocument/didOpen, didChange, didSave, and didClose document sync
+- Debounced live validation with cancellation of superseded validation runs
+- textDocument/publishDiagnostics notifications mapped from shared Typewriter diagnostics
+- In-memory template discovery so diagnostics use the current open document text, not only saved file content
+- textDocument/completion for template collections, scalar members, filters, helper methods, and loaded C# metadata
+- context-aware completion for C# helper blocks and TypeScript output regions
+- textDocument/hover for template members, helper methods, and loaded C# metadata
+- textDocument/definition for C# source symbols and generated output from output directives
+- textDocument/semanticTokens/full for Typewriter tokens, C# helper blocks, and TypeScript output regions
+- VS Code language client startup when typewriter.languageServer.enabled is true
+- VS Code Typewriter: Restart Language Server command
+- VS Code settings for languageServer.path and languageServer.arguments
+```
+
+Implemented project loading in Typewriter.Buildalyzer:
+
+```text
+- Buildalyzer submodule integrated from https://github.com/AdaskoTheBeAsT/Buildalyzer.git
+- Submodule branch configured as feature/typewriter-v2
+- Typewriter.Buildalyzer now uses Buildalyzer AnalyzerManager instead of the earlier lightweight parser
+- TargetFramework / TargetFrameworks evaluation through Buildalyzer
+- MSBuild-evaluated source files
+- MSBuild-evaluated metadata references, including NuGet/package references
+- MSBuild-evaluated preprocessor symbols
+- Nullable and ImplicitUsings property capture
+- Recursive ProjectReference traversal
+- Generated obj assembly metadata files are filtered out before Roslyn compilation
+- .sln workspace support through Buildalyzer AnalyzerManager
+- .slnx workspace support through Typewriter project discovery plus explicit MSBuild solution properties
+- Single-project .sln/.slnx workspaces can resolve the project automatically
+- Multi-project .sln/.slnx workspaces report a diagnostic and require --project
+- Explicit --all-projects fan-out for multi-project workspaces
+- Project-local template discovery when fan-out is enabled
+- Buildalyzer.Logger kept on netstandard2.0 for MSBuild logger loading
+- Runtime dependencies for Buildalyzer.Logger, MsBuildPipeLogger, and Roslyn are copied for CLI/test execution
+- Buildalyzer evaluation disables MSBuild node reuse and shared compilation for more predictable CLI/test execution
+- Legacy non-SDK .csproj loading with ToolsVersion and TargetFrameworkVersion
+- TW0003 diagnostic surfacing for unresolved unconditional <Import> elements even when Buildalyzer reports success with zero source files
+```
+
+Implemented Roslyn metadata extraction:
+
+```text
+- Classes
+- Records
+- Interfaces
+- Enums
+- Structs
+- Delegates
+- Properties
+- Indexer properties with parameters
+- Methods and parameters
+- Constants, fields, static readonly fields, and events
+- Property types
+- Nullable reference annotations
+- Nullable<T>
+- Nullable generic type arguments
+- Nullable collection element types
+- Per-declaration nullable context from `#nullable enable`, `#nullable disable`, and `#nullable restore`
+- Collections and arrays
+- Dictionary detection
+- Attributes and attribute arguments
+- Attribute arguments containing nulls, constants, typeof values, source-like multi-argument values, and named arguments
+- XML doc comments and parameter comments
+- Base types and implemented interfaces
+- Nested classes, records, interfaces, and enums
+- Type parameters and type arguments
+- Tuple/value tuple metadata
+- Assembly names and source file locations
+- Enum values
+- Enum values on type references, so enum defaults can be resolved during per-source rendering
+- Accessibility
+```
+
+Implemented template support:
+
+```text
+- $Classes[...] 
+- $Records[...] 
+- $Interfaces[...] 
+- $Enums[...] 
+- $Structs[...]
+- $Properties[...] 
+- $Properties($IsIndexer)[...] with $Parameters for indexer parameter rendering
+- $Values[...] / $EnumValues[...]
+- $Methods[...]
+- $Parameters[...]
+- $Constants[...]
+- $Fields[...]
+- $StaticReadOnlyFields[...]
+- $Events[...]
+- $Delegates[...]
+- $DocComment[...] and $DocComment[$Parameters[...]]
+- $TypeParameters and $TypeArguments as direct legacy string-convertible collections
+- Scalar substitutions such as $Name, $name, $FullName, $Namespace, $Type
+- Name case formatting through `GetName(NameCase)`, `ToNameCase(NameCase)`, and direct template aliases such as `$LowerKebabName`, `$UpperSnakeName`, and `$Name[$CamelCase]`
+- Boolean blocks such as $IsNullable[...][...]
+- Collection separators
+- Basic filters: Class, Record, Interface, Enum, Struct, HasProperties, Public, Internal
+- Name= and Namespace= filters
+- Old-style [Attribute] filters
+- Old-style :BaseType inheritance filters
+- Inline lambda filters for common predicates such as Name/Namespace checks, boolean flags, .Any(...), and string StartsWith/EndsWith/Contains/Equals calls
+- Compatibility code-block capture for simple bool/string helper methods
+- Compiled helper methods returning CodeModel collections can feed template collection blocks
+- Compiled predicate helpers can receive both parent and current CodeModel contexts, for example `bool Filter(Record r, Property p)` used by `$Properties($Filter)`
+- Recipe-style predicate helpers used by NetCoreTypewriterRecipes model templates, including IncludeClass, IncludeRecord, IncludeEnums, IncludeInterface, and IncludeProperty
+- Type helper blocks such as $Type[$Default], $Type[$Name], ClassName(), Default(), BaseClass/BaseRecord, nullable marks, and optional $Name$ closing delimiters
+- `$Type[$Default]` resolves enum defaults to the first enum member when available, for example `FirstSet.ValA`, instead of falling back to `0`
+- Nullable dictionaries preserve outer nullability even when the value type is nullable, for example `Record<string, string | null> | null`
+- Nullable collection element types are parenthesized before array suffixes, for example `(string | null)[]`
+- Parent-aware CodeModel contexts for class, method, parameter, property, constant, enum value, attribute, attribute argument, and type-reference helper results
+- Original public Typewriter.CodeModel member surface, collection interfaces, and implicit conversions are exposed for compiled C# helpers
+- Metadata-side $Parent[...] traversal for methods, parameters, properties, constants, and enum values
+- Object-valued scalar substitutions keep their object context for nested blocks such as $Parent[$UrlFieldName]
+- CodeModel Type.Name uses a legacy stable type name without nullable TypeScript union syntax; direct $Type rendering still keeps nullable TypeScript output.
+- Wildcard name/full-name filters
+- Template directives:
+  - // typewriter-template: v1
+  - // output: relative/path.ts
+  - // typewriter-output: relative/path.ts
+- Legacy SingleFileMode("...") compatibility block detection for output filename
+- Template Settings.OutputFilenameFactory execution for the current rendered CodeModel file
+- Per-source-file rendering when Settings.OutputFilenameFactory is configured and no explicit output path is present
+- No-match suppression for per-source-file OutputFilenameFactory renders where root template filters match no types
+```
+
+Implemented configuration loading:
+
+```text
+- typewriter.json
+- typewriter.config.json
+- .typewriterrc.json
+- Workspace-level config
+- Project-level config
+- Environment overrides
+- CLI overrides for framework, dry-run, and fail-on-warning
+- JSON Schema (typewriter.schema.json) for typewriter.json validation and editor autocomplete
+- typewriter init emits $schema reference as the first property
+```
+
+Configuration precedence currently implemented:
+
+```text
+CLI arguments
+    ↓
+environment variables
+    ↓
+nearest project config
+    ↓
+workspace config
+    ↓
+default settings
+```
+
+Implemented tests:
+
+```text
+- Template directive parsing
+- Template rendering
+- Attribute and inheritance filters
+- Inline lambda filters
+- Recipe-style compatibility predicates from NetCoreTypewriterRecipes model templates
+- Configuration loading
+- Project loading
+- Solution workspace project resolution
+- Buildalyzer solution property handling for .slnx workspaces
+- SimpleApi generation snapshot
+- NullableModels generation snapshot
+- RecordsAndEnums generation snapshot
+- MultiProjectSolution ProjectReference generation snapshot
+- WebApiServices service generation snapshot
+- WebApiServices constants generation snapshot
+- SignalRHubs generation snapshot
+- System.CommandLine CLI command parsing
+- Engine all-projects fan-out
+- CLI integration tests for generate JSON output, all-projects fan-out, project-load failure, and template parse failure
+- CLI integration tests for watch startup, cancellation, and source-change regeneration
+- Engine test for Settings.OutputFilenameFactory output path planning
+- Engine test for Settings.OutputFilenameFactory source-file fan-out
+- Engine regression coverage for no-match suppression during source-file fan-out
+- Engine parser regression coverage for preserving TypeScript template literal interpolation such as `${environment.apiBaseUrl}`
+- Engine regression coverage for preferring dictionary TypeScript mapping over enumerable mapping
+- Engine regression coverage for nullable dictionary outer nullability
+- Engine regression coverage for nullable collection element parenthesizing
+- Engine regression coverage for enum defaults in `$Type[$Default]`
+- Engine regression coverage for two-parameter compiled predicate helpers
+- Roslyn regression coverage for `[AllowedValues(null, Const.Value1, Const.Value2)]`
+- Engine reflection and compile-time coverage for original public Typewriter.CodeModel properties and implicit conversions
+- Engine renderer coverage for CodeModel parity members such as doc comments, fields, static readonly fields, events, delegates, type parameters, and nested types
+- Engine compatibility probe for the external Angular/System.Text.Json service recipe when `D:\GitHub\NetCoreTypewriterRecipes` is available
+- Direct external Angular/System.Text.Json service recipe snapshot when `D:\GitHub\NetCoreTypewriterRecipes` is available
+- Direct external React/System.Text.Json service recipe snapshot when `D:\GitHub\NetCoreTypewriterRecipes` is available
+- Direct external Angular/System.Text.Json and React/System.Text.Json model recipe snapshots when `D:\GitHub\NetCoreTypewriterRecipes` is available
+- Direct external Angular/Newtonsoft.Json and React/Newtonsoft.Json model recipe snapshots when `D:\GitHub\NetCoreTypewriterRecipes` is available
+- Direct external Angular sample constants recipe snapshot when `D:\GitHub\NetCoreTypewriterRecipes` is available
+- Roslyn metadata extraction, including nullable generic arguments and nullable directive regions
+- Language server template diagnostics over open document text
+- Language server completion, hover, C# source definition, generated-output definition, semantic-token, and embedded-language context services
+- Language server JSON-RPC protocol loop for initialize, document sync, completion, semantic tokens, shutdown, and exit
+- UnifiedDiffBuilder unit tests for identical content, new files, deleted files, single-line changes, insertions, deletions, multi-line replacements, CRLF handling, line-ending-only changes, final-newline-only changes, hunk merging, and distant hunk separation
+- Generated-file writer regression coverage verifies that `--diff` skips the LCS calculation for unchanged outputs
+- Public API compatibility tests preserve the pre-4.6.1 `GeneratedFile` and `GenerationRequest` constructor signatures
+- CLI integration tests for --diff output in JSON and text modes, including line-ending-only changes
+- CLI integration test for $schema reference as first property in typewriter init output
+- JSON Schema drift-detection test cross-checking typewriter.schema.json against serialized TypewriterConfiguration.Default
+- Buildalyzer regression tests for old-style non-SDK csproj loading and TW0003 diagnostic surfacing for unresolved unconditional imports
+- Exact snapshot coverage for every issue sample: issue66, issue67, issue68, issue69, issue69v2, issue74, issue75, issue81, issue90, and issue96
+- Visual Studio generate-on-save scope tests for project-local, workspace-level, and missing templates
+- Template discovery test for directory-valued --template
+- Roslyn metadata tests for indexer properties and struct types
+- Engine render tests for $Structs, $Types(Struct), struct properties, and nested structs
+- CodeModel parity tests for Property.IsIndexer, Property.Parameters, and Struct public surface
+```
+
+Verified commands:
+
+```bash
+dotnet build AdaskoTheBeAsT.Typewriter.slnx --configuration Release --no-restore -m:1
+dotnet test AdaskoTheBeAsT.Typewriter.slnx --configuration Release --no-build -m:1
+dotnet run --project src/Typewriter.Cli/Typewriter.Cli.csproj --no-build -- generate --workspace AdaskoTheBeAsT.Typewriter.slnx --project samples/SimpleApi/SimpleApi.csproj --template samples/SimpleApi/Models.tst --framework net10.0 --output json --dry-run
+npm --prefix vscode run lint
+npm --prefix vscode run bundle
+.\rider\gradlew.bat -p rider verifyPlugin
+```
+
+The full verification on 2026-07-02 passes with 265 tests and a warning-free clean Release build. Nullable and obsolete-API warnings from the pinned Buildalyzer submodule are suppressed only for that vendored project at the repository integration boundary; Typewriter projects retain their normal warnings-as-errors policy.
+
+The Visual Studio focused build produces:
+
+```text
+src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix
+```
+
+The CLI sample currently generates:
+
+```text
+samples/SimpleApi/generated/models.ts
+```
+
+## NetCoreTypewriterRecipes Audit
+
+The `.tst` files under `D:\GitHub\NetCoreTypewriterRecipes` were reviewed as the current compatibility target.
+
+Observed model-template requirements:
+
+```text
+- $Classes($IncludeClass), $Records($IncludeRecord), $Enums($IncludeEnums), $Interfaces($IncludeInterface)
+- $Properties($IncludeProperty)
+- code-block bool/string helpers such as IncludeClass, IncludeRecord, IncludeEnums, IncludeProperty, NullableMark
+- $Type[$Default], $Type[$Name], BaseClass/BaseRecord, TypeArguments, ClassName(), Default()
+- enum helper methods such as IsEnumAsNumber and GetEnumAsStringIfItsStringable
+```
+
+Completed model-template edge cases:
+
+```text
+- nullable dictionary output keeps both value nullability and outer dictionary nullability
+- nullable list output uses `(T | null)[]` precedence instead of `T | null[]`
+- enum defaults render as the first enum member when enum metadata is available
+- TypeMetadataReference carries enum values so source-file fan-out can resolve enum defaults
+- two-parameter compiled predicate helpers receive parent and child CodeModel objects
+- AllowedValuesAttribute with null and constant arguments no longer fails metadata extraction
+- shared name-case formatting covers recipe helpers such as Hyphenated(...) and direct `$LowerKebabName` / `$UpperSnakeName` template aliases
+```
+
+Observed service/constants-template requirements now partially covered:
+
+```text
+- $Methods, $Parameters, and $Constants are available in the renderer.
+- Method return types, parameter default values, method/parameter/constant attributes, and parent links are extracted and exposed.
+- Static class detection, constant values, and enum value attributes are extracted and exposed.
+- Compiled service helpers can override built-in member names such as $ReturnType.
+- Compiled helpers can now return CodeModel object collections that are consumed by nested template blocks, for example `$SkipParameters[$name: $Type][, ]`.
+- Template Settings.OutputFilenameFactory is executed and can provide the generated output filename for the current render.
+- Settings.OutputFilenameFactory can now fan out one render per populated source file when no explicit output path is present.
+- Per-source-file fan-out now skips files where filtered root collections such as `$Classes($IncludeClass)` match no items, even if the template contains static header text.
+- CodeModel Type.Name no longer leaks nullable TypeScript union syntax into legacy helper logic such as service method name generation.
+- `$Parent[...]` works for metadata-backed methods, parameters, properties, constants, and enum values, not only CodeModel-backed helper results.
+- WebApi helper coverage now includes HttpMethod(), Url()/Route() route composition, Typewriter-style Type-to-string comparisons, Type.OriginalName, task unwrapping, and typeof(...) response-type attribute formatting.
+- SignalR hub template coverage now includes hub class filtering by Hub base type, HubMethodName, infrastructure parameter skipping, stream-like return detection, hub routes, and Type.OriginalName/TypeArguments support.
+- End-to-end local snapshots now cover representative WebApi service generation, constants generation, and SignalR hub generation.
+- A direct external recipe probe now renders the Angular/System.Text.Json service recipe against AngularWebApiSample-shaped metadata when the sibling `NetCoreTypewriterRecipes` checkout is available.
+- Direct external snapshots now render the Angular/System.Text.Json and React/System.Text.Json service recipes from the sibling `NetCoreTypewriterRecipes` checkout against representative WebApi-shaped metadata.
+- Direct external snapshots now render Angular/React System.Text.Json model recipes, Angular/React Newtonsoft.Json model recipes, and the Angular sample constants recipe from the sibling `NetCoreTypewriterRecipes` checkout.
+- Template runtime compatibility now covers source-like multi-argument attribute values for recipes such as `JsonDerivedType` and named-argument values such as `JsonPolymorphic(TypeDiscriminatorPropertyName = "...")`.
+- Metadata-side `$Type[...]` blocks now use the legacy TypeScript-facing type view for `Name`, `ClassName`, `Default`, `OriginalName`, primitive/date/guid/time-span flags, and string literal settings.
+- Per-source-file `OutputFilenameFactory` resolution is lazy, so files with records/enums/models but no root filter matches do not fail service recipe generation.
+- Template parsing now distinguishes legacy `${ ... }` C# helper blocks from TypeScript template-literal interpolation, so recipe output such as `${environment.apiBaseUrl}` is preserved.
+- TypeScript type mapping now preserves nullable dictionary and nullable list precedence for Angular/React model recipes.
+- Enum default rendering now uses enum members for recipe constructor defaults when enum values are known.
+- Attribute metadata extraction handles the Typewriter issue 55 `AllowedValuesAttribute` shape with `null` plus constant values.
+```
+
+## Shared Helper and Public Surface Coverage
+
+This section comes from a direct audit of `.tst` helper methods under `D:\GitHub\NetCoreTypewriterRecipes` and the original public CodeModel surface under `D:\GitHub\Typewriter`.
+
+Already covered or mostly covered:
+
+```text
+- Typewriter.Extensions.Types: ClassName(), Default(), and Unwrap() are present.
+- Typewriter.Extensions.WebApi: HttpMethod(), Url(), Route(), and RequestData() are present.
+- Settings surface used by the recipes is present: IncludeCurrentProject(), IncludeProject(), IncludeReferencedProjects(), IncludeAllProjects(), SingleFileMode(), OutputFilenameFactory, UseStringLiteralCharacter(), DisableStrictNullGeneration(), DisableUtf8BomGeneration().
+- CodeModel collections and common item members are present for classes, records, interfaces, enums, delegates, members, attributes, doc comments, type references, and parent links.
+- Name-case formatting now covers Hyphenated(string)-style helpers through NameCase.LowerKebabCase and direct template aliases.
+```
+
+## Partially Implemented
+
+```text
+- Solution workspace loading supports a single resolved project, explicit --project, and explicit --all-projects fan-out.
+- Template compatibility covers common collection/scalar/filter patterns, inline lambda filters, model-template predicates from NetCoreTypewriterRecipes, and two-parameter parent/child predicate helpers, but not full old Typewriter compatibility.
+- Template `${ ... }` C# code blocks are compiled with Roslyn. User `using` lines, `Template(Settings settings)` constructors, multi-statement helper methods, local `#r` references, local-cache `#r "nuget: PackageId, Version"` references, and missing NuGet package restore through `dotnet restore` are supported.
+- The compiled helper runtime exposes the original public `Typewriter.CodeModel` member surface, collection interfaces, and implicit conversions for classes, records, interfaces, enums, delegates, members, attributes, doc comments, type references, settings, logging, and common type/WebApi extensions.
+- Roslyn metadata now includes ordinary public/internal methods, parameters, return types, method/parameter attributes, const fields, fields, static readonly fields, events, delegates, doc comments, static type flags, enum member attributes, nested types, tuple elements, and parent identifiers for members.
+- The renderer and compiled helper adapter now expose `$Methods`, `$Parameters`, `$Constants`, `$Fields`, `$StaticReadOnlyFields`, `$Events`, `$Delegates`, `$TypeParameters`, `$DocComment`, `$IsStatic`, method return types, parameter defaults, constant values, enum value attributes, and parent-aware CodeModel objects for helper parameters.
+- Compiled helpers are resolved before built-in members, so recipe helpers such as `ReturnType(Method m)` can intentionally override template member names.
+- CodeModel `Type` and metadata-side `$Type[...]` blocks now carry TypeScript-friendly `Name`, C# `OriginalName`, generic `TypeArguments`, task flags, primitive/date/guid/time-span flags, dynamic flags, Typewriter-style implicit string conversion for old helper comparisons, and template string-literal settings for defaults.
+- CodeModel `Type` and metadata-side `$Type[...]` default rendering can resolve enum defaults from reference-local enum values or project metadata.
+- Attribute values are formatted for common legacy recipe expectations, including raw single string values, source-like multi-argument values such as `typeof(Foo), "bar"`, and named arguments such as `PropertyName = "displayName"`.
+- Record base-class selection ignores compiler-added interface references such as `IEquatable<T>` so records do not render false base-record inheritance.
+- Settings.OutputFilenameFactory is compiled and evaluated for the current render, and generated output planning can use the runtime filename when no explicit `// output:` directive or SingleFileMode filename is present.
+- Settings.OutputFilenameFactory can drive source-file fan-out, with each populated SourceFileMetadata rendered as the current CodeModel file.
+- Source-file fan-out skips no-match renders for filtered root type collections and resolves OutputFilenameFactory lazily, avoiding generated header-only files and factory errors for non-matching source files.
+- Object-valued scalar substitutions keep their object context for nested blocks; this supports real recipe patterns such as `$Parent[$UrlFieldName]`.
+- CodeModel Type.Name is separated from nullable TypeScript rendering, so direct `$Type` can still render `string | null` while legacy helper code sees `Type.Name == "string"`.
+- Representative WebApi and SignalR helper tests cover verb detection, route composition, response type attributes, SignalR hub routes, HubMethodName, stream-like methods, and skipped infrastructure parameters.
+- Representative WebApi service, WebApi constants, and SignalR hub templates are covered by checked-in sample snapshots.
+- The external Angular/System.Text.Json service recipe has a renderer compatibility probe that executes when the sibling recipe repository is present.
+- External Angular/System.Text.Json and React/System.Text.Json service recipes have checked snapshots that execute when the sibling recipe repository is present.
+- External Angular/React System.Text.Json model recipes, Angular/React Newtonsoft.Json model recipes, and the Angular sample constants recipe have checked snapshots that execute when the sibling recipe repository is present.
+- Recent Angular model compatibility fixes cover nullable dictionaries, nullable lists, and enum default constructor values.
+- The Typewriter issue 55 `AllowedValuesAttribute` scenario is covered by Roslyn metadata and renderer helper tests.
+- Template parsing preserves TypeScript template literal interpolation while still compiling legacy C# helper blocks.
+- Template diagnostics are returned through the shared diagnostic model. C# compile diagnostics are line-mapped back to the original `.tst` file; CLI text output writes compiler-style diagnostics to stderr, while JSON output remains structured.
+- Nullable awareness is resolved from Roslyn nullable context at each declaration position, including project Nullable settings plus `#nullable enable`, `#nullable disable`, and `#nullable restore` regions.
+- Watch mode is implemented in the CLI; VS Code save-time validate/generate settings and Visual Studio generate-on-save are implemented.
+- Language server editor intelligence is implemented for common template members and loaded C# metadata, but the analysis catalog still depends on the currently implemented metadata and compatibility surface.
+- Compiled template helpers are loaded into collectible assembly load contexts and unloaded after render/output filename evaluation.
+```
+
+## Current Practical Scope
+
+The repository now has a working first vertical slice:
+
+```text
+Input:
+- one SDK-style .csproj, or a .sln/.slnx workspace plus one resolvable project
+- one or more C# source files
+- one .tst template
+
+Process:
+- CLI loads configuration
+- Engine resolves project inputs from --project, .csproj, .sln, or .slnx
+- Buildalyzer project loader evaluates MSBuild inputs
+- Roslyn extracts metadata
+- Engine renders the template
+- Engine compiles and invokes C# helpers from template code blocks when present
+- CLI writes deterministic generated TypeScript
+
+Output:
+- generated .ts file
+- shared diagnostics
+- compiler-style template diagnostics in text mode and structured diagnostics in JSON mode
+- JSON or text CLI result
+- repeated generation in watch mode
+- VS Code commands, syntax highlighting, and Problems diagnostics over the CLI JSON contract
+- Visual Studio VSIX adapter with commands, generate-on-save, Output window logging, and Error List diagnostics over the CLI JSON contract
+- Visual Studio native Ctrl+Space fallback completions for `.tst` files
+- Language server live diagnostics, completion, hover, definition, semantic highlighting, and basic embedded C#/TypeScript completion support for `.tst` files
+```

--- a/docs/packing_plan.md
+++ b/docs/packing_plan.md
@@ -1,0 +1,386 @@
+# Typewriter Packaging Plan
+
+Implemented and verified locally against the repository on July 2, 2026.
+
+Local commands and the CI workflow only create artifacts. The tag-triggered release workflow publishes the CLI and language-server packages to NuGet and attaches editor packages to a GitHub release. Marketplace publishing remains separate.
+
+## Package Matrix
+
+| Product | Installable artifact | Marketplace | Current state |
+|---|---|---|---|
+| Typewriter CLI | `.nupkg` | NuGet | Published by the tag release workflow |
+| Typewriter language server | `.nupkg` | NuGet | Published by the tag release workflow |
+| Visual Studio | `.vsix` | GitHub release; Visual Studio Marketplace planned | Visual Studio 2026 package with architecture-neutral CLI/LSP payload |
+| Visual Studio Code | `.vsix` | GitHub release; VS Code Marketplace planned | Bundled package configured |
+| JetBrains Rider | `.zip` | GitHub release; JetBrains Marketplace planned | Gradle wrapper and verification configured |
+
+All locally built artifacts are copied to `artifacts/packages/`.
+
+## Versioning
+
+Use one release version for every package. `setver.ps1` synchronizes it in:
+
+| File | Version source |
+|---|---|
+| `Directory.Build.props` | `Version`, `AssemblyVersion`, and `FileVersion` |
+| `src/Typewriter.VisualStudio/source.extension.vsixmanifest` | VSIX identity |
+| `vscode/package.json` | Extension package |
+| `rider/gradle.properties` | Plugin package |
+
+Before a future release, build all artifacts from the same commit and tag. Never
+publish different content under an already published version.
+
+`setver.ps1` receives the version once and updates all package version sources.
+
+## Visual Studio
+
+### Current package
+
+Build:
+
+```powershell
+dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj `
+  --configuration Release `
+  -m:1
+```
+
+Output:
+
+```text
+src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix
+```
+
+The existing CI already builds and uploads this artifact.
+
+### Supported Visual Studio version
+
+The current manifest uses version range `[18.0,19.0)`. This means the VSIX targets
+Visual Studio 2026/Dev18, not Visual Studio 2022/Dev17.
+
+Visual Studio 2026 is the intended and documented target.
+
+### ARM64 assessment
+
+The current manifest correctly declares both `amd64` and `arm64` installation
+targets. The built extension assembly was inspected and is IL-only AnyCPU:
+
+```text
+Typewriter.VisualStudio.dll: I386 PE, ILOnly
+```
+
+The CLI and language-server payloads are now published with `UseAppHost=false`.
+The VSIX contains their managed `.dll`, `.deps.json`, `.runtimeconfig.json`, and
+dependencies without x64 apphosts. The adapter launches them through the matching
+system `dotnet` host.
+
+### ARM64 implementation
+
+The implemented architecture-neutral VSIX:
+
+1. Publishes the CLI and language server with `UseAppHost=false`.
+2. Packages their managed payloads and runtime configuration.
+3. Does not include architecture-specific apphost executables.
+4. Launches them as:
+
+```text
+dotnet Typewriter.Cli.dll
+dotnet Typewriter.LanguageServer.dll
+```
+
+The package requires a matching .NET 10 runtime on AMD64 or ARM64. Final ARM64
+release qualification still requires an install-and-run smoke test on ARM64
+hardware or an ARM64 CI runner.
+
+### Visual Studio release checks
+
+Before release:
+
+```powershell
+dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj `
+  --configuration Release `
+  -m:1
+```
+
+Then test installation and these workflows on every declared architecture and
+Visual Studio major version:
+
+- Open a `.tst` file.
+- Confirm highlighting and completion.
+- Run Generate Current Template.
+- Run Generate All Templates.
+- Confirm language-server diagnostics.
+- Confirm generate-on-save.
+- Inspect the Typewriter Output pane and Error List.
+
+Do not advertise ARM64 support based only on the manifest. Execute this smoke test
+on an ARM64 machine or ARM64 CI runner.
+
+## Visual Studio Code
+
+### Package format
+
+VS Code extensions are packaged as VSIX files with the official `@vscode/vsce`
+tool:
+
+```powershell
+cd vscode
+npm ci
+npx @vscode/vsce package
+```
+
+Expected output:
+
+```text
+vscode/typewriter-vscode-<version>.vsix
+```
+
+Install locally:
+
+```powershell
+code --install-extension vscode/typewriter-vscode-<version>.vsix --force
+```
+
+### Bundling
+
+The extension is bundled before running `vsce`:
+
+1. `@vscode/vsce` and `esbuild` are development dependencies.
+2. `src/extension.js` is bundled to `dist/extension.js`.
+3. The `vscode` module remains external.
+4. `package.json` points `main` to `./dist/extension.js`.
+5. `node_modules/` and source files are excluded from the VSIX.
+
+Suggested scripts:
+
+```json
+{
+  "scripts": {
+    "check": "node --check src/extension.js",
+    "bundle": "esbuild src/extension.js --bundle --platform=node --external:vscode --outfile=dist/extension.js",
+    "vscode:prepublish": "npm run bundle",
+    "package": "vsce package"
+  }
+}
+```
+
+The package also contains repository metadata, a license, a 256px PNG icon, and a
+changelog.
+
+### Platform handling
+
+The current extension JavaScript has no native Node dependency and does not bundle
+the Typewriter CLI. Produce one universal VSIX; do not pass `--target`.
+
+If native binaries or native Node modules are bundled later, produce separate
+packages with targets such as:
+
+```powershell
+vsce package --target win32-x64
+vsce package --target win32-arm64
+vsce package --target linux-x64
+vsce package --target linux-arm64
+vsce package --target darwin-x64
+vsce package --target darwin-arm64
+```
+
+### VS Code release checks
+
+```powershell
+npm ci --prefix vscode
+npm --prefix vscode run check
+npm --prefix vscode run bundle
+npx --yes @vscode/vsce ls --tree
+npx --yes @vscode/vsce package --allow-missing-repository
+```
+
+Inspect the `vsce ls --tree` output and confirm that `dist/extension.js` is present.
+Install the resulting VSIX in a clean Extension Development Host or clean VS Code
+profile and test:
+
+- Extension activation after opening a `.tst` file.
+- Generate Current Template.
+- Generate All Templates.
+- Validate Current Template.
+- Restart Language Server.
+- Diagnostics, completion, hover, definition, and semantic highlighting.
+- Generate-on-save and validate-on-save.
+
+No `vsce publish` command is part of this workflow.
+
+## JetBrains Rider
+
+### Package format
+
+JetBrains plugins are distributed as ZIP archives. The IntelliJ Platform Gradle
+Plugin `buildPlugin` task creates the archive under:
+
+```text
+rider/build/distributions/
+```
+
+Build:
+
+```powershell
+gradle -p rider buildPlugin
+```
+
+Expected output:
+
+```text
+rider/build/distributions/Typewriter-<version>.zip
+```
+
+Install locally in Rider:
+
+1. Open Settings.
+2. Select Plugins.
+3. Open the gear menu.
+4. Select Install Plugin from Disk.
+5. Select the generated ZIP.
+6. Restart Rider.
+
+Do not extract or re-zip the generated distribution manually.
+
+### Gradle wrapper
+
+The repository contains:
+
+```text
+rider/gradlew
+rider/gradlew.bat
+rider/gradle/wrapper/gradle-wrapper.jar
+rider/gradle/wrapper/gradle-wrapper.properties
+```
+
+Use:
+
+```powershell
+.\rider\gradlew.bat -p rider buildPlugin
+```
+
+The wrapper uses Gradle `9.0.0` with IntelliJ Platform Gradle Plugin `2.16.0`.
+
+### Rider validation
+
+Run the available Gradle verification tasks before packaging:
+
+```powershell
+.\rider\gradlew.bat -p rider verifyPluginProjectConfiguration
+.\rider\gradlew.bat -p rider test
+.\rider\gradlew.bat -p rider verifyPlugin
+.\rider\gradlew.bat -p rider buildPlugin
+```
+
+Use `runIde` for an isolated local Rider instance:
+
+```powershell
+.\rider\gradlew.bat -p rider runIde
+```
+
+Test:
+
+- `.tst` file association and highlighting.
+- Tools | Typewriter actions.
+- Settings persistence.
+- Generate and validate commands.
+- Generate-on-save and validate-on-save.
+- CLI resolution from the source repository.
+- Fallback to a globally installed `typewriter` tool.
+
+The current plugin contains Kotlin/JVM code only and does not bundle native
+binaries. One Rider ZIP is sufficient across operating systems and CPU
+architectures supported by the targeted Rider build. The Typewriter CLI/.NET SDK
+must be installed separately when the source repository is not available.
+
+### Rider publishing
+
+No `publishPlugin` task is configured or run by this workflow. `buildPlugin` only
+creates the local ZIP distribution.
+
+## CI Packaging Workflow
+
+Extend `.github/workflows/ci.yml` with these stages.
+
+### Prerequisites
+
+- .NET SDK from `global.json`.
+- Node.js 22.
+- Java 21.
+- Committed Gradle wrapper.
+- An existing `artifacts/packages/` directory.
+
+### Validation
+
+```text
+dotnet restore
+dotnet build
+dotnet test
+npm ci --prefix vscode
+npm --prefix vscode run check
+npm --prefix vscode run bundle
+vsce ls --tree
+Gradle verifyPluginProjectConfiguration
+Gradle test
+Gradle verifyPlugin
+```
+
+### Packaging
+
+```text
+dotnet pack CLI
+dotnet pack language server
+dotnet build Visual Studio VSIX
+vsce package VS Code extension
+Gradle buildPlugin Rider extension
+```
+
+### Artifact names
+
+Normalize release artifact names:
+
+```text
+AdaskoTheBeAsT.Typewriter.Cli.<version>.nupkg
+AdaskoTheBeAsT.Typewriter.LanguageServer.<version>.nupkg
+Typewriter.VisualStudio-<version>.vsix
+typewriter-vscode-<version>.vsix
+Typewriter-Rider-<version>.zip
+```
+
+If Visual Studio uses self-contained architecture-specific payloads:
+
+```text
+Typewriter.VisualStudio-<version>-win-x64.vsix
+Typewriter.VisualStudio-<version>-win-arm64.vsix
+```
+
+## Local Packaging Gate
+
+Current status:
+
+- Package versions match the release tag.
+- The Visual Studio manifest and README target Visual Studio 2026.
+- The VSIX contains architecture-neutral managed CLI and language-server payloads.
+- The VS Code VSIX contains bundled `vscode-languageclient` code.
+- The VS Code package contains license, icon, changelog, and repository metadata.
+- The Rider Gradle wrapper is committed.
+- Rider verification passes against Rider 2026.1.2.
+- CI builds and retains all package files from the same commit without publishing.
+- The tag release workflow publishes NuGet packages and GitHub release assets.
+
+Still required before claiming tested ARM64 support:
+
+- Install and exercise the Visual Studio VSIX on an ARM64 Windows machine.
+- Test each installable artifact from the packaged file in a clean IDE profile.
+
+## References
+
+- VS Code extension publishing and packaging:
+  https://code.visualstudio.com/api/working-with-extensions/publishing-extension
+- IntelliJ Platform Gradle Plugin tasks:
+  https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-tasks.html
+- JetBrains plugin signing:
+  https://plugins.jetbrains.com/docs/intellij/plugin-signing.html
+- JetBrains Marketplace upload API:
+  https://plugins.jetbrains.com/docs/marketplace/plugin-upload.html
+- Visual Studio ARM64 extension guidance:
+  https://devblogs.microsoft.com/visualstudio/now-introducing-arm64-support-for-vs-extensions/

--- a/docs/perf-opt.md
+++ b/docs/perf-opt.md
@@ -1,0 +1,146 @@
+# Generation Performance Optimization Plan
+
+## Goal
+
+Improve Typewriter generation throughput, especially repeated watch and IDE generation runs, without changing generated output or public behavior.
+
+## Measurement First
+
+Before implementation, add lightweight timing around these pipeline stages:
+
+1. Workspace and project resolution
+2. Template discovery and parsing
+3. MSBuild project loading
+4. Roslyn parse, compile, generator execution, and metadata extraction
+5. Template runtime compilation and helper invocation
+6. Rendering
+7. Planning, formatting, and writing outputs
+
+Use the timings to validate each optimization independently and avoid optimizing unmeasured cold paths.
+
+## Current Baseline
+
+The following optimizations are already present:
+
+- Performance stage diagnostics behind `TYPEWRITER_TRACE_PERF`.
+- Project metadata and compilation caching with bounded entries.
+- Linear rendered-whitespace normalization.
+- Per-source mode inspection without a discarded full-project render.
+- Existing generated-file content reuse between planning and writing.
+- Precompiled template glob matchers and pruning of common ignored directories.
+- Parse/declaration diagnostics during normal generation and full diagnostics during validation.
+- A combined type/delegate syntax-tree walk that avoids method and accessor bodies.
+- Pooled type-reference recursion guards.
+- A shared `ProjectMetadataIndex` reused across templates and source-file render contexts.
+- Compiled-helper method and parameter metadata indexing.
+- Parsed documentation comment caching.
+- TypeScript type mapping memoization.
+- Default-setting fast paths in output formatting.
+- Local `#load` caching and a shared remote-load `HttpClient`.
+- Watcher extension checks before path-segment inspection.
+- Bounded parsed-template caching keyed by template file stamp with exact source verification.
+- CLI watch reuse of generator, metadata, renderer, discovery, and writer services across cycles.
+- Persistent IDE generation through the language-server `typewriter/generate` request, with CLI fallback for unavailable or older servers.
+- Project-input manifests with source/shape file stamps and watcher-driven dirty-path validation.
+- Reused syntax trees keyed by file stamp and parse options, with indexed parallel parsing for changed trees.
+- Type-reference graph caching for repeated Roslyn symbol conversions.
+- Metadata cache counter summaries behind `TYPEWRITER_TRACE_PERF`.
+
+## Remaining Original Opportunities
+
+| Priority | Area | Current behavior | Recommended change | Impact | Risk |
+| --- | --- | --- | --- | --- | --- |
+| P1 | `TemplateDocument.Parse` | Scans template content several times for code blocks, output directives, directive stripping, and compatibility block stripping. | Parse in a single pass that gathers directives, code blocks, cleaned content, and line mapping. | Medium | Medium |
+| P1 | `TemplateRuntimeCompiler.CompileFactory` | Reuses compiled bytes but loads them into a fresh `AssemblyLoadContext` per template/project. | Cache loaded host type plus load context while safe, or pool factories by compiled cache key and release when cache entry is evicted. | Medium | Medium |
+| P2 | `TemplateRenderer.MatchesRecipeTypePredicate` | Repeatedly scans the same helper body with `Contains` and literal extraction for every type. | Precompute a recipe predicate descriptor once per compatibility method. | Low-medium | Low |
+
+## Additional Opportunities Found
+
+| Priority | Area | Current behavior | Recommended change | Impact | Risk |
+| --- | --- | --- | --- | --- | --- |
+| P0 | `FileSystemTemplateDiscovery.FindTemplatesAsync` | Common ignored directories are pruned and glob matchers are compiled, but every remaining file is still enumerated and configured excludes are applied after traversal. | Derive traversal roots and filename filters from simple include patterns. Prune configured directory excludes before descending. | High in large repos | Low-medium |
+| P1 | `CSharpProjectMetadataProvider.TryCreateType` | Repeatedly enumerates `symbol.GetMembers()` for properties, methods, constants, fields, static readonly fields, events, and delegates. Recreates nested metadata once per nested kind. | Materialize members and nested type members once per symbol, partition by kind, then build nested metadata once and group by `TypeMetadataKind`. | Medium-high | Medium |
+| P1 | `TemplateRenderer.RenderCore`, `AppendCollection`, and block readers | Reparses template text and extracts block substrings while rendering every collection item. Nested collection rendering repeats the same parsing work many times. | Parse `TemplateDocument` into a reusable render plan or AST containing text, identifier, block, filter, separator, and conditional nodes. Render nodes directly. | High for large templates | Medium-high |
+| P1 | `CompiledTemplateHelper` | Method names and parameters are indexed, but every invocation still allocates context/argument arrays and uses `MethodInfo.Invoke`. | Index by name, arity, and compatible parameter shape. Cache delegates for common one- and two-argument helper signatures. | Medium | Medium |
+| P1 | `TemplateCodeModelAdapterFactory` | `CreateFile` is cached, but repeated type/member adaptation and parent lookup still recreate legacy `CodeModel` graphs. | Cache adapted objects per metadata node and settings, and lazily create child collections. | High for helper-heavy templates | Medium |
+| P1 | `CSharpProjectMetadataProvider.GetDocComment` | Parsed comments are cached, but documentation is still requested eagerly for every supported symbol. | Make documentation extraction feature-driven or lazy when templates do not reference documentation. | Medium-high | Medium |
+| P2 | `OutputContentFormatter.Format` | Default settings have a fast path, but non-default formatting still uses several full-string passes and split/join allocations. | Combine newline normalization, indentation, trailing-whitespace trimming, and final-newline handling in one writer pass. | Medium for large outputs | Low-medium |
+| P2 | `WorkspaceProjectResolver.ResolveProjectPaths` | Common directories are pruned and explicit solution paths are parsed, but directory workspaces still recursively scan projects and results are not cached. | Prefer a single top-level solution when available and cache project discovery by workspace directory stamp or watcher invalidation. | Medium | Low |
+| P2 | `MsBuildProjectLoader.LoadCore` | Creates a new Buildalyzer `AnalyzerManager` and evaluates MSBuild metadata per load. This cost repeats across watch runs. | Reuse manager and project load results through the same metadata cache. Invalidate on project, props, targets, lock file, or environment changes. | High in watch mode | Medium-high |
+
+## Further Opportunities
+
+| Priority | Area | Current behavior | Recommended change | Impact | Risk | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| P0 | IDE generation process lifetime | VS Code reuses its active language-server connection. Visual Studio prefers its editor LSP connection and lazily starts a package-scoped server when no `.tst` editor has activated LSP. Rider owns a project-scoped language-server process. All adapters fall back to the CLI when persistent generation is unavailable. | Keep the `typewriter/generate` request compatible and route future IDE generation entry points through it. | Very high for IDE saves | High | Implemented |
+| P0 | CLI watch session state | Watch mode now reuses generator services, but each event still performs full configuration, project discovery, metadata validation, template discovery, and generation work. | Introduce a generation session that receives changed paths and invalidates only affected configuration, projects, templates, and outputs. | High | Medium | Partial |
+| P0 | Metadata cache validation | Cache hits use a per-input stamp manifest, and watcher-capable hosts feed dirty paths into metadata validation. Unknown-provenance requests fall back to precise manifest validation. | Continue broadening changed-path invalidation to template and discovery caches. | High in repeated runs | High | Implemented |
+| P1 | Source text and syntax-tree reuse | Source syntax trees are cached by path, parse options, and file stamp. Metadata rebuilds reuse unchanged trees and parse changed trees in parallel while preserving source order. | Consider caching `SourceText` separately only if measurements show value. | High | High | Implemented |
+| P1 | Declaration discovery | Symbol discovery previously traversed all syntax descendants, including method and accessor bodies. | Restrict traversal to namespace and type declaration containers. | Medium | Low | Implemented |
+| P1 | Type-reference graph creation | Roslyn symbol-to-`TypeMetadataReference` conversion uses a cache keyed by symbol identity and nullable annotation, with recursion guards for cycles. | Measure whether additional per-member caching is needed. | Medium-high | Medium | Implemented |
+| P1 | Feature-driven metadata extraction | Metadata construction eagerly builds methods, fields, events, attributes, documentation, initializers, nested types, and legacy compatibility data regardless of template usage. | Analyze parsed templates for required metadata features and build only those categories. Treat arbitrary compiled helper code as requiring the full model. | High for simple templates | High | Pending |
+| P1 | Project metadata index reuse | Full-project indexes were rebuilt for template inspection and each template render; source-scoped indexes were rebuilt across templates. | Build one project index and reusable source render contexts per generation project. | Medium | Low | Implemented |
+| P1 | Parsed template reuse | Template parsing repeated on every generation even when the template was unchanged. | Cache parsed documents and parse diagnostics by full path, length, and modification timestamp, verify exact source content on hits, and use bounded eviction. | Medium | Low | Implemented |
+
+## Recommended Implementation Phases
+
+### Phase 0: Baseline and Guardrails
+
+1. Extend timing diagnostics with cache hit/miss and invalidation-reason counters.
+2. Add representative performance fixtures:
+   - cold generation
+   - repeated generation with no changes
+   - watch-trigger generation after one source change
+   - large output rendering
+3. Capture generated-output snapshots before optimizations.
+
+### Phase 1: Quick, Low-risk Wins
+
+1. Precompute recipe predicate metadata for compatibility methods.
+2. Finish the single-pass `OutputContentFormatter`.
+3. Derive direct traversal roots and filename filters from simple template patterns.
+4. Partition Roslyn members once per type.
+
+### Phase 2: Discovery and Rendering Throughput
+
+1. Derive direct traversal roots and filename filters from simple include patterns.
+2. Prune configured directory excludes before traversal.
+3. Cache project discovery results and avoid broad recursive scans when a solution is available.
+4. Replace repeated template text parsing during rendering with a parsed render plan.
+
+### Phase 3: Roslyn Metadata Pipeline
+
+1. Replace broad metadata fingerprinting with precise invalidation.
+2. Cache source text and syntax trees by file stamp and parse options.
+3. Partition `GetMembers()` and nested type members once per symbol.
+4. Cache type-reference graphs per compilation.
+5. Make XML documentation extraction feature-driven.
+6. Add feature-driven metadata construction for non-helper templates.
+
+### Phase 4: Compiled Template and Legacy CodeModel Runtime
+
+1. Cache `CompiledTemplateHelper` delegates by name, arity, and parameter shape.
+2. Cache adapted legacy `CodeModel` objects per render state.
+3. Reuse loaded compiled template assemblies where safe.
+
+### Phase 5: Persistent IDE and Watch Sessions
+
+1. Introduce a formal generation session with changed-path invalidation for CLI watch.
+2. Define a generation request endpoint in the language server or a dedicated daemon. Implemented as `typewriter/generate`.
+3. Route IDE save generation through the persistent process. Implemented for Visual Studio, VS Code, and Rider with CLI fallback.
+4. Feed watcher dirty paths into project, template, and discovery cache invalidation.
+
+Measured on `samples/SimpleApi` with the Release pipeline:
+
+- First language-server generation: 2,313 ms total, including 2,293 ms metadata load.
+- Second generation in the same server process: 7 ms total, including 6.7 ms metadata validation.
+
+## Validation Strategy
+
+For every phase:
+
+1. Run unit tests and snapshot tests.
+2. Compare generated outputs before and after.
+3. Record timing before and after on the same fixtures.
+4. Keep changes behind internal abstractions where behavior risk is medium or high.
+5. Prefer one optimization per pull request unless changes are tightly coupled.

--- a/docs/perf_improvement.md
+++ b/docs/perf_improvement.md
@@ -1,0 +1,367 @@
+# Performance Improvement Plan: Incremental Generation
+
+Target: GitHub issue [#99](https://github.com/AdaskoTheBeAsT/Typewriter/issues/99)
+"Visual Studio Extension - Generate on save performance issues" and plan2026-07-02.md
+Point 3 (metadata cache validation and syntax-tree reuse).
+
+Date: 2026-07-06. All statements verified against code on branch
+`bugfix/98-include-project` (master-based).
+
+---
+
+## 1. Problem Statement
+
+With ~900 generated classes, saving a single `.cs` file in Visual Studio makes the
+IDE unresponsive, because generate-on-save triggers a full generation of every
+template against every source file instead of only the output affected by the
+changed file.
+
+Expected incremental behavior:
+
+| Change | Expected regeneration scope |
+| --- | --- |
+| `.tst` template saved | All outputs of that template (template change invalidates every output it produces) |
+| One `.cs` saved | Only the `.ts` output(s) produced from that source file, plus outputs of files that reference its types |
+| `.csproj` / props / targets / lock / config saved | Full regeneration (project shape changed) |
+| `.cs` deleted or renamed | Orphaned output removed; new output created for the renamed file |
+
+---
+
+## 2. Current Behavior (verified in code)
+
+### 2.1 The `.tst` path is already scoped correctly
+
+`src/Typewriter.VisualStudio/TypewriterSaveListener.cs` classifies a saved `.tst`
+as `SaveGenerationScope.CurrentTemplate` and calls
+`TypewriterCommandService.GenerateSavedTemplateAsync`, which generates only that
+template. This matches the expected behavior and needs no change.
+
+### 2.2 The `.cs` path regenerates everything
+
+- `TypewriterSaveListener` classifies any non-template input extension as
+  `SaveGenerationScope.AllTemplates` and calls
+  `TypewriterCommandService.GenerateSavedInputAsync(inputPath)`.
+- `GenerateSavedInputAsync` forwards to `GenerateAllTemplatesAsync(inputPathOverride)`
+  where `inputPathOverride` is only used by `CreateGenerationContextAsync` to
+  resolve the project context. The saved path is then discarded; the request that
+  reaches the engine carries no information about what changed.
+- In `src/Typewriter.Engine/TypewriterGenerator.cs`, `GenerateProjectAsync`
+  builds `CreateSourceFileRenderContexts` for every source file with types and
+  renders each context per template. With 900 classes and 3 templates that is
+  2,700 renders per save.
+
+### 2.3 No changed-path information exists anywhere in the pipeline
+
+- `src/Typewriter.Abstractions/GenerationRequest.cs` has no dirty-paths field.
+- `src/Typewriter.Cli/FileSystemGenerationWatcher.cs` only signals "something
+  changed" through a bare `TaskCompletionSource`; the paths from
+  `FileSystemEventArgs` are checked against watched extensions and then discarded.
+- `src/Typewriter.LanguageServer/WorkspaceGenerationRequest.cs`
+  (`typewriter/generate`) has `Command`, `WorkspacePath`, `ProjectPath`,
+  `TemplatePath`, `Framework`, `AllProjects`, `TemplateSearchPath` and nothing else.
+
+### 2.4 Metadata cache validation is a stat storm
+
+`src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs`:
+
+- `MetadataCache` (`ConcurrentDictionary<ProjectMetadataCacheKey, ProjectMetadataCacheEntry>`,
+  line ~22) stores results, but every cache hit calls
+  `ProjectMetadataFingerprint.IsCurrent()` (line ~1845), which recomputes a
+  SHA256 hash over all tracked file paths plus a full recursive directory
+  enumeration (`EnumerateDirectoriesForFingerprint`). Large repositories pay a
+  large stat/hash cost just to prove nothing changed.
+- On any miss, all sources are re-read and re-parsed serially via
+  `CSharpSyntaxTree.ParseText` in a loop (line ~188-226). There is no
+  `SourceText` or `SyntaxTree` reuse.
+- Measured on `samples/SimpleApi` (see perf-opt.md): first generation 2,313 ms
+  total, of which 2,293 ms is metadata load.
+
+### 2.5 What already works and must be preserved
+
+- `FileSystemGeneratedFileWriter` skips disk writes when content is unchanged
+  (`WriteOnlyWhenChanged`), so disk churn is already fine; the remaining cost is
+  CPU spent rendering.
+- Bounded parsed-template cache in `TypewriterGenerator` keyed by
+  `(path, length, lastWriteTicks)` with exact source verification.
+- Persistent IDE generation via the language-server `typewriter/generate`
+  request with CLI fallback (perf-opt.md Phase 5, implemented).
+- `ProjectMetadataIndex` shared across templates and source render contexts.
+- `TrimMetadataCache` bounds (32 entries) and `TrimTemplateDocumentCache`
+  bounds (256 entries).
+
+### 2.6 Gap between plan2026-07-02.md Point 3 and issue #99
+
+Point 3 fixes the metadata cost (2.1 above becomes milliseconds) and re-parse
+cost, but its acceptance criteria stop at "one-file change re-parses exactly one
+file". Rendering is still full-project. Closing issue #99 requires a fourth
+work stream: changed-path scoped rendering (section 3.4 below).
+
+---
+
+## 3. Design
+
+Four work streams, in dependency order.
+
+### 3.1 Changed-path plumbing (prerequisite for everything)
+
+New contract:
+
+```csharp
+// Typewriter.Abstractions/GenerationRequest.cs
+public sealed record GenerationRequest(
+    string? WorkspacePath,
+    string? ProjectPath,
+    string? TemplatePath,
+    GenerationMode Mode,
+    TypewriterConfiguration Configuration,
+    bool AllProjects = false,
+    string? TemplateSearchPath = null)
+{
+    public bool IncludeDiff { get; init; }
+
+    // null = unknown provenance, full generation (today's behavior).
+    // non-null = only these inputs changed since the last successful run.
+    public IReadOnlyCollection<ChangedInput>? ChangedInputs { get; init; }
+}
+
+public sealed record ChangedInput(string FullPath, ChangedInputKind Kind);
+
+public enum ChangedInputKind
+{
+    Modified,
+    Added,
+    Deleted,
+    Renamed,
+}
+```
+
+Producers:
+
+1. **CLI watch** (`src/Typewriter.Cli/FileSystemGenerationWatcher.cs`):
+   replace the bare signal with an accumulating
+   `ConcurrentDictionary<string, ChangedInputKind>` populated from
+   `OnFileChanged` / `OnFileRenamed` (rename contributes a `Deleted` for
+   `OldFullPath` and an `Added` for `FullPath`). `TypewriterCli.RunWatchedGenerationAsync`
+   drains the set after the quiet period and passes it into the request.
+   On `OnWatcherError` (buffer overflow), clear the set and pass `null`
+   (full run) because events were lost.
+2. **Visual Studio** (`TypewriterSaveListener` / `TypewriterCommandService`):
+   the listener already knows the saved path. Extend `SaveGenerationRequest`
+   to carry a path set instead of a single path; `Merge` unions paths instead
+   of collapsing to a scope. `GenerateSavedInputAsync` passes the set through
+   the persistent client and the CLI fallback (`--changed <path>` repeated
+   argument on the `generate` command).
+3. **Language server** (`WorkspaceGenerationRequest` in
+   `src/Typewriter.LanguageServer`): add
+   `IReadOnlyList<ChangedInputPayload>? ChangedInputs` (path + kind) to the
+   `typewriter/generate` payload. Missing field = null = full generation, so
+   older clients remain compatible.
+4. **Rider plugin**: same payload addition; out of scope for the first PR but
+   the protocol field is host-neutral from day one.
+
+Safety valve: any consumer that cannot map a changed path to a known input
+category treats the run as full generation. Incremental is an optimization
+layered on a correct full path, never a replacement.
+
+### 3.2 Metadata: precise stamps instead of a broad fingerprint (plan Point 3, step 1)
+
+Replace `ProjectMetadataFingerprint` (paths + directories + single SHA256) with
+a manifest:
+
+```csharp
+private sealed record FileStamp(long Length, long LastWriteTicks);
+
+private sealed record ProjectInputManifest(
+    IReadOnlyDictionary<string, FileStamp> Files,      // sources, csproj, props/targets, assets/lock, additional inputs
+    IReadOnlyDictionary<string, DirectoryStamp> Dirs); // only where globs require existence/child-set checks
+```
+
+Validation rules:
+
+- Compare stamps per file, short-circuit on the first difference.
+- Record the invalidation reason (which file, which category) for the
+  `TYPEWRITER_TRACE_PERF` counters requested by perf-opt.md Phase 0.
+- Directory stamps only track the child-name set for directories where source
+  globs can pick up added files; no recursive enumeration of the whole tree.
+
+New counters behind `TYPEWRITER_TRACE_PERF`: cache hits, misses,
+stat-validated hits, dirty-path-validated hits, invalidation reasons.
+
+### 3.3 Metadata: watcher-driven dirty paths and syntax-tree reuse (plan Point 3, steps 2-3)
+
+1. `IMetadataCacheInvalidation` in `Typewriter.Abstractions` (or
+   `Typewriter.Roslyn`): `void MarkDirty(string fullPath)`. CLI watch and the
+   language-server `WorkspaceGenerationService` feed changed paths in. A cache
+   entry with zero dirty paths since its last validation is accepted with no
+   filesystem access at all; entries with dirty paths validate only those paths
+   against the manifest. One-shot CLI invocations fall back to the full
+   manifest stamp check (still cheap: one stat per file, no hashing, no
+   directory recursion).
+2. Bounded `SyntaxTree` cache keyed by
+   `(fullPath, parseOptionsChecksum, length, lastWriteTicks)`.
+   On metadata rebuild: reuse trees for unchanged files, parse only changed
+   files (in parallel via `Parallel.ForEachAsync`, preserving the current
+   deterministic ordering of `syntaxTrees` by source path).
+3. When a cached `CSharpCompilation` exists for the project, update it with
+   `compilation.ReplaceSyntaxTree(oldTree, newTree)` per changed file (and
+   `AddSyntaxTrees` / `RemoveSyntaxTrees` for added/deleted files) instead of
+   `CSharpCompilation.Create` from scratch.
+4. Re-extract `SourceFileMetadata` only for changed files; reuse the metadata
+   objects of untouched files. Caveat: type metadata is symbol-derived, and a
+   symbol graph can span files. Reused `SourceFileMetadata` is safe because it
+   is a detached snapshot (records, no live Roslyn symbols); the cross-file
+   correctness question is handled at render scoping time (3.4), not here.
+5. Type-reference graph cache (perf-opt P1): per-compilation
+   `Dictionary<(ITypeSymbol, NullableAnnotation), TypeMetadataReference>` with
+   an in-progress sentinel for cycles; the pooled
+   `TypeReferenceVisitedSymbolSets` guard stays as backstop.
+
+### 3.4 Scoped rendering in `TypewriterGenerator` (new, closes issue #99)
+
+#### 3.4.1 Scope decision
+
+In `GenerateProjectAsync`, before the per-template loop, classify
+`request.ChangedInputs`:
+
+| Condition | Decision |
+| --- | --- |
+| `ChangedInputs == null` | Full generation (today's behavior) |
+| Any changed path is `.tst`, `.csproj`, `.sln`/`.slnx`, props/targets, config json | Full generation |
+| Any `Added`/`Deleted`/`Renamed` source file | Scoped generation + orphan handling (3.4.3) |
+| Only `Modified` `.cs` files that belong to the project's source set | Scoped generation |
+| Changed path not attributable to any known input | Full generation (safety valve) |
+
+Per template, inside scoped generation:
+
+| Template shape | Behavior |
+| --- | --- |
+| Per-source-file mode (`ShouldRenderPerSourceFile == true`) | Render only contexts in the affected-file closure (3.4.2) |
+| Fixed `OutputPath` or `SingleFileMode` | Always render (single render over the project; writer skips unchanged output) |
+| Uses `IncludeProject` | Always render fully; changed paths in included projects also invalidate via `MarkDirty` |
+
+#### 3.4.2 Cross-file dependency closure (correctness)
+
+"One `.cs` -> one `.ts`" alone is an approximation: the output for file A can
+change when file B changes. Concrete cases: import lines computed from
+referenced types, base classes, property/parameter/return types,
+`ProducesResponseType` attribute types. Renaming a class in B must regenerate
+A's imports.
+
+Chosen approach: **reverse dependency index**, built during metadata
+extraction where the full `TypeMetadataReference` graph is already walked, so
+the marginal cost is near zero.
+
+- Forward edges: for each source file F, the set of source files that define
+  types referenced by F's types (base types, interfaces, property types,
+  method parameter/return types, attribute argument types, type arguments,
+  nested references transitively through the reference graph as already
+  materialized).
+- Store the **reverse** index (`file -> files that reference its types`) in
+  `ProjectMetadataIndex`.
+- Affected set for a change = changed files + reverse closure (transitive,
+  because A -> B -> C renames propagate through re-exported types). In
+  practice the closure is a handful of files, not 900.
+- The index is rebuilt only for changed files during incremental metadata
+  update; reverse edges from unchanged files into a changed file are looked up
+  from the persisted index.
+
+Fallback mode (config switch, also the interim behavior until the index PR
+lands): render the changed files immediately, then schedule a debounced
+full-project sweep in the background. The writer skips unchanged content so
+the sweep is write-cheap, but it still costs full render CPU; this is a
+stopgap, not the end state.
+
+#### 3.4.3 Deletes and renames
+
+- `Deleted` source file: locate its previously planned output via
+  `GeneratedFilePlanner` conventions (same naming logic as
+  `ApplyLegacySourceOutputPath` + `FileNameConventionFormatter`) and delete the
+  output file if it exists and carries the Typewriter generated-file header
+  (`GeneratedFileHeader`), never otherwise. Also render the reverse closure of
+  the deleted file (imports pointing at it become compile errors in consuming
+  outputs; surfacing them fast matters).
+- `Renamed` = `Deleted` old + `Added` new.
+- `Added`: render the new file's context; the reverse closure of an added file
+  is empty by definition.
+
+#### 3.4.4 Configuration
+
+`TypewriterConfiguration`: `generation.incremental: "auto" | "off"`
+(default `auto`). `off` forces full generation for troubleshooting and as an
+escape hatch during rollout. Scope decisions are logged under
+`TYPEWRITER_TRACE_PERF` ("scoped: 3 of 912 contexts, closure [+2]", "full:
+changed path X not attributable").
+
+### 3.5 Secondary win: compiled factory reuse (perf-opt P1, optional)
+
+`CreateCompiledTemplateFactory` currently loads compiled bytes into a fresh
+`AssemblyLoadContext` per template per run and disposes it at the end of
+`GenerateProjectAsync`. For per-save generation through the persistent language
+server this is a fixed per-save cost. Pool factories by compiled-cache key and
+release on cache eviction. Independent of the streams above; schedule last.
+
+---
+
+## 4. PR Breakdown
+
+| # | Content | Depends on | Size |
+| --- | --- | --- | --- |
+| PR1 | Stamp manifest replaces fingerprint hash; invalidation-reason counters behind `TYPEWRITER_TRACE_PERF`; perf fixtures (cold, no-change repeat, one-change) | - | M |
+| PR2 | `ChangedInputs` on `GenerationRequest`; watcher path accumulation in CLI watch; `--changed` CLI argument; `typewriter/generate` payload field; VS save listener passes paths; `IMetadataCacheInvalidation` + `MarkDirty` feed | PR1 | M |
+| PR3 | `SyntaxTree` cache, `ReplaceSyntaxTree` incremental compilation update, per-file metadata re-extraction, parallel parse of changed files; type-reference graph cache | PR1, PR2 | L |
+| PR4 | Scoped rendering: scope decision table, per-source context filtering, delete/rename orphan handling, `generation.incremental` setting, debounced full-sweep fallback | PR2 | L |
+| PR5 | Reverse dependency index in `ProjectMetadataIndex`; closure-based affected set replaces fallback sweep as default | PR3, PR4 | M |
+| PR6 (optional) | Compiled template factory pooling across runs | - | S |
+
+Each PR: full `dotnet build` / `dotnet test` (currently 265 tests), snapshot
+byte-parity, `npm --prefix vscode run lint && bundle` where the extension is
+touched, Rider `verifyPlugin` where touched (per implemented.md).
+
+---
+
+## 5. Acceptance Criteria
+
+1. Repeated watch/LSP generation with no changes performs zero source
+   re-parsing, zero renders, and no full-tree stat storm (PR1-3).
+2. A one-file `.cs` change re-parses exactly one file (regression test with an
+   injectable parse hook or counter, PR3).
+3. A one-file `.cs` change renders only the affected closure: with 900 classes
+   and no cross-file references, exactly 1 render context per per-source
+   template (regression test on a two-file project asserting 1 of 2 contexts
+   rendered, PR4).
+4. Renaming a type referenced from another file regenerates both outputs
+   (closure test, PR5).
+5. Deleting a `.cs` removes its generated output only when the output carries
+   the Typewriter header (PR4).
+6. `.tst` save regenerates all outputs of that template (existing behavior,
+   guarded by a test).
+7. All existing tests and snapshots pass byte-identical before/after every PR.
+8. Measured on `samples/SimpleApi` equivalent scaled fixture: save-to-generated
+   latency drops from seconds (full render) to tens of milliseconds
+   (stamp check + 1 parse + `ReplaceSyntaxTree` + closure renders).
+
+---
+
+## 6. Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Missed cross-file dependency produces a stale output | Reverse index derived from the same reference graph used for rendering; closure tests; `generation.incremental: off` escape hatch; fallback sweep mode |
+| `FileSystemWatcher` event loss (buffer overflow) | `OnWatcherError` clears accumulated paths and forces a full run |
+| Stale metadata after incremental compilation update | Reused `SourceFileMetadata` is a detached snapshot; changed files always fully re-extracted; snapshot byte-parity gates every PR |
+| Deleting a user file mistaken for generated output | Delete only files carrying the `GeneratedFileHeader` marker |
+| Protocol drift between IDE clients and language server | `ChangedInputs` is optional in `typewriter/generate`; missing field means full generation, so old client + new server and new client + old server both degrade to today's behavior |
+| Duplicate-output detection (`ReportDuplicateOutputPath`) weakened by partial runs | Persist the planned-output map per template across incremental runs in the session state |
+
+---
+
+## 7. Relationship to Existing Plans
+
+- plan2026-07-02.md Point 3 maps to PR1-3 plus the type-reference cache; this
+  document supersedes its "3 PRs" estimate with the extended scope.
+- perf-opt.md "CLI watch session state" (Partial) and "Metadata cache
+  validation" / "Source text and syntax-tree reuse" (Pending) are covered by
+  PR2/PR3; "Feed watcher dirty paths into ... cache invalidation" (Phase 5,
+  item 4) is PR2.
+- The suggested overall sequence in plan2026-07-02.md (Point 5 -> Point 4 ->
+  Point 3 -> Point 2) is unaffected; within Point 3, use the PR ordering above.

--- a/docs/plan2026-07-02.md
+++ b/docs/plan2026-07-02.md
@@ -1,0 +1,346 @@
+# Typewriter Development Plan 2026-07-02
+
+Scope: the four verified gaps from the 2026-07-02 code audit (points 2-5), plus a
+gap analysis against the legacy codebase preserved on branch `feature/master-origin`.
+
+All statements below were verified against code on `master` as of 2026-07-02, not
+only against the markdown roadmap files.
+
+---
+
+## Point 2: Embedded C#/TypeScript Language-Service Forwarding
+
+### Current state (verified)
+
+- `src/Typewriter.LanguageServer` already has an embedded-region model:
+  `TemplateEmbeddedLanguage.cs`, `EmbeddedLanguageKind.cs`, `EmbeddedLanguageRegion.cs`,
+  `EmbeddedSpanMapping.cs`, `EmbeddedCSharpDocument.cs`, and
+  `EmbeddedCSharpLanguageService.cs` (own Roslyn-based completions for helper blocks).
+- Semantic tokens for Typewriter/C#/TypeScript regions exist
+  (`TemplateSemanticTokenService.cs`).
+- `vscode/src/extension.js` has no `TextDocumentContentProvider`, no virtual
+  documents, and no forwarding to the C# extension or the built-in TypeScript
+  service.
+
+### Goal
+
+Full IntelliSense (completion, hover, signature help, diagnostics, definitions,
+semantic tokens) inside `${ ... }` C# helper blocks and TypeScript output regions,
+by forwarding to real language services through virtual documents, never by
+reimplementing C# or TypeScript analysis.
+
+### Implementation steps
+
+1. Harden the region model (language server).
+   - Extend `TemplateEmbeddedLanguage` to emit stable virtual-document snapshots
+     per open `.tst` file: one C# virtual document (helper blocks stitched into
+     the existing `EmbeddedCSharpDocument` shadow class) and one TypeScript
+     virtual document (template output text with Typewriter `$...` expressions
+     replaced by placeholder identifiers of identical length to keep columns stable).
+   - Reuse `EmbeddedSpanMapping` for bidirectional position translation; add
+     round-trip unit tests in `Typewriter.LanguageServer.Tests` for multi-block
+     templates, CRLF content, and `${env.x}` TypeScript template-literal
+     interpolation (must stay TypeScript, not C#).
+
+2. Add custom LSP requests to expose virtual content.
+   - New requests in `LanguageServerHost`: `typewriter/embeddedDocument`
+     (returns virtual content + version for a `.tst` URI and kind) and
+     `typewriter/mapPosition` (tst position -> virtual position and back).
+   - Push `typewriter/embeddedDocumentChanged` notifications on didChange so the
+     client can refresh virtual docs incrementally.
+
+3. VS Code virtual-document providers (client side).
+   - Register `workspace.registerTextDocumentContentProvider` for two schemes,
+     e.g. `typewriter-cs:` and `typewriter-ts:`, backed by the new LSP request.
+   - Give virtual docs proper extensions (`...tst.g.cs`, `...tst.g.ts`) so the
+     C# extension and built-in TypeScript features pick them up automatically.
+
+4. Forward requests via `vscode.commands.executeCommand`.
+   - In middleware for the `.tst` language client (or plain provider
+     registrations), translate the position with `typewriter/mapPosition`, then call:
+     `vscode.executeCompletionItemProvider`, `vscode.executeHoverProvider`,
+     `vscode.executeSignatureHelpProvider`, `vscode.executeDefinitionProvider`
+     against the virtual URI, and map ranges in results back to the `.tst` document.
+   - Merge results: Typewriter template completions stay authoritative for
+     `$...` expressions; embedded results are used only when the cursor maps
+     into a C# helper block or TypeScript output region
+     (`EmbeddedLanguageKind` decides).
+
+5. Diagnostics mapping.
+   - Subscribe to `vscode.languages.onDidChangeDiagnostics` for the virtual URIs,
+     translate ranges back, and publish merged diagnostics under the `.tst` URI
+     (drop diagnostics that map into synthesized glue code).
+
+6. Fallback behavior.
+   - If no C# extension or TS provider responds, keep the current
+     `EmbeddedCSharpLanguageService` results (already working today). Guard with a
+     setting `typewriter.embeddedLanguages.forwarding: "auto" | "off"`.
+
+7. Visual Studio and Rider.
+   - Out of scope for the first PR; keep the LSP-side requests host-neutral so
+     the Rider plugin and a future VS LSP client can reuse them.
+
+### Tests / acceptance
+
+- Round-trip mapping unit tests; completion/hover/diagnostic integration tests
+  in `vscode` (extension test host) for one sample template.
+- Embedded diagnostics point at correct `.tst` line/column.
+- `${environment.apiBaseUrl}` output remains untouched by C# forwarding.
+
+Estimated size: 3-4 PRs (region hardening, LSP requests, VS Code providers +
+forwarding, diagnostics merge).
+
+---
+
+## Point 3: Performance - Metadata Cache Validation and Syntax-Tree Reuse
+
+### Current implementation state (verified in `src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs`)
+
+- `MetadataCache` stores a `ProjectInputManifest` per entry, separating source
+  file stamps from shape inputs. Unknown-provenance runs use precise manifest
+  validation, while watcher-backed runs validate only dirty paths.
+- CLI watch and language-server workspace generation feed changed paths into
+  `MetadataCacheInvalidation`. Deleted, renamed, or unknown inputs mark the
+  cache as broadly dirty so validation remains conservative.
+- Source syntax trees are cached by normalized path, parse options, and file
+  stamp. Metadata rebuilds reuse unchanged trees and parse changed trees in
+  parallel by source index, preserving deterministic `syntaxTrees` ordering.
+- `TypeMetadataReference` graph creation uses a symbol/nullable cache with
+  recursion guards. Cache hit/miss, validation, rebuild, parse, and tree-reuse
+  counters are reported through `TYPEWRITER_TRACE_PERF`.
+
+### Implementation steps
+
+1. Precise per-file stamps instead of one broad hash.
+   - Replace the single fingerprint hash with a manifest:
+     `IReadOnlyDictionary<string, FileStamp>` (path -> length + lastWriteTimeUtc)
+     for sources, project files, props/targets, assets/lock files, and
+     additional inputs; plus a small set of directory stamps only where globs
+     require them.
+   - Validation compares stamps per file and short-circuits on first difference;
+     record the invalidation reason for the perf counters requested by
+     perf-opt Phase 0.
+
+2. Watcher-driven dirty paths.
+   - Add `IMetadataCacheInvalidation` (in `Typewriter.Roslyn` or Abstractions):
+     `MarkDirty(string fullPath)`.
+   - CLI watch (`typewriter watch`) and the language-server workspace generation
+     service feed changed paths into it. A cache entry with no dirty paths since
+     last validation is accepted without any filesystem stat; entries with dirty
+     paths validate only those paths.
+   - Non-watch invocations (one-shot CLI) fall back to the per-file stamp
+     manifest check.
+
+3. `SourceText`/`SyntaxTree` cache.
+   - New bounded cache keyed by `(fullPath, parseOptionsChecksum, length, lastWriteTimeUtc)`
+     storing the parsed `SyntaxTree`.
+   - On metadata rebuild, reuse trees for unchanged files and parse only changed
+     files; rebuild the `CSharpCompilation` from the mixed tree set
+     (`compilation.ReplaceSyntaxTree` when an existing compilation is cached,
+     otherwise `Create` with reused trees).
+   - Parse changed files in parallel (`Parallel.ForEachAsync`), preserving the
+     current deterministic ordering of `syntaxTrees` by source path.
+
+4. Type-reference graph cache (perf-opt P1, same file).
+   - Per-compilation `Dictionary<(ITypeSymbol, NullableAnnotation), TypeMetadataReference>`
+     with an in-progress sentinel to break cycles (the pooled
+     `TypeReferenceVisitedSymbolSets` guard stays as a backstop).
+
+5. Guardrails.
+   - Keep `TrimMetadataCache` bounds; add counters (hits, misses, stat-validated
+     hits, dirty-path-validated hits) behind `TYPEWRITER_TRACE_PERF`.
+   - Snapshot tests must produce byte-identical output before/after; add a
+     regression test that edits one file in a two-file project and asserts only
+     one file is re-parsed (via an injectable parse hook or counter).
+
+### Acceptance
+
+- Repeated watch/LSP generation with no changes performs zero source re-parsing
+  and no full-tree stat storm.
+- One-file change re-parses exactly one file.
+- All 265 existing tests and snapshots pass unchanged.
+
+Estimated size: 3 PRs (stamp manifest + counters, watcher dirty-path feed,
+syntax-tree reuse + type-reference cache).
+
+---
+
+## Point 4: Shared WebApi/Service Helper Extension Library
+
+### Current state (verified)
+
+- `src/Typewriter.Engine/Extensions/` contains only `Documentation`, `Types`
+  (`ClassName()`, `Default()`, `Unwrap()`), and `WebApi` (`HttpMethodExtensions`,
+  `UrlExtensions`, `RequestDataExtensions`).
+- No shared implementations exist for the recipe helpers repeated across
+  `NetCoreTypewriterRecipes` templates: `MethodName`, `ReturnType`, `Imports`,
+  `SkipParameters`, `GetPropertyName`, discriminator/JsonDerivedType helpers,
+  enum helpers, naming helpers.
+
+### Implementation steps
+
+Add new static extension classes under `src/Typewriter.Engine/Extensions/`,
+namespaced to match the legacy convention (`Typewriter.Extensions.*`) so template
+`using` lines work in compiled helper blocks. Recommended grouping and order
+(each family lands with recipe-backed snapshot tests before templates are
+migrated):
+
+1. `Extensions/Naming/NamingExtensions.cs`
+   - `ServiceName(Class)`, `ConstName(Class)`, `ParentServiceName(Method)`,
+     `ParentConstName(Method)`, `UrlFieldName(Class)`, `UrlFieldName(Method)`,
+     `MethodName(Method)` (CustomName* attributes + non-CancellationToken
+     parameter type suffixes), `HookNameQuery(Method)`, `HookNameMutation(Method)`.
+   - Backed by existing `NameCaseFormatter`; add acronym-aware camel casing from
+     Point 5 first so names like `URLValue` match legacy output.
+
+2. `Extensions/WebApi/ActionExtensions.cs`
+   - `GetActionNameByAttribute(Method, string)`, per-verb
+     `Http{Get,Post,Put,Delete}ActionNameByAttribute(Method)`,
+     `Is{Get,Post,Put,Delete}Method(Method)`, `IsPostMethodWithResult`,
+     `IsPutMethodWithResult`, `IsGetOrDeleteMethod(Class)`, `GetRouteValue(Class)`
+     (controller placeholder replacement, class-level Route fallback).
+   - Reuse route logic already in `UrlExtensions`/`HttpMethodExtensions`; do not
+     duplicate verb detection.
+
+3. `Extensions/WebApi/ParameterExtensions.cs`
+   - `GetParameterValue(Parameter)`, `SkipParameters(Method)`,
+     `SkipParametersForBody(Method)`, `ContainsSkipParameters`,
+     `NotContainsSkipParameters`, `ContainsOneSkipParameters`,
+     `ContainsMoreSkipParameters`, `IsPrimitive(Parameter)`,
+     `IsDictionary(Parameter)`, `IsDictionary(string)`, `NameOfType(Type)`.
+   - Return `ParameterCollection` so results feed nested template blocks
+     (`$SkipParameters[$name: $Type][, ]` already works with CodeModel
+     collections returned from helpers).
+
+4. `Extensions/WebApi/ReturnTypeExtensions.cs`
+   - `ReturnType(Method)` with `ProducesResponseType` parsing and
+     `Task`/`ActionResult`/`IActionResult` unwrapping (reuse `Unwrap()`),
+     `SkipReturnType(string)`, `Imports(Class)` (model import discovery from
+     return types, ProducesResponseType attributes, parameters, dictionaries,
+     enums). Introduce a small shared result record if structured data is needed
+     (legacy `AdvancedTypeInfo`/`NullParam` shape).
+
+5. `Extensions/Serialization/SerializationExtensions.cs`
+   - `GetPropertyName(Property)` (`JsonPropertyName`,
+     `JsonProperty(PropertyName = ...)`, `nameof(...)` parsing),
+     `GetDiscriminator(IAttributeCollection)`,
+     `GenerateTypeForInterfaceByClass/Record`, `GenerateTypeForClass/Record`,
+     `GenerateTypeForClass2/Record2` + `GenerateTypeInitFor*2`
+     (JsonDerivedType/JsonPolymorphic chains), `SanitizeDefault(Type)`,
+     `Sep(...)` overloads, `LoudName(Constant)`.
+
+6. `Extensions/Enums/EnumExtensions.cs`
+   - `IsEnumAsNumber(Enum)`, `GetAttributeValueOrReturnEnumNameIfNoAttribute(EnumValue)`,
+     `GetEnumAsStringIfItsStringable(EnumValue)`.
+
+7. Wire-up.
+   - Expose the new namespaces to compiled template helpers the same way
+     `Typewriter.Extensions.WebApi` is exposed today (verify the implicit-usings /
+     reference list in `TemplateRuntimeCompiler`).
+   - Add unit tests per family plus recipe-backed snapshots (external
+     `NetCoreTypewriterRecipes` snapshots when the sibling checkout exists,
+     mirroring the existing conditional snapshot pattern in
+     `Typewriter.SnapshotTests`).
+   - Only after snapshots are green, migrate recipe templates to the shared
+     helpers (separate repo, out of scope here).
+
+Estimated size: 5-6 PRs, one per helper family, tests-first.
+
+---
+
+## Point 5: `Typewriter.CodeModel.Helpers` Facade and `ContextAttribute` Shim
+
+### Current state (verified)
+
+- New engine already uses `namespace Typewriter.CodeModel` for the parity surface
+  (`src/Typewriter.Engine/CodeModel/*`), but there is no `static class Helpers`,
+  no `GetTypeScriptName`, `GetOriginalName`, `IsPrimitive`, and no
+  `Typewriter.CodeModel.Attributes.ContextAttribute` anywhere in `src`.
+- Legacy source of truth exists on `feature/master-origin`:
+  - `src/Typewriter/CodeModel/Helpers.cs` (acronym-aware `CamelCase`,
+    `GetTypeScriptName(ITypeMetadata, Settings)`, `GetOriginalName`, `IsPrimitive`,
+    `_primitiveTypes` map).
+  - `src/CodeModel/Attributes/ContextAttribute.cs`
+    (`[AttributeUsage(AttributeTargets.Class)]`, `Name`, `CollectionName`).
+- Current `NameCaseFormatter.ToLegacyCamelCase` only lowercases the first
+  character; legacy `Helpers.CamelCase` lowercases leading acronyms
+  (`URLValue` -> `urlValue`, `IPAddress` -> `ipAddress`).
+
+### Implementation steps
+
+1. Acronym-aware camel case first (behavioral risk).
+   - Port the legacy `CamelCase` loop into `NameCaseFormatter` as
+     `NameCase.LegacyCamelCase` (or a new `NameCase.LegacyAcronymCamelCase` if
+     changing `$name` output is deemed too risky; decide via snapshot diff).
+   - Before switching `$name`, add snapshot coverage for `URLValue`, `IPAddress`,
+     `XMLDocument` per the to_implement.md note, and diff all existing checked-in
+     snapshots. If any external recipe output changes, gate the behavior behind
+     `TypewriterConfiguration` (default legacy-accurate).
+
+2. `Typewriter.CodeModel.Helpers` facade.
+   - New file `src/Typewriter.Engine/CodeModel/Helpers.cs`:
+     `public static class Helpers` with `CamelCase(string)` delegating to the
+     acronym-aware implementation, and `GetTypeScriptName`, `GetOriginalName`,
+     `IsPrimitive` delegating to the existing TypeScript mapping
+     (`TypeScriptTypeMapper`-backed logic already used for `$Type` rendering).
+   - Signature compatibility: legacy takes `ITypeMetadata` + `Settings`; the new
+     facade should accept the parity `Typewriter.CodeModel.Type` (implicit
+     conversions already exist for compiled helpers) and the parity `Settings`.
+     Verify against legacy call sites in recipe templates before finalizing.
+   - Add compile-time and reflection tests mirroring the existing
+     "original public Typewriter.CodeModel surface" test pattern.
+
+3. `ContextAttribute` shim.
+   - New file `src/Typewriter.Engine/CodeModel/Attributes/ContextAttribute.cs`,
+     copied 1:1 from the legacy branch (sealed, class-target, `Name`,
+     `CollectionName`). Pure compile/reflection compatibility; no runtime wiring
+     unless a real template needs it.
+
+4. Consistency check.
+   - Ensure `Helpers.GetTypeScriptName` and the renderer's `$Type` output agree
+     (single shared implementation, no duplicated mapping tables). Legacy
+     `_primitiveTypes` map goes into one shared internal location.
+
+Estimated size: 2 PRs (camel-case + snapshots, facade + shim + tests).
+
+---
+
+## Gap Analysis vs `feature/master-origin` (legacy codebase)
+
+`feature/master-origin` is a strict git ancestor of `master` and holds the last
+legacy Typewriter codebase (`Typewriter.sln`, old VSIX). Nothing on that branch
+is "ahead" in git terms; the meaningful comparison is legacy features not yet
+reimplemented in the rewrite. Verified deltas:
+
+| Legacy feature (feature/master-origin) | Status in rewrite | Action |
+| --- | --- | --- |
+| `Typewriter.CodeModel.Helpers` static facade | Missing | Point 5 |
+| `Typewriter.CodeModel.Attributes.ContextAttribute` | Missing | Point 5 |
+| Acronym-aware `CamelCase` (`URLValue` -> `urlValue`) | Missing (`ToLegacyCamelCase` is lower-first only) | Point 5, step 1 |
+| VS item templates (`src/ItemTemplates`: Angular WebApiController.tst, Empty Template.tst, Models.tst + .vstemplate files) | Missing; no ItemTemplates anywhere in the new repo | Backlog: add "New Typewriter template" item templates to the VSIX (and equivalent VS Code/Rider file templates) |
+| Editor: signature help (`SignatureHelpController`) | Missing in LSP (`TemplateFeatureService` has no signatureHelp) | Add `textDocument/signatureHelp` for helper methods and template functions; cheap once Point 2 forwarding exists for C# blocks |
+| Editor: outlining/folding (`OutliningController`) | Missing (no foldingRange support) | Add `textDocument/foldingRange` for `$Collection[...]` blocks and `${ ... }` helper blocks |
+| Editor: document formatting (`FormattingController`) | Missing | Optional backlog; low demand, do after folding |
+| Editor: brace matching (`BraceMatchingController`) | Partially covered (VS Code language-configuration bracket pairs; VS classification only) | Acceptable; no LSP work needed |
+| Editor: quick info, completion, classification, syntax errors | Covered (LSP hover, completion, semantic tokens, diagnostics; VS native fallback) | None |
+| `docs/` folder (user documentation) | New repo has README-level docs only | Backlog: docs site per to_implement.md Milestone 10 |
+| Legacy generation internals (Parser, SingleFileParser, ItemFilter, GenerationController, SolutionMonitor) | Reimplemented in `Typewriter.Engine` + adapters | None; remaining edge cases tracked as recipe-driven hardening |
+| Legacy Roslyn metadata (`RoslynVoidTaskMetadata` etc.) | Reimplemented; parity verified by existing tests | None |
+
+Recommended ordering for the extra gaps: item templates (small, visible win for
+VS users), then folding + signature help (pairs naturally with Point 2), then
+formatting and docs.
+
+---
+
+## Suggested Overall Sequence
+
+1. Point 5 (small, unblocks Point 4 naming parity)          ~2 PRs
+2. Point 4 helper families, tests-first                     ~5-6 PRs
+3. Point 3 perf (stamps -> dirty paths -> tree reuse)       ~3 PRs
+4. Point 2 embedded forwarding (LS requests -> VS Code)     ~3-4 PRs
+5. Legacy extras: item templates, foldingRange, signatureHelp
+
+Each PR: full `dotnet build`/`dotnet test` (currently 265 tests), snapshot
+byte-parity, `npm --prefix vscode run lint && bundle`, and Rider `verifyPlugin`
+where touched, per the verified commands in implemented.md.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,0 +1,126 @@
+# Incremental Generation Implementation Progress
+
+## Overview
+
+Implementing performance optimization so that changing a `.cs` file only regenerates affected `.ts` outputs, while `.tst` changes trigger full regeneration. Based on the plan in `docs/perf_improvement.md`.
+
+## Completed Work
+
+### 1. Abstractions Layer (DONE)
+
+Created new types in `src/Typewriter.Abstractions/`:
+
+- **`ChangedInputKind.cs`** — enum (Modified, Added, Deleted, Renamed)
+- **`ChangedInput.cs`** — record (FullPath, Kind)
+- **`MetadataCacheInvalidation.cs`** — process-wide dirty-path tracking with version-based validation. Hosts with filesystem watchers call `EnableTracking()` + `MarkDirty(path)`. Cache entries validated at a version with no dirty paths since then can be accepted without filesystem access. Uses `System.Threading.Lock`.
+- **`MetadataCacheMetrics.cs`** — process-wide counters (CacheHits, CacheMisses, StatValidatedHits, DirtyValidatedHits, SourceOnlyRebuilds, FullLoads, ParsedSourceFiles, ReusedSyntaxTrees, LastInvalidationReason). Lock-based for ParallelChecker compliance.
+- **`GenerationConfiguration.cs`** — record with `Incremental` property ("auto"/"off"), `IsIncrementalEnabled` check.
+
+Modified existing types:
+
+- **`GenerationRequest.cs`** — added `IReadOnlyCollection<ChangedInput>? ChangedInputs` property
+- **`TypewriterConfiguration.cs`** — added `GenerationConfiguration Generation { get; init; }` property (defaults to `GenerationConfiguration.Default`)
+
+### 2. Roslyn Layer (DONE)
+
+Major rewrite of `src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs`:
+
+**New caching architecture** (replaced old `ProjectMetadataFingerprint` hash-based approach):
+
+- **`ProjectInputManifest`** — per-file stamp manifest separating source files from shape files:
+  - Source files: `.cs` files tracked by (Exists, Length, LastWriteTicks) via `FileStamp`
+  - Shape files: `.csproj`, project references, assembly references — changes require full reload
+  - Directories: tracked by `LastWriteTimeUtc.Ticks` — new/deleted files change directory stamp
+  - `Validate()` — full stat-based validation (fallback when no watcher)
+  - `ValidateDirtyPaths(dirtyPaths)` — only stats the changed paths (fast path when watcher active)
+
+- **`LookupCache()`** — replaces `TryGetCachedResult()`. Returns `CacheLookupResult` with three outcomes:
+  - `Hit` — cache valid, return cached result
+  - `RebuildFromSources` — only source `.cs` files changed, reuse `ProjectLoadResult` (skip MSBuild), re-parse only changed files
+  - `Miss` — shape changed or no cache, full MSBuild reload
+
+- **`FileStamp`** — record (Exists, Length, LastWriteTicks) with `Create(path)` factory
+
+- **`ManifestValidation`** — record distinguishing Valid / ShapeChanged / SourcesChanged
+
+- **`ProjectMetadataCacheEntry`** — changed from record to class. Now holds `Result`, `Manifest`, `LoadedProject`, and `LastValidatedVersion` (atomic, for dirty-path tracking).
+
+- **SyntaxTree cache** — `ConcurrentDictionary<string, CachedSyntaxTree>` keyed by normalized path. Each entry stores `ParseOptionsKey`, `FileStamp`, and `SyntaxTree`. On rebuild, only changed source files are re-parsed; unchanged ones reuse cached syntax trees. Bounded at 8192 entries with FIFO eviction.
+
+- **TypeReference cache** — `ConditionalWeakTable<ITypeSymbol, TypeReferenceCacheNode>` caches `CreateTypeReference` results by symbol + `NullableAnnotation` index. Avoids re-traversing the type graph for repeated references.
+
+- **Metrics integration** — `MetadataCacheMetrics.RecordCacheHit/RecordCacheMiss/RecordSourceOnlyRebuild/RecordFullLoad/RecordParsedSourceFile/RecordReusedSyntaxTree` called at each decision point.
+
+- **Test hooks** — `internal static` methods: `GetSourceParseCountForTests(path)`, `GetLastCacheOutcomeForTests(projectPath)`, `ClearCachesForTests()`. Added `InternalsVisibleTo("Typewriter.Roslyn.Tests")` in `Properties/AssemblyInfo.cs`.
+
+- **Removed unused usings** — `System.Security.Cryptography`, `System.Text` (were only used by old SHA256 fingerprint hashing).
+
+- **Builds clean** with 0 warnings, 0 errors.
+
+### 3. Engine Layer (DONE)
+
+- **`ProjectMetadataIndex`** — reverse dependency index maps declared type names to source files and resolves transitive affected source files for incremental renders.
+- **`TypewriterGenerator.GenerateProjectAsync`** — scopes per-source-file rendering when `ChangedInputs` contains only changed `.cs` files and incremental generation is enabled. Template, project, config, deleted, and renamed inputs still trigger full rendering.
+- **`TypewriterConfigurationLoader`** — reads the `generation.incremental` configuration option and defaults to `"auto"`.
+- **Performance trace** — emits stage timings and the `MetadataCacheMetrics.CreateSummary()` counter line behind `TYPEWRITER_TRACE_PERF`.
+
+### 4. CLI Layer (DONE)
+- `--changed` is parsed into `CliOptions.ChangedPaths`.
+- Watch mode accumulates changed paths, enables `MetadataCacheInvalidation`, drains changed inputs per generation cycle, and passes them to `GenerationRequest`.
+
+### 5. LSP Layer (DONE)
+- `WorkspaceGenerationRequest` accepts `ChangedInputs`.
+- `WorkspaceGenerationService` maps request changed inputs to engine changed inputs, enables metadata dirty-path tracking for the persistent service lifetime, marks explicit dirty paths, and falls back to full manifest validation when provenance is unknown.
+
+### 6. VS Extension (DONE)
+- Save handling collects changed paths.
+- Persistent language-server requests include `changedInputs`.
+- CLI fallback passes `--changed` arguments.
+
+### 7. VS Code Extension (DONE)
+- Save requests merge changed paths and send them through the language-server generation request.
+- CLI fallback builds matching `--changed` arguments.
+
+### 8. Schema (DONE)
+- `typewriter.schema.json` includes the `generation.incremental` enum with `"auto"` and `"off"`.
+
+### 9. Tests — DONE
+- **Roslyn incremental metadata test** — `GetMetadataReusesCacheAndRebuildsFromSourcesOnDirtyPath` in `CSharpProjectMetadataProviderTests.cs`: creates temp project with 2 source files, verifies cache miss on first load, cache hit (dirty-validated) on second, source-only rebuild on third (only changed file re-parsed, unchanged file parse count stays same).
+- **Engine scoped rendering tests** — 5 tests in `TypewriterGeneratorWorkspaceTests.cs`: (1) only affected source files rendered when ChangedInputs provided (UserDto changed → UserDto.ts + OrderDto.ts via transitive closure, ProductDto.ts excluded); (2) nothing rendered when changed file is not part of the project; (3) full render when ChangedInputs include non-.cs file (template); (4) full render when ChangedInput kind is Deleted; (5) full render when incremental is disabled via config.
+- **CLI parsing tests** — 2 tests in `CliCommandLineTests.cs`: (1) `--changed` repeated option captures all paths in order; (2) ChangedPaths defaults to empty when option omitted.
+- **Language-server dirty-path test** — `GenerateAsyncRefreshesOutputAfterSourceFileChanges` verifies the persistent workspace generation path marks the changed source path and refreshes output.
+
+### 10. Verification
+- Targeted suites on 2026-07-07: LanguageServer 37 pass, Roslyn 15 pass, Engine 174 pass.
+- Serialized full solution suite on 2026-07-07: 292 pass, 0 failed.
+
+### 11. Documentation
+- Update `docs/perf_improvement.md` with implementation notes and deviations from original plan
+
+## Key Design Decisions
+
+1. **Stamp manifest vs SHA256 hash** — replaced the old fingerprint that hashed all file sizes+timestamps into a single hash with a per-file stamp manifest. This allows distinguishing "source file changed" (can skip MSBuild) from "shape file changed" (must reload project).
+
+2. **Dirty-path tracking** — `MetadataCacheInvalidation` provides O(1) cache validation when a filesystem watcher is active. Without a watcher, falls back to stat-based manifest validation (still faster than old approach because it can identify source-only changes).
+
+3. **Source-only rebuild** — when only `.cs` files change, the `ProjectLoadResult` (MSBuild evaluation) is reused. Only changed source files are re-parsed; unchanged ones use the SyntaxTree cache. The compilation is rebuilt from the new+cached syntax trees.
+
+4. **TypeReference cache** — keyed by `ITypeSymbol` + `NullableAnnotation` via `ConditionalWeakTable`. Prevents re-traversing the Roslyn type graph for repeated type references within a single compilation.
+
+5. **Lock-based metrics** — `MetadataCacheMetrics` uses a simple `Lock` instead of `Interlocked` to satisfy ParallelChecker analyzer. Performance impact is negligible since these are debug/trace counters.
+
+## Files Changed Summary
+
+### Created
+- `docs/progress.md` (this file)
+- `src/Typewriter.Abstractions/ChangedInput.cs`
+- `src/Typewriter.Abstractions/ChangedInputKind.cs`
+- `src/Typewriter.Abstractions/MetadataCacheInvalidation.cs`
+- `src/Typewriter.Abstractions/MetadataCacheMetrics.cs`
+- `src/Typewriter.Abstractions/GenerationConfiguration.cs`
+- `src/Typewriter.Roslyn/Properties/AssemblyInfo.cs`
+
+### Modified
+- `src/Typewriter.Abstractions/GenerationRequest.cs` — added `ChangedInputs` property
+- `src/Typewriter.Abstractions/TypewriterConfiguration.cs` — added `Generation` property
+- `src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs` — stamp manifest, dirty-path validation, SyntaxTree cache, type-reference cache, metrics, test hooks (+450/-144 lines)

--- a/docs/rider_install.md
+++ b/docs/rider_install.md
@@ -1,25 +1,32 @@
- From repo root:
+# Rider Plugin Install And Test
 
-   powershell
-     .\rider\gradlew.bat -p rider verifyPluginProjectConfiguration
-     .\rider\gradlew.bat -p rider verifyPlugin
-     .\rider\gradlew.bat -p rider runIde
+From the repository root, verify the Rider plugin project and launch a Rider sandbox:
 
-   runIde should launch a Rider sandbox with the plugin installed. Open a solution containing .tst files, then test:
+```powershell
+.\rider\gradlew.bat -p rider verifyPluginProjectConfiguration
+.\rider\gradlew.bat -p rider verifyPlugin
+.\rider\gradlew.bat -p rider runIde
+```
 
-   •  .tst file recognition and highlighting
-   •  Tools > Typewriter > Generate Current Template
-   •  Tools > Typewriter > Generate All Templates
-   •  Tools > Typewriter > Validate Current Template
-   •  Settings > Typewriter options
-   •  save-time generation/validation
+`runIde` should launch a Rider sandbox with the plugin installed. Open a solution containing `.tst` files, then test:
 
-   To test packaged install:
+- `.tst` file recognition and highlighting
+- `Tools > Typewriter > Generate Current Template`
+- `Tools > Typewriter > Generate All Templates`
+- `Tools > Typewriter > Validate Current Template`
+- `Settings > Typewriter` options
+- Save-time generation and validation
 
-   powershell
-     .\rider\gradlew.bat -p rider buildPlugin
+To test packaged install:
 
-   Then install rider\build\distributions\typewriter-rider-<version>.zip in Rider via Settings > Plugins > Gear > Install Plugin from
-    Disk.
+```powershell
+.\rider\gradlew.bat -p rider buildPlugin
+```
 
-    .\Build-RiderPluginWithTools.ps1 -Configuration Release
+Then install `rider\build\distributions\typewriter-rider-<version>.zip` in Rider through `Settings > Plugins > Gear > Install Plugin from Disk`.
+
+To build the packaged plugin with embedded Typewriter tools:
+
+```powershell
+.\Build-RiderPluginWithTools.ps1 -Configuration Release
+```

--- a/docs/rider_install.md
+++ b/docs/rider_install.md
@@ -1,0 +1,25 @@
+ From repo root:
+
+   powershell
+     .\rider\gradlew.bat -p rider verifyPluginProjectConfiguration
+     .\rider\gradlew.bat -p rider verifyPlugin
+     .\rider\gradlew.bat -p rider runIde
+
+   runIde should launch a Rider sandbox with the plugin installed. Open a solution containing .tst files, then test:
+
+   •  .tst file recognition and highlighting
+   •  Tools > Typewriter > Generate Current Template
+   •  Tools > Typewriter > Generate All Templates
+   •  Tools > Typewriter > Validate Current Template
+   •  Settings > Typewriter options
+   •  save-time generation/validation
+
+   To test packaged install:
+
+   powershell
+     .\rider\gradlew.bat -p rider buildPlugin
+
+   Then install rider\build\distributions\typewriter-rider-<version>.zip in Rider via Settings > Plugins > Gear > Install Plugin from
+    Disk.
+
+    .\Build-RiderPluginWithTools.ps1 -Configuration Release

--- a/docs/to_implement.md
+++ b/docs/to_implement.md
@@ -1,0 +1,1483 @@
+# Typewriter To Implement
+
+Target architecture, roadmap, and remaining backlog. Completed and current-state details are tracked in [implemented.md](implemented.md).
+
+## Goal
+
+Reimplement Typewriter from scratch as a modern, editor-independent TypeScript generator for C# projects.
+
+The new design should not be a Visual Studio-only extension. Instead, it should have a shared generator engine that can be used by:
+
+- a CLI / `dotnet tool`
+- a Visual Studio extension
+- a VS Code extension
+- an optional Language Server Protocol server
+- CI pipelines and pre-commit hooks
+
+The main principle:
+
+```text
+One generator engine.
+Multiple thin adapters.
+```
+
+---
+
+## Target Architecture
+
+```text
+                         ┌────────────────────────┐
+                         │   Typewriter.Engine    │
+                         │  Template + Generation │
+                         └───────────┬────────────┘
+                                     │
+              ┌──────────────────────┼──────────────────────┐
+              │                      │                      │
+┌─────────────▼─────────────┐ ┌──────▼──────┐ ┌─────────────▼─────────────┐
+│ Typewriter.VisualStudio   │ │ Typewriter  │ │ Typewriter.LanguageServer │
+│ VSIX adapter              │ │ CLI         │ │ LSP for .tst files        │
+└───────────────────────────┘ └──────┬──────┘ └─────────────┬─────────────┘
+                                     │                      │
+                               ┌─────▼──────────────────────▼────-─-─┐
+                               │        VS Code extension            │
+                               │ TypeScript/Node adapter             │
+                               └─────────────────────────────────────┘
+```
+
+---
+
+## Core Product Decisions
+
+### 1. The engine must be editor-independent
+
+The generator must not depend on:
+
+- `DTE`
+- `EnvDTE`
+- `IVsHierarchy`
+- `AsyncPackage`
+- Visual Studio MEF
+- VS Code APIs
+- Node.js APIs
+- editor save events
+- editor output windows
+
+The engine should only know about:
+
+- solutions
+- projects
+- source files
+- templates
+- metadata
+- generation output
+- diagnostics
+- configuration
+
+### 2. CLI comes before extensions
+
+The CLI should be the first real product surface.
+
+If the CLI works well, Visual Studio and VS Code become wrappers around it.
+
+The CLI should support:
+
+```bash
+typewriter generate --workspace ./MySolution.sln
+typewriter generate --project ./src/MyApi/MyApi.csproj
+typewriter generate --template ./src/MyApi/Models.tst
+typewriter watch --workspace ./MySolution.sln
+typewriter validate --workspace ./MySolution.sln
+```
+
+### 3. Visual Studio and VS Code are adapters
+
+Visual Studio should provide:
+
+- `.tst` file recognition
+- commands
+- generate on save
+- diagnostics
+- output window integration
+- optional syntax highlighting / editor features
+
+VS Code should provide:
+
+- `.tst` file association
+- syntax highlighting
+- commands
+- file watchers
+- diagnostics in the Problems panel
+- optional LSP-powered completion and hover
+
+---
+
+## Proposed Repository Structure
+
+```text
+repo/
+  src/
+    Typewriter.Abstractions/
+    Typewriter.Engine/
+    Typewriter.Roslyn/
+    Typewriter.Buildalyzer/
+    Typewriter.Cli/
+    Typewriter.LanguageServer/
+    Typewriter.VisualStudio/
+    Typewriter.VisualStudio.Legacy/
+
+  vscode/
+    package.json
+    tsconfig.json
+    src/
+      extension.ts
+      typewriterClient.ts
+      diagnostics.ts
+      watcher.ts
+      configuration.ts
+    syntaxes/
+      tst.tmLanguage.json
+    language-configuration.json
+
+  tests/unit/
+    Typewriter.Engine.Tests/
+    Typewriter.Roslyn.Tests/
+    Typewriter.Cli.Tests/
+    Typewriter.SnapshotTests/
+    Typewriter.LanguageServer.Tests/
+
+  samples/
+    SimpleApi/
+    NullableModels/
+    RecordsAndEnums/
+    MultiProjectSolution/
+    NetCoreTypewriterRecipes/
+
+  docs/
+    architecture.md
+    template-language.md
+    cli.md
+    vscode-extension.md
+    visual-studio-extension.md
+```
+
+---
+
+## Main Projects
+
+## Typewriter.Abstractions
+
+Contains contracts shared by all other projects.
+
+Example interfaces:
+
+```csharp
+public interface ITypewriterGenerator
+{
+    Task<GenerationResult> GenerateAsync(
+        GenerationRequest request,
+        CancellationToken cancellationToken);
+}
+
+public interface ITemplateDiscovery
+{
+    Task<IReadOnlyList<TemplateFile>> FindTemplatesAsync(
+        WorkspaceContext workspace,
+        CancellationToken cancellationToken);
+}
+
+public interface IProjectMetadataProvider
+{
+    Task<ProjectMetadata> GetMetadataAsync(
+        ProjectContext project,
+        CancellationToken cancellationToken);
+}
+
+public interface IGeneratedFileWriter
+{
+    Task WriteAsync(
+        GeneratedFile file,
+        CancellationToken cancellationToken);
+}
+
+public interface IGenerationReporter
+{
+    void Info(string message);
+    void Warning(GenerationDiagnostic diagnostic);
+    void Error(GenerationDiagnostic diagnostic);
+}
+```
+
+Suggested models:
+
+```csharp
+public sealed record GenerationRequest(
+    string WorkspacePath,
+    string? ProjectPath,
+    string? TemplatePath,
+    GenerationMode Mode,
+    TypewriterConfiguration Configuration);
+
+public sealed record GenerationResult(
+    bool Success,
+    IReadOnlyList<GeneratedFile> GeneratedFiles,
+    IReadOnlyList<GenerationDiagnostic> Diagnostics,
+    TimeSpan Duration);
+
+public sealed record GeneratedFile(
+    string Path,
+    string Content,
+    bool Changed);
+
+public sealed record GenerationDiagnostic(
+    string? File,
+    int? Line,
+    int? Column,
+    DiagnosticSeverity Severity,
+    string Message,
+    string? Code = null);
+```
+
+---
+
+## Typewriter.Engine
+
+Responsible for:
+
+- template parsing
+- template compilation
+- template execution
+- generation orchestration
+- diagnostics
+- output file mapping
+- incremental generation decisions
+
+Should not contain Roslyn-specific or editor-specific code directly.
+
+Internal flow:
+
+```text
+GenerationRequest
+    ↓
+ConfigurationLoader
+    ↓
+TemplateDiscovery
+    ↓
+ProjectMetadataProvider
+    ↓
+TemplateCompiler
+    ↓
+TemplateExecutor
+    ↓
+GeneratedFilePlanner
+    ↓
+GeneratedFileWriter
+    ↓
+GenerationResult
+```
+
+Important design goal:
+
+```text
+Generation should be deterministic:
+Same input files + same configuration = same output files.
+```
+
+---
+
+## Typewriter.Roslyn
+
+Responsible for reading C# code using Roslyn.
+
+Should provide metadata such as:
+
+- classes
+- records
+- interfaces
+- enums
+- properties
+- methods
+- attributes
+- generic type arguments
+- nullable annotations
+- XML documentation
+- inheritance
+- implemented interfaces
+- namespaces
+- accessibility
+- constants
+- static members
+
+Avoid leaking Roslyn types into the public engine API.
+
+Do not expose:
+
+```csharp
+INamedTypeSymbol
+IPropertySymbol
+ICompilationUnitSyntax
+SemanticModel
+Compilation
+```
+
+Instead expose Typewriter-owned metadata models:
+
+```csharp
+public sealed record TypeMetadata(
+    string Name,
+    string FullName,
+    string Namespace,
+    TypeKind Kind,
+    IReadOnlyList<PropertyMetadata> Properties,
+    IReadOnlyList<AttributeMetadata> Attributes,
+    IReadOnlyList<TypeMetadataReference> BaseTypes,
+    bool IsNullableAware);
+```
+
+---
+
+## Typewriter.Buildalyzer
+
+Responsible for loading projects and solutions outside Visual Studio.
+
+Used by:
+
+- CLI
+- VS Code
+- Language Server
+- CI
+
+Responsibilities:
+
+- load `.sln`
+- load `.csproj`
+- resolve target frameworks
+- resolve project references
+- create Roslyn workspace/compilation inputs
+- handle multi-targeted projects
+- report project loading diagnostics
+
+Important scenarios:
+
+```text
+- single SDK-style .csproj
+- multi-project solution
+- project references
+- shared projects, if needed
+- generated source files
+- nullable-enabled projects
+- multi-targeting: net8.0;net9.0;net10.0
+```
+
+---
+
+## Typewriter.Cli
+
+The CLI is the main automation surface.
+
+Initial commands:
+
+```bash
+typewriter generate
+typewriter watch
+typewriter validate
+typewriter list-templates
+typewriter list-projects
+```
+
+Suggested options:
+
+```bash
+--workspace <path-to-sln-or-folder>
+--project <path-to-csproj>
+--template <path-to-tst>
+--configuration <Debug|Release>
+--framework <target-framework>
+--output json|text
+--verbosity quiet|minimal|normal|detailed|diagnostic
+--dry-run
+--fail-on-warning
+--no-restore
+```
+
+Example JSON output:
+
+```json
+{
+  "success": false,
+  "durationMs": 1240,
+  "generatedFiles": [
+    {
+      "path": "src/api/generated/user.model.ts",
+      "changed": true
+    }
+  ],
+  "diagnostics": [
+    {
+      "file": "src/api/models.tst",
+      "line": 12,
+      "column": 5,
+      "severity": "error",
+      "code": "TW0001",
+      "message": "Unknown extension method: ToTypeScriptType"
+    }
+  ]
+}
+```
+
+The VS Code extension should use JSON output.
+
+---
+
+## Typewriter.VisualStudio
+
+Visual Studio support should be a thin wrapper around the engine or CLI.
+
+Use the modern SDK-style VSIX project format.
+
+Recommended staged approach:
+
+```text
+Stage 1:
+- SDK-style VSIX
+- classic VSSDK integration
+- use Typewriter.Engine internally
+
+Stage 2:
+- add VisualStudio.Extensibility hybrid shell
+- migrate simple commands first
+
+Stage 3:
+- optionally move orchestration out-of-process
+- keep VS-only APIs behind a small in-process broker
+```
+
+Visual Studio adapter responsibilities:
+
+- discover active solution/project
+- expose commands
+- react to document save events
+- call generator
+- update generated files
+- report diagnostics
+- show output logs
+- manage VS-specific file nesting/project inclusion
+
+Visual Studio should not own the generator logic.
+
+---
+
+## VS Code Extension
+
+Location:
+
+```text
+vscode/
+```
+
+Responsibilities:
+
+- register `.tst` files
+- provide syntax highlighting
+- expose commands
+- watch files
+- run CLI or language server
+- parse JSON diagnostics
+- publish diagnostics to Problems panel
+- show output in a Typewriter output channel
+
+Example commands:
+
+```json
+{
+  "contributes": {
+    "commands": [
+      {
+        "command": "typewriter.generate",
+        "title": "Typewriter: Generate Current Template"
+      },
+      {
+        "command": "typewriter.generateAll",
+        "title": "Typewriter: Generate All Templates"
+      },
+      {
+        "command": "typewriter.watch",
+        "title": "Typewriter: Start Watch Mode"
+      },
+      {
+        "command": "typewriter.restartServer",
+        "title": "Typewriter: Restart Language Server"
+      }
+    ]
+  }
+}
+```
+
+Suggested VS Code settings:
+
+```json
+{
+  "typewriter.cliPath": "typewriter",
+  "typewriter.generateOnSave": true,
+  "typewriter.debounceMs": 750,
+  "typewriter.workspacePath": null,
+  "typewriter.outputFormat": "json",
+  "typewriter.trace.server": "off"
+}
+```
+
+File watchers:
+
+```ts
+const csWatcher = vscode.workspace.createFileSystemWatcher("**/*.cs");
+const templateWatcher = vscode.workspace.createFileSystemWatcher("**/*.tst");
+const projectWatcher = vscode.workspace.createFileSystemWatcher("**/*.{csproj,sln,props,targets}");
+```
+
+Debounce all watcher-triggered generation.
+
+---
+
+## Typewriter.LanguageServer
+
+The language server is optional but recommended for rich `.tst` editor support.
+
+Use it for:
+
+- template diagnostics
+- autocomplete
+- hover
+- go to definition
+- find references
+- code actions
+- document symbols
+- workspace symbols
+- embedded C# helper-block highlighting and IntelliSense
+- embedded TypeScript output-region highlighting and IntelliSense
+
+Do not put full generation only in the language server. Generation should remain in the engine and CLI.
+
+Suggested LSP features by milestone:
+
+```text
+Milestone 1:
+- diagnostics
+- document sync
+
+Milestone 2:
+- completion for known template members
+- completion for known C# metadata
+
+Milestone 3:
+- hover documentation
+- go to generated output
+- go to C# source symbol
+
+Milestone 4:
+- code actions
+- template refactoring helpers
+
+Post-MVP:
+- embedded-language region mapping for `.tst` files
+- semantic highlighting for C# helper blocks and TypeScript output regions
+- completion, hover, signature help, diagnostics, and go-to-definition inside C# helper blocks
+- completion, hover, diagnostics, and symbol navigation inside TypeScript output regions
+- virtual-document forwarding to Roslyn and the TypeScript language service instead of reimplementing either language server
+```
+
+---
+
+## Template Language Strategy
+
+You have two possible approaches.
+
+## Option A: Preserve Typewriter `.tst` compatibility
+
+Pros:
+
+- easier migration for existing users
+- compatible with old recipes
+- less disruption
+
+Cons:
+
+- may preserve old design limitations
+- harder to clean up syntax
+- compatibility layer may be expensive
+
+## Option B: New template language inspired by old Typewriter
+
+Pros:
+
+- clean implementation
+- better diagnostics
+- easier LSP support
+- easier long-term maintenance
+
+Cons:
+
+- breaking change
+- users must migrate templates
+
+Recommended approach:
+
+```text
+Start with old Typewriter compatibility where practical,
+but version the template language explicitly.
+```
+
+Example:
+
+```text
+// typewriter-template: v1
+```
+
+or:
+
+```json
+{
+  "templateVersion": 1
+}
+```
+
+Later you can introduce:
+
+```text
+// typewriter-template: v2
+```
+
+---
+
+## Configuration
+
+Support a configuration file at repo or project level.
+
+Suggested names:
+
+```text
+typewriter.json
+typewriter.config.json
+.typewriterrc.json
+```
+
+Example:
+
+```json
+{
+  "templates": [
+    "**/*.tst"
+  ],
+  "exclude": [
+    "**/bin/**",
+    "**/obj/**",
+    "**/node_modules/**"
+  ],
+  "generateOnSave": true,
+  "defaultTargetFramework": null,
+  "output": {
+    "newline": "lf",
+    "encoding": "utf-8",
+    "writeOnlyWhenChanged": true
+  },
+  "diagnostics": {
+    "failOnWarning": false
+  }
+}
+```
+
+Configuration precedence:
+
+```text
+CLI arguments
+    ↓
+environment variables
+    ↓
+nearest project config
+    ↓
+repo config
+    ↓
+default settings
+```
+
+---
+
+## Generation Pipeline
+
+```text
+1. Resolve workspace
+2. Load configuration
+3. Discover templates
+4. Resolve project context
+5. Load C# metadata
+6. Compile/evaluate templates
+7. Plan generated files
+8. Compare with existing generated files
+9. Write changed files only
+10. Return diagnostics and result summary
+```
+
+Generation should support cancellation at each stage.
+
+---
+
+## Watch Mode
+
+Watch mode should be implemented in the CLI, not only in the editors.
+
+```bash
+typewriter watch --workspace ./MySolution.sln
+```
+
+Watch these files:
+
+```text
+*.cs
+*.tst
+*.csproj
+*.sln
+Directory.Build.props
+Directory.Build.targets
+typewriter.json
+```
+
+Rules:
+
+```text
+- debounce changes
+- collapse duplicate requests
+- cancel previous generation if a new change arrives
+- do not write files if content did not change
+- log generated files
+- report diagnostics continuously
+```
+
+---
+
+## Diagnostics
+
+Diagnostics should be first-class.
+
+Required fields:
+
+```text
+- severity
+- code
+- message
+- file
+- line
+- column
+- optional help link
+```
+
+Example codes:
+
+```text
+TW0001 Unknown template member
+TW0002 Template parse error
+TW0003 Project load failed
+TW0004 C# compilation failed
+TW0005 Output path outside workspace
+TW0006 Generated file conflict
+TW0007 Unsupported target framework
+TW0008 Extension method failed
+```
+
+All adapters should consume the same diagnostic model.
+
+---
+
+## Safety Rules for Generated Files
+
+The generator should avoid destructive behavior.
+
+Rules:
+
+```text
+- never delete files unless explicitly requested
+- write only inside workspace by default
+- block output paths outside workspace unless configured
+- avoid overwriting non-generated files
+- add a generated-file header by default
+- write only if content changed
+- preserve line endings if configured
+```
+
+Suggested generated header:
+
+```ts
+// <auto-generated />
+// Generated by Typewriter. Do not edit manually.
+```
+
+---
+
+## Testing Strategy
+
+## Unit Tests
+
+Cover:
+
+```text
+- template parsing
+- template execution
+- type mapping
+- enum mapping
+- nullable reference types
+- generic types
+- attributes
+- records
+- inheritance
+- extension methods
+- diagnostics
+- output path calculation
+```
+
+## Snapshot Tests
+
+Use sample C# projects and templates.
+
+Input:
+
+```text
+samples/SimpleApi/**/*.cs
+samples/SimpleApi/**/*.tst
+```
+
+Expected output:
+
+```text
+samples/SimpleApi/expected/**/*.ts
+```
+
+## CLI Tests
+
+Cover:
+
+```text
+- generate solution
+- generate project
+- generate single template
+- dry run
+- JSON output
+- error exit code
+- warning handling
+- invalid config
+```
+
+## VS Code Tests
+
+Cover:
+
+```text
+- extension activates on .tst
+- command calls CLI
+- diagnostics are published
+- generate on save works
+- file watcher debounce works
+```
+
+## Visual Studio Tests
+
+Cover manually at first:
+
+```text
+- install VSIX
+- open solution
+- save .cs file
+- save .tst file
+- generate current template
+- generate all templates
+- diagnostics shown
+- output shown
+```
+
+---
+
+## Milestone Plan
+
+## Milestone 1: Clean Core Foundation
+
+Deliverables:
+
+```text
+- new solution structure
+- Typewriter.Abstractions
+- Typewriter.Engine skeleton
+- Typewriter.Roslyn skeleton
+- simple metadata model
+- basic template discovery
+- first unit tests
+```
+
+Acceptance criteria:
+
+```text
+- engine can receive a GenerationRequest
+- engine returns a GenerationResult
+- no editor-specific dependency exists in the engine
+```
+
+---
+
+## Milestone 2: Roslyn Metadata
+
+Deliverables:
+
+```text
+- load C# files
+- extract classes, interfaces, records, enums
+- extract properties and types
+- support nullable annotations
+- support attributes
+- tests for metadata extraction
+```
+
+Acceptance criteria:
+
+```text
+- metadata model is independent from Roslyn types
+- sample project metadata can be serialized to JSON
+```
+
+---
+
+## Milestone 3: First Template Execution
+
+Deliverables:
+
+```text
+- parse minimal .tst template
+- execute template against metadata
+- generate .ts file
+- write changed files only
+- produce diagnostics
+```
+
+Acceptance criteria:
+
+```text
+- sample C# class generates expected TypeScript interface
+- snapshot test passes
+```
+
+---
+
+## Milestone 4: CLI MVP
+
+Deliverables:
+
+```text
+- typewriter generate
+- --workspace
+- --project
+- --template
+- --output json
+- --dry-run
+- proper exit codes
+```
+
+Exit codes:
+
+```text
+0 success
+1 generation failed
+2 invalid arguments
+3 project loading failed
+4 template parsing failed
+```
+
+Acceptance criteria:
+
+```text
+- CLI can generate from a sample project
+- CLI JSON output can be consumed by another process
+```
+
+---
+
+## Milestone 5: Watch Mode
+
+Deliverables:
+
+```text
+- typewriter watch
+- file watchers
+- debounce
+- cancellation
+- continuous diagnostics
+```
+
+Acceptance criteria:
+
+```text
+- changing a .cs file regenerates affected output
+- changing a .tst file regenerates affected output
+- repeated quick saves cause one generation run
+```
+
+---
+
+## Milestone 6: VS Code MVP
+
+Deliverables:
+
+```text
+- VS Code extension project
+- .tst file association
+- basic syntax highlighting
+- Typewriter: Generate command
+- Typewriter: Generate All command
+- run CLI
+- parse JSON diagnostics
+- show diagnostics in Problems panel
+```
+
+Acceptance criteria:
+
+```text
+- opening a workspace with .tst files activates extension
+- generate command writes output
+- template errors appear in Problems panel
+```
+
+---
+
+## Milestone 7: Visual Studio MVP
+
+Deliverables:
+
+```text
+- SDK-style VSIX project
+- command: Generate Current Template
+- command: Generate All Templates
+- generate on save
+- output window logging
+- diagnostics integration
+```
+
+Acceptance criteria:
+
+```text
+- extension installs in Visual Studio
+- generation uses shared engine
+- no duplicated generator logic exists in VS project
+```
+
+---
+
+## Milestone 8: Language Server MVP
+
+Deliverables:
+
+```text
+- LSP server process
+- document open/change events
+- template diagnostics
+- VS Code LSP client integration
+```
+
+Acceptance criteria:
+
+```text
+- .tst errors appear without running full generation manually
+- server can be restarted from VS Code command palette
+```
+
+---
+
+## Milestone 9: Rich Template Experience
+
+Deliverables:
+
+```text
+- completion for metadata members
+- completion for template functions
+- hover documentation
+- go to C# symbol
+- go to generated file
+```
+
+Acceptance criteria:
+
+```text
+- editing .tst feels close to a real language experience
+```
+
+---
+
+## Post-MVP Embedded Language Intelligence
+
+Current status:
+
+```text
+- LSP semanticTokens support now provides Typewriter, C# helper-block, and TypeScript output-region semantic highlighting.
+- Completion is context-aware: `$...` uses Typewriter template completions, C# helper blocks get basic C#/CodeModel completions, and TypeScript output regions get basic TypeScript/type completions.
+- VS Code and Visual Studio both have native fallback Ctrl+Space completions for `.tst` files when the language server is unavailable or still starting.
+- Remaining work is full embedded-language service forwarding for deeper C# and TypeScript IntelliSense.
+```
+
+Goal:
+
+```text
+Make `.tst` files behave like mixed Typewriter/C#/TypeScript documents without moving generation logic into the editor layer.
+```
+
+Deliverables:
+
+```text
+- Parse `.tst` files into template, C# helper, and TypeScript output regions.
+- Expose virtual C# documents for `${ ... }` compatibility/helper blocks.
+- Expose virtual TypeScript documents for generated output text regions.
+- Forward embedded C# completion, hover, signature help, semantic tokens, diagnostics, and definitions to Roslyn language services.
+- Forward embedded TypeScript completion, hover, semantic tokens, diagnostics, and definitions to the TypeScript language service.
+- Translate positions and ranges between the original `.tst` document and each virtual embedded document.
+- Keep Typewriter template completions active for `$...` expressions while embedded language services handle ordinary C# and TypeScript syntax.
+```
+
+Acceptance criteria:
+
+```text
+- C# code inside helper blocks has real C# highlighting, completion, hover, signature help, diagnostics, and go-to-definition.
+- TypeScript output regions have TypeScript highlighting, completion, hover, diagnostics, and symbol navigation where source mapping is possible.
+- Template member IntelliSense still works for `$Classes`, `$Properties`, `$Type`, helper calls, and metadata symbols.
+- Embedded diagnostics point back to the correct `.tst` line and column.
+- The implementation uses virtual documents and request forwarding, not a custom C# or TypeScript parser.
+```
+
+Implementation notes:
+
+```text
+- Reuse and harden the current embedded-region parser as virtual-document forwarding is added.
+- Extend the current LSP semanticTokens support as the embedded region model grows.
+- Add virtual-document providers in the VS Code extension for C# and TypeScript embedded regions.
+- Prefer Roslyn LSP or C# Dev Kit/OmniSharp interop for C# requests when available.
+- Prefer VS Code's built-in TypeScript language features for TypeScript virtual documents.
+- If a host cannot provide embedded-language forwarding, keep graceful fallback to current template-only IntelliSense.
+```
+
+---
+
+## Milestone 10: Packaging and Release
+
+Deliverables:
+
+```text
+- NuGet package for engine abstractions if useful
+- dotnet tool package for CLI
+- VSIX package
+- VS Code extension package
+- GitHub Actions pipeline
+- release notes
+- docs site or README docs
+```
+
+Acceptance criteria:
+
+```text
+- CLI can be installed as dotnet tool
+- VSIX can be installed manually
+- VS Code extension can be packaged as .vsix
+- samples are documented
+```
+
+---
+
+## Suggested Development Order
+
+```text
+1. Create new repository/solution
+2. Define abstractions and result/diagnostic models
+3. Build metadata extraction with Roslyn
+4. Build minimal template execution
+5. Add snapshot tests
+6. Add CLI generate command
+7. Add JSON output
+8. Add watch mode
+9. Add VS Code extension MVP
+10. Add Visual Studio extension MVP
+11. Add LSP server
+12. Add advanced template support
+13. Add packaging and CI
+```
+
+---
+
+## Recommended PR Sequence
+
+```text
+PR 01: Initial solution structure
+PR 02: Abstractions and diagnostics model
+PR 03: Roslyn metadata extraction
+PR 04: Template discovery and parsing skeleton
+PR 05: First generation pipeline
+PR 06: Snapshot test infrastructure
+PR 07: CLI generate command
+PR 08: CLI JSON output and exit codes
+PR 09: Project/solution loading through Buildalyzer
+PR 10: Watch mode
+PR 11: VS Code extension skeleton
+PR 12: VS Code commands and CLI bridge
+PR 13: VS Code diagnostics
+PR 14: Visual Studio SDK-style VSIX skeleton
+PR 15: Visual Studio commands and engine bridge
+PR 16: Visual Studio generate-on-save
+PR 17: Language server skeleton
+PR 18: Language server diagnostics
+PR 19: Completion and hover
+PR 20: Packaging and release workflow
+```
+
+---
+
+## CI Pipeline
+
+Suggested GitHub Actions jobs:
+
+```text
+build-dotnet
+- restore
+- build
+- test
+- pack CLI
+
+build-vscode
+- npm ci
+- npm run lint
+- npm run test
+- npm run package
+
+build-visualstudio
+- restore
+- build VSIX
+- collect artifact
+
+snapshot-tests
+- run generation against samples
+- compare expected output
+
+release
+- publish NuGet dotnet tool
+- publish VSIX artifact
+- publish VS Code VSIX artifact
+```
+
+---
+
+## Important Risks
+
+| Risk                                                | Mitigation                                               |
+| --------------------------------------------------- | -------------------------------------------------------- |
+| Old `.tst` compatibility becomes too expensive      | Version the template language and provide migration docs |
+| Project loading outside Visual Studio is unreliable | Use Buildalyzer and test many sample project shapes      |
+| VS Code extension becomes slow                      | Keep heavy work in CLI/server process                    |
+| Generated files overwrite user files                | Require generated-file header and safe write rules       |
+| Visual Studio APIs force in-process code            | Keep VS-specific logic in thin adapter only              |
+| LSP becomes too big too early                       | Ship CLI and basic VS Code integration first             |
+
+---
+
+## First Minimal Vertical Slice
+
+Build this before anything fancy:
+
+```text
+Input:
+- one .csproj
+- one C# class
+- one .tst template
+
+Process:
+- CLI loads project
+- Roslyn extracts class metadata
+- engine executes template
+- CLI writes .ts file
+
+Output:
+- deterministic generated TypeScript
+- JSON result
+- snapshot test
+```
+
+Example target command:
+
+```bash
+typewriter generate \
+  --project ./samples/SimpleApi/SimpleApi.csproj \
+  --template ./samples/SimpleApi/Models.tst \
+  --output json
+```
+
+Only after this works should you build editor integration.
+
+---
+
+## Definition of Done for the Rewrite
+
+The rewrite is successful when:
+
+```text
+- Typewriter can run without Visual Studio
+- Typewriter can generate from CLI
+- Typewriter can run in CI
+- VS Code can generate using the same engine
+- Visual Studio can generate using the same engine
+- diagnostics are shared across all adapters
+- generated output is deterministic
+- snapshot tests protect compatibility
+- no generator logic is duplicated between editors
+```
+
+---
+
+## Long-Term Opportunities
+
+Once the core is editor-independent, future support becomes much easier:
+
+```text
+- Rider plugin
+- GitHub Action
+- pre-commit hook
+- MSBuild integration
+- NuGet package for generation during build
+- watch daemon
+- web-based template playground
+- template formatter
+- template analyzer
+- migration tool from old Typewriter templates
+```
+
+---
+
+## Final Recommendation
+
+Reimplement Typewriter as:
+
+```text
+Typewriter.Engine       = core product
+Typewriter.Cli          = first-class automation interface
+Typewriter.VisualStudio = Visual Studio adapter
+VS Code extension       = VS Code adapter
+Language Server         = optional rich editor experience
+```
+
+Do not start with the Visual Studio extension.
+Do not start with the VS Code extension.
+Do not duplicate the generator in TypeScript.
+
+Start with the engine and CLI.
+Everything else should wrap them.
+
+---
+
+## NetCoreTypewriterRecipes Open Audit Items
+
+Observed service/constants-template requirements still needing recipe-backed implementation:
+
+```text
+- Additional service template variants from `D:\GitHub\NetCoreTypewriterRecipes`, especially recipes that depend on request/response helper edge cases not represented by the current WebApi sample.
+- More complete legacy parser/runtime collection behavior where real recipes depend on old Typewriter edge cases.
+- Request body/response helper coverage beyond the representative WebApi route/verb/response tests.
+```
+
+## Additional Helper and Public Surface Backlog
+
+This section comes from a direct audit of `.tst` helper methods under `D:\GitHub\NetCoreTypewriterRecipes` and the original public CodeModel surface under `D:\GitHub\Typewriter`.
+
+Recipe helper candidates to move into shared extensions:
+
+```text
+- Naming helpers:
+  - ServiceName(Class), ConstName(Class), ParentServiceName(Method), ParentConstName(Method)
+  - UrlFieldName(Class), UrlFieldName2(Method)
+  - MethodName(Method), including CustomName* attributes and non-CancellationToken parameter type suffixes
+  - HookNameQuery(Method) and HookNameMutation(Method) for React query/mutation naming
+
+- Web API action helpers:
+  - GetActionNameByAttribute(Method, string)
+  - HttpGetActionNameByAttribute(Method), HttpPostActionNameByAttribute(Method), HttpPutActionNameByAttribute(Method), HttpDeleteActionNameByAttribute(Method)
+  - IsGetMethod(Method), IsPostMethod(Method), IsPostMethodWithResult(Method), IsPutMethod(Method), IsPutMethodWithResult(Method), IsDeleteMethod(Method), IsGetOrDeleteMethod(Class)
+  - GetRouteValue(Class), especially controller placeholder replacement and class-level Route fallback behavior
+
+- Request/parameter helpers:
+  - GetParameterValue(Parameter)
+  - SkipParameters(Method), SkipParametersForBody(Method)
+  - ContainsSkipParameters(Method), NotContainsSkipParameters(Method), ContainsOneSkipParameters(Method), ContainsMoreSkipParameters(Method)
+  - IsPrimitive(Parameter), IsDictionary(Parameter), IsDictionary(string), NameOfType(Type)
+
+- Return type and import helpers:
+  - ReturnType(Method), especially ProducesResponseType parsing and Task/ActionResult/IActionResult handling
+  - SkipReturnType(string)
+  - Imports(Class), including model import discovery from method return types, ProducesResponseType attributes, parameters, dictionaries, and enums
+  - A small shared shape equivalent to AdvancedTypeInfo / NullParam if service import and parameter helpers need structured return data
+
+- Serializer/model helpers:
+  - GetPropertyName(Property), including JsonPropertyName, JsonProperty(PropertyName = "..."), and nameof(...) parsing
+  - GetDiscriminator(IAttributeCollection)
+  - GenerateTypeForInterfaceByClass(Class), GenerateTypeForInterfaceByRecord(Record), GenerateTypeForClass(Class), GenerateTypeForRecord(Record)
+  - GenerateTypeForClass2(Class), GenerateTypeForRecord2(Record), GenerateTypeInitForClass2(Class), GenerateTypeInitForRecord2(Record) for JsonDerivedType / JsonPolymorphic inheritance chains
+  - SanitizeDefault(Type), Sep(Enum), Sep(EnumValue), Sep(Constant), LoudName(Constant)
+
+- Enum helpers:
+  - IsEnumAsNumber(Enum)
+  - GetAttributeValueOrReturnEnumNameIfNoAttribute(EnumValue)
+  - GetEnumAsStringIfItsStringable(EnumValue)
+```
+
+Original Typewriter public surface candidates to copy or verify:
+
+```text
+- Typewriter.CodeModel.Helpers public static class:
+  - CamelCase(string)
+  - GetTypeScriptName(ITypeMetadata, Settings)
+  - GetOriginalName(ITypeMetadata)
+  - IsPrimitive(ITypeMetadata)
+- Typewriter.CodeModel.Attributes.ContextAttribute as a compatibility stub for external code that reflects CodeModel context metadata.
+- Original acronym-aware CamelCase behavior. Current `$name` compatibility is lower-first; before changing it, add acronym snapshot coverage for names like URLValue, IPAddress, and XMLDocument.
+- Keep verifying original CodeModel interfaces whenever new public members are copied. The current collection interfaces are already close to original IReadOnlyList<T> + IFilterable behavior.
+```
+
+Recommended implementation order:
+
+```text
+1. Add public Typewriter.CodeModel.Helpers facade backed by current NameCaseFormatter and TypeScriptTypeMapper-compatible logic.
+2. Add a WebApi/service helper extension set for action names, method names, parameter skipping/body selection, and return-type extraction.
+3. Add serializer/model helper extensions for JSON property names, discriminator parsing, and JsonDerivedType/JsonPolymorphic generation.
+4. Add recipe-backed snapshots for each helper family before replacing repeated helper code in external recipe templates.
+5. Add ContextAttribute only as a low-risk compile/reflection compatibility shim unless a real template or package needs more metadata.
+```
+
+## Not Implemented Yet
+
+```text
+- old Typewriter parser/runtime edge cases not yet covered by real recipe snapshots
+- additional external service recipe variants and request/response helper edge cases not yet represented by current samples
+- exact original Typewriter output comparison where original output can be captured
+- shared WebApi/service helper extensions for repeated NetCoreTypewriterRecipes helpers such as MethodName, ReturnType, Imports, SkipParameters, and GetPropertyName
+- original Typewriter.CodeModel.Helpers public facade and optional ContextAttribute compatibility shim
+- template NuGet restore hardening for private-source authentication failures, floating/range version diagnostics, and incompatible asset edge cases
+- full embedded C# and TypeScript IntelliSense inside `.tst` files through virtual documents and language-service forwarding
+- VS Code package publishing
+- Visual Studio VSIX signing/publishing
+- JetBrains Marketplace publishing
+- automated synchronization of repository and package changelogs
+- migration tooling for old templates
+```
+
+## Next Best Development Steps
+
+```text
+1. Finish Milestone 10 publishing work.
+   - add VS Code marketplace packaging/publishing.
+   - add Visual Studio VSIX signing/publishing.
+   - add JetBrains Marketplace publishing.
+   - automate synchronization of repository and package changelogs.
+
+2. Continue compatibility hardening in parallel as new real recipes expose gaps.
+   - Add direct snapshots for additional service template variants under `D:\GitHub\NetCoreTypewriterRecipes`.
+   - Tighten remaining old parser/runtime behaviors where direct recipe snapshots expose gaps.
+   - Keep diagnostics/completions/hover aligned with the renderer's actual supported members.
+
+3. Extend embedded-language IntelliSense beyond the current basic semantic-token and keyword/type completion support.
+   - Map `.tst` regions to virtual C# and TypeScript documents.
+   - Forward embedded-language requests to Roslyn and TypeScript services.
+   - Translate diagnostics, semantic tokens, hovers, completions, and definitions back to `.tst` positions.
+```

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.adaskothebeast.typewriter
 pluginName=Typewriter
-pluginVersion=4.6.1
+pluginVersion=4.7.0
 pluginSinceBuild=261
 platformVersion=2026.1.2
 

--- a/src/Typewriter.Abstractions/ChangedInput.cs
+++ b/src/Typewriter.Abstractions/ChangedInput.cs
@@ -1,0 +1,5 @@
+namespace Typewriter.Abstractions;
+
+public sealed record ChangedInput(
+    string FullPath,
+    ChangedInputKind Kind);

--- a/src/Typewriter.Abstractions/ChangedInputKind.cs
+++ b/src/Typewriter.Abstractions/ChangedInputKind.cs
@@ -1,0 +1,9 @@
+namespace Typewriter.Abstractions;
+
+public enum ChangedInputKind
+{
+    Modified,
+    Added,
+    Deleted,
+    Renamed,
+}

--- a/src/Typewriter.Abstractions/GenerationConfiguration.cs
+++ b/src/Typewriter.Abstractions/GenerationConfiguration.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Typewriter.Abstractions;
+
+public sealed record GenerationConfiguration(string Incremental)
+{
+    public const string IncrementalAuto = "auto";
+    public const string IncrementalOff = "off";
+
+    public static GenerationConfiguration Default { get; } = new(Incremental: IncrementalAuto);
+
+    [JsonIgnore]
+    public bool IsIncrementalEnabled =>
+        !IncrementalOff.Equals(value: Incremental, comparisonType: StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Typewriter.Abstractions/GenerationRequest.cs
+++ b/src/Typewriter.Abstractions/GenerationRequest.cs
@@ -10,4 +10,12 @@ public sealed record GenerationRequest(
     string? TemplateSearchPath = null)
 {
     public bool IncludeDiff { get; init; }
+
+    /// <summary>
+    /// The inputs known to have changed since the previous successful generation.
+    /// <c>null</c> means the provenance is unknown and a full generation is performed.
+    /// A non-null value allows the generator to scope per-source-file rendering to the
+    /// affected files when <see cref="GenerationConfiguration.IsIncrementalEnabled"/> allows it.
+    /// </summary>
+    public IReadOnlyCollection<ChangedInput>? ChangedInputs { get; init; }
 }

--- a/src/Typewriter.Abstractions/MetadataCacheInvalidation.cs
+++ b/src/Typewriter.Abstractions/MetadataCacheInvalidation.cs
@@ -1,0 +1,150 @@
+namespace Typewriter.Abstractions;
+
+/// <summary>
+/// Process-wide dirty-path tracking for the project metadata cache. Hosts that run a
+/// filesystem watcher over every metadata input (for example <c>typewriter watch</c>)
+/// enable tracking and feed changed paths in. Cache entries validated at a version with
+/// no dirty paths marked since then can be accepted without any filesystem access.
+/// Hosts without a watcher leave tracking disabled and cache validation falls back to
+/// the per-file stamp manifest check.
+/// </summary>
+public static class MetadataCacheInvalidation
+{
+    private const int MaxTrackedPaths = 8192;
+    private static readonly Lock Sync = new();
+    private static readonly Dictionary<string, long> DirtyPaths = new(comparer: StringComparer.OrdinalIgnoreCase);
+    private static long _version;
+    private static long _unknownBeforeVersion;
+    private static bool _trackingEnabled;
+
+    public static bool TrackingEnabled
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _trackingEnabled;
+            }
+        }
+    }
+
+    public static long CurrentVersion
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _version;
+            }
+        }
+    }
+
+    public static void EnableTracking()
+    {
+        lock (Sync)
+        {
+            if (_trackingEnabled)
+            {
+                return;
+            }
+
+            _trackingEnabled = true;
+            _version++;
+            _unknownBeforeVersion = _version;
+            DirtyPaths.Clear();
+        }
+    }
+
+    public static void MarkDirty(string fullPath)
+    {
+        if (string.IsNullOrWhiteSpace(value: fullPath))
+        {
+            return;
+        }
+
+        string normalizedPath;
+        try
+        {
+            normalizedPath = Path.GetFullPath(path: fullPath);
+        }
+        catch (ArgumentException)
+        {
+            return;
+        }
+        catch (NotSupportedException)
+        {
+            return;
+        }
+        catch (PathTooLongException)
+        {
+            return;
+        }
+
+        lock (Sync)
+        {
+            if (!_trackingEnabled)
+            {
+                return;
+            }
+
+            _version++;
+            if (DirtyPaths.Count >= MaxTrackedPaths)
+            {
+                DirtyPaths.Clear();
+                _unknownBeforeVersion = _version;
+                return;
+            }
+
+            DirtyPaths[key: normalizedPath] = _version;
+        }
+    }
+
+    public static void MarkAllDirty()
+    {
+        lock (Sync)
+        {
+            _version++;
+            _unknownBeforeVersion = _version;
+            DirtyPaths.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Returns the paths marked dirty after <paramref name="sinceVersion"/>, or <c>null</c>
+    /// when tracking cannot answer (tracking disabled, tracking started after the entry
+    /// was validated, or the tracked set overflowed) and a full manifest check is required.
+    /// </summary>
+    /// <param name="sinceVersion">The version the cache entry was last validated at.</param>
+    /// <returns>The dirty paths, an empty list when nothing changed, or <c>null</c> when unknown.</returns>
+    public static IReadOnlyList<string>? GetDirtySince(long sinceVersion)
+    {
+        lock (Sync)
+        {
+            if (!_trackingEnabled || sinceVersion < _unknownBeforeVersion)
+            {
+                return null;
+            }
+
+            if (sinceVersion >= _version)
+            {
+                return [];
+            }
+
+            return DirtyPaths
+                .Where(predicate: pair => pair.Value > sinceVersion)
+                .Select(selector: pair => pair.Key)
+                .ToArray();
+        }
+    }
+
+    public static void Reset()
+    {
+        lock (Sync)
+        {
+            _trackingEnabled = false;
+            _version++;
+            _unknownBeforeVersion = _version;
+            DirtyPaths.Clear();
+        }
+    }
+}

--- a/src/Typewriter.Abstractions/MetadataCacheMetrics.cs
+++ b/src/Typewriter.Abstractions/MetadataCacheMetrics.cs
@@ -1,0 +1,206 @@
+using System.Globalization;
+
+namespace Typewriter.Abstractions;
+
+/// <summary>
+/// Process-wide counters describing project metadata cache behavior. Reported through
+/// the generation performance trace when <c>TYPEWRITER_TRACE_PERF</c> is enabled.
+/// </summary>
+public static class MetadataCacheMetrics
+{
+    private static readonly Lock Sync = new();
+    private static long _cacheHits;
+    private static long _cacheMisses;
+    private static long _statValidatedHits;
+    private static long _dirtyValidatedHits;
+    private static long _sourceOnlyRebuilds;
+    private static long _fullLoads;
+    private static long _parsedSourceFiles;
+    private static long _reusedSyntaxTrees;
+    private static string? _lastInvalidationReason;
+
+    public static long CacheHits
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _cacheHits;
+            }
+        }
+    }
+
+    public static long CacheMisses
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _cacheMisses;
+            }
+        }
+    }
+
+    public static long StatValidatedHits
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _statValidatedHits;
+            }
+        }
+    }
+
+    public static long DirtyValidatedHits
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _dirtyValidatedHits;
+            }
+        }
+    }
+
+    public static long SourceOnlyRebuilds
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _sourceOnlyRebuilds;
+            }
+        }
+    }
+
+    public static long FullLoads
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _fullLoads;
+            }
+        }
+    }
+
+    public static long ParsedSourceFiles
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _parsedSourceFiles;
+            }
+        }
+    }
+
+    public static long ReusedSyntaxTrees
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _reusedSyntaxTrees;
+            }
+        }
+    }
+
+    public static string? LastInvalidationReason
+    {
+        get
+        {
+            lock (Sync)
+            {
+                return _lastInvalidationReason;
+            }
+        }
+    }
+
+    public static void RecordCacheHit(bool dirtyValidated)
+    {
+        lock (Sync)
+        {
+            _cacheHits++;
+            if (dirtyValidated)
+            {
+                _dirtyValidatedHits++;
+            }
+            else
+            {
+                _statValidatedHits++;
+            }
+        }
+    }
+
+    public static void RecordCacheMiss(string? reason)
+    {
+        lock (Sync)
+        {
+            _cacheMisses++;
+            if (!string.IsNullOrWhiteSpace(value: reason))
+            {
+                _lastInvalidationReason = reason;
+            }
+        }
+    }
+
+    public static void RecordSourceOnlyRebuild()
+    {
+        lock (Sync)
+        {
+            _sourceOnlyRebuilds++;
+        }
+    }
+
+    public static void RecordFullLoad()
+    {
+        lock (Sync)
+        {
+            _fullLoads++;
+        }
+    }
+
+    public static void RecordParsedSourceFile()
+    {
+        lock (Sync)
+        {
+            _parsedSourceFiles++;
+        }
+    }
+
+    public static void RecordReusedSyntaxTree()
+    {
+        lock (Sync)
+        {
+            _reusedSyntaxTrees++;
+        }
+    }
+
+    public static string CreateSummary()
+    {
+        lock (Sync)
+        {
+            return string.Create(
+                provider: CultureInfo.InvariantCulture,
+                handler: $"hits={_cacheHits} (stat={_statValidatedHits}, dirty={_dirtyValidatedHits}), misses={_cacheMisses}, source-only-rebuilds={_sourceOnlyRebuilds}, full-loads={_fullLoads}, parsed-files={_parsedSourceFiles}, reused-trees={_reusedSyntaxTrees}, last-invalidation={_lastInvalidationReason ?? "none"}");
+        }
+    }
+
+    public static void Reset()
+    {
+        lock (Sync)
+        {
+            _cacheHits = 0;
+            _cacheMisses = 0;
+            _statValidatedHits = 0;
+            _dirtyValidatedHits = 0;
+            _sourceOnlyRebuilds = 0;
+            _fullLoads = 0;
+            _parsedSourceFiles = 0;
+            _reusedSyntaxTrees = 0;
+            _lastInvalidationReason = null;
+        }
+    }
+}

--- a/src/Typewriter.Abstractions/TypewriterConfiguration.cs
+++ b/src/Typewriter.Abstractions/TypewriterConfiguration.cs
@@ -8,6 +8,8 @@ public sealed record TypewriterConfiguration(
     OutputConfiguration Output,
     DiagnosticsConfiguration Diagnostics)
 {
+    public GenerationConfiguration Generation { get; init; } = GenerationConfiguration.Default;
+
     public static IReadOnlyList<string> DefaultInputExtensions { get; } =
     [
         ".cs",

--- a/src/Typewriter.Cli/CliCommandLine.cs
+++ b/src/Typewriter.Cli/CliCommandLine.cs
@@ -95,6 +95,7 @@ internal static class CliCommandLine
 
     private sealed class CliOptionSet
     {
+#pragma warning disable S107
         private CliOptionSet(
             Option<string?> workspace,
             Option<string?> project,
@@ -105,7 +106,9 @@ internal static class CliCommandLine
             Option<bool> dryRun,
             Option<bool> failOnWarning,
             Option<bool> allProjects,
-            Option<bool> diff)
+            Option<bool> diff,
+            Option<string[]> changed)
+#pragma warning restore S107
         {
             Workspace = workspace;
             Project = project;
@@ -117,6 +120,7 @@ internal static class CliCommandLine
             FailOnWarning = failOnWarning;
             AllProjects = allProjects;
             Diff = diff;
+            Changed = changed;
         }
 
         private Option<string?> Workspace { get; }
@@ -138,6 +142,8 @@ internal static class CliCommandLine
         private Option<bool> AllProjects { get; }
 
         private Option<bool> Diff { get; }
+
+        private Option<string[]> Changed { get; }
 
         public static CliOptionSet Create()
         {
@@ -185,6 +191,10 @@ internal static class CliCommandLine
                 diff: new Option<bool>(name: "--diff")
                 {
                     Description = "Include unified diffs for changed files in the output.",
+                },
+                changed: new Option<string[]>(name: "--changed")
+                {
+                    Description = "Path of an input file changed since the previous generation. May be repeated. When every changed input is a C# source file, only the affected outputs are re-rendered.",
                 });
         }
 
@@ -200,6 +210,7 @@ internal static class CliCommandLine
             command.Options.Add(item: FailOnWarning);
             command.Options.Add(item: AllProjects);
             command.Options.Add(item: Diff);
+            command.Options.Add(item: Changed);
         }
 
         public CliOptions CreateOptions(
@@ -218,6 +229,9 @@ internal static class CliCommandLine
                 AllProjects: parseResult.GetValue(option: AllProjects),
                 Diff: parseResult.GetValue(option: Diff),
                 Force: false,
-                Help: false);
+                Help: false)
+            {
+                ChangedPaths = parseResult.GetValue(option: Changed) ?? [],
+            };
     }
 }

--- a/src/Typewriter.Cli/CliOptions.cs
+++ b/src/Typewriter.Cli/CliOptions.cs
@@ -15,6 +15,8 @@ internal sealed record CliOptions(
     bool Force,
     bool Help)
 {
+    public IReadOnlyList<string> ChangedPaths { get; init; } = [];
+
     public static CliOptions Default { get; } = new(
         Command: CliCommand.Generate,
         WorkspacePath: null,

--- a/src/Typewriter.Cli/FileSystemGenerationWatcher.cs
+++ b/src/Typewriter.Cli/FileSystemGenerationWatcher.cs
@@ -274,6 +274,7 @@ internal sealed class FileSystemGenerationWatcher : IDisposable
 
     private void MarkChangedInputsOverflowed()
     {
+        MetadataCacheInvalidation.MarkAllDirty();
         lock (_sync)
         {
             _changedInputsOverflowed = true;

--- a/src/Typewriter.Cli/FileSystemGenerationWatcher.cs
+++ b/src/Typewriter.Cli/FileSystemGenerationWatcher.cs
@@ -4,9 +4,12 @@ namespace Typewriter.Cli;
 
 internal sealed class FileSystemGenerationWatcher : IDisposable
 {
+    private const int MaxTrackedChangedInputs = 4096;
     private readonly Lock _sync = new();
     private readonly FileSystemWatcher[] _watchers;
     private readonly HashSet<string> _watchedExtensions;
+    private readonly Dictionary<string, ChangedInputKind> _changedInputs = new(comparer: StringComparer.OrdinalIgnoreCase);
+    private bool _changedInputsOverflowed;
     private TaskCompletionSource _changeSignal = CreateSignal();
 
     private FileSystemGenerationWatcher(
@@ -53,6 +56,36 @@ internal sealed class FileSystemGenerationWatcher : IDisposable
         while (IsSignaled());
     }
 
+    /// <summary>
+    /// Returns the inputs changed since the previous drain and clears the accumulated set.
+    /// Returns <c>null</c> when the provenance is unknown (no change recorded yet, the
+    /// tracked set overflowed, or a watcher error occurred) and a full generation is required.
+    /// </summary>
+    /// <returns>The changed inputs, or <c>null</c> when a full generation is required.</returns>
+    public IReadOnlyCollection<ChangedInput>? DrainChangedInputs()
+    {
+        lock (_sync)
+        {
+            if (_changedInputsOverflowed)
+            {
+                _changedInputsOverflowed = false;
+                _changedInputs.Clear();
+                return null;
+            }
+
+            if (_changedInputs.Count == 0)
+            {
+                return null;
+            }
+
+            var drained = _changedInputs
+                .Select(selector: pair => new ChangedInput(FullPath: pair.Key, Kind: pair.Value))
+                .ToArray();
+            _changedInputs.Clear();
+            return drained;
+        }
+    }
+
     private static IEnumerable<string> ResolveWatchRoots(CliOptions options)
     {
         var roots = new[]
@@ -94,6 +127,14 @@ internal sealed class FileSystemGenerationWatcher : IDisposable
 
     private static TaskCompletionSource CreateSignal() =>
         new(creationOptions: TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private static ChangedInputKind MapChangedInputKind(WatcherChangeTypes changeType) =>
+        changeType switch
+        {
+            WatcherChangeTypes.Created => ChangedInputKind.Added,
+            WatcherChangeTypes.Deleted => ChangedInputKind.Deleted,
+            _ => ChangedInputKind.Modified,
+        };
 
     private bool ShouldWatchPath(string path)
     {
@@ -143,7 +184,20 @@ internal sealed class FileSystemGenerationWatcher : IDisposable
         object sender,
         RenamedEventArgs args)
     {
-        if (ShouldWatchPath(path: args.FullPath) || ShouldWatchPath(path: args.OldFullPath))
+        var signal = false;
+        if (ShouldWatchPath(path: args.OldFullPath))
+        {
+            RecordChange(path: args.OldFullPath, kind: ChangedInputKind.Renamed);
+            signal = true;
+        }
+
+        if (ShouldWatchPath(path: args.FullPath))
+        {
+            RecordChange(path: args.FullPath, kind: ChangedInputKind.Renamed);
+            signal = true;
+        }
+
+        if (signal)
         {
             Signal();
         }
@@ -155,14 +209,77 @@ internal sealed class FileSystemGenerationWatcher : IDisposable
     {
         if (ShouldWatchPath(path: args.FullPath))
         {
+            RecordChange(path: args.FullPath, kind: MapChangedInputKind(changeType: args.ChangeType));
             Signal();
         }
     }
 
     private void OnWatcherError(
         object sender,
-        ErrorEventArgs args) =>
+        ErrorEventArgs args)
+    {
+        MetadataCacheInvalidation.MarkAllDirty();
+        lock (_sync)
+        {
+            _changedInputsOverflowed = true;
+            _changedInputs.Clear();
+        }
+
         Signal();
+    }
+
+    private void RecordChange(
+        string path,
+        ChangedInputKind kind)
+    {
+        string fullPath;
+        try
+        {
+            fullPath = Path.GetFullPath(path: path);
+        }
+        catch (ArgumentException)
+        {
+            MarkChangedInputsOverflowed();
+            return;
+        }
+        catch (NotSupportedException)
+        {
+            MarkChangedInputsOverflowed();
+            return;
+        }
+        catch (PathTooLongException)
+        {
+            MarkChangedInputsOverflowed();
+            return;
+        }
+
+        MetadataCacheInvalidation.MarkDirty(fullPath: fullPath);
+        lock (_sync)
+        {
+            if (_changedInputsOverflowed)
+            {
+                return;
+            }
+
+            if (_changedInputs.Count >= MaxTrackedChangedInputs && !_changedInputs.ContainsKey(key: fullPath))
+            {
+                _changedInputsOverflowed = true;
+                _changedInputs.Clear();
+                return;
+            }
+
+            _changedInputs[key: fullPath] = kind;
+        }
+    }
+
+    private void MarkChangedInputsOverflowed()
+    {
+        lock (_sync)
+        {
+            _changedInputsOverflowed = true;
+            _changedInputs.Clear();
+        }
+    }
 
     private void Signal()
     {

--- a/src/Typewriter.Cli/TypewriterCli.cs
+++ b/src/Typewriter.Cli/TypewriterCli.cs
@@ -89,20 +89,61 @@ internal static class TypewriterCli
         var result = await GenerateOnceAsync(
             options: options,
             generator: CreateGenerator(),
+            changedInputs: CreateChangedInputs(changedPaths: options.ChangedPaths),
             cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
         WriteResult(result: result, output: options.Output);
         return GetExitCode(result: result);
+    }
+
+    private static IReadOnlyCollection<ChangedInput>? CreateChangedInputs(IReadOnlyList<string> changedPaths)
+    {
+        if (changedPaths.Count == 0)
+        {
+            return null;
+        }
+
+        var changedInputs = new List<ChangedInput>(capacity: changedPaths.Count);
+        foreach (var changedPath in changedPaths)
+        {
+            string fullPath;
+            try
+            {
+                fullPath = Path.GetFullPath(path: changedPath);
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+            catch (NotSupportedException)
+            {
+                return null;
+            }
+            catch (PathTooLongException)
+            {
+                return null;
+            }
+
+            changedInputs.Add(
+                item: new ChangedInput(
+                    FullPath: fullPath,
+                    Kind: File.Exists(path: fullPath) ? ChangedInputKind.Modified : ChangedInputKind.Deleted));
+        }
+
+        return changedInputs;
     }
 
     private static async Task<int> WatchAsync(
         CliOptions options,
         CancellationToken cancellationToken)
     {
+        var resetMetadataTracking = false;
         try
         {
             var configuration = await CreateConfigurationAsync(options: options, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             var generator = CreateGenerator();
             using var watcher = FileSystemGenerationWatcher.Create(options: options, configuration: configuration);
+            MetadataCacheInvalidation.EnableTracking();
+            resetMetadataTracking = true;
             await RunWatchedGenerationAsync(
                 options: options,
                 watcher: watcher,
@@ -123,6 +164,13 @@ internal static class TypewriterCli
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             return 0;
+        }
+        finally
+        {
+            if (resetMetadataTracking)
+            {
+                MetadataCacheInvalidation.Reset();
+            }
         }
 
         return 0;
@@ -145,6 +193,7 @@ internal static class TypewriterCli
                 await GenerateAndWriteAsync(
                     options: options,
                     generator: generator,
+                    changedInputs: watcher.DrainChangedInputs(),
                     cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             }
             finally
@@ -173,11 +222,13 @@ internal static class TypewriterCli
     private static async Task GenerateAndWriteAsync(
         CliOptions options,
         TypewriterGenerator generator,
+        IReadOnlyCollection<ChangedInput>? changedInputs,
         CancellationToken cancellationToken)
     {
         var result = await GenerateOnceAsync(
             options: options,
             generator: generator,
+            changedInputs: changedInputs,
             cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
         WriteResult(result: result, output: options.Output);
     }
@@ -185,6 +236,7 @@ internal static class TypewriterCli
     private static async Task<GenerationResult> GenerateOnceAsync(
         CliOptions options,
         TypewriterGenerator generator,
+        IReadOnlyCollection<ChangedInput>? changedInputs,
         CancellationToken cancellationToken)
     {
         var configuration = await CreateConfigurationAsync(options: options, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
@@ -198,6 +250,7 @@ internal static class TypewriterCli
             TemplateSearchPath: options.TemplateSearchPath)
         {
             IncludeDiff = options.Diff,
+            ChangedInputs = changedInputs,
         };
 
         return await generator.GenerateAsync(request: request, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);

--- a/src/Typewriter.Engine/ProjectMetadataIndex.cs
+++ b/src/Typewriter.Engine/ProjectMetadataIndex.cs
@@ -4,7 +4,10 @@ namespace Typewriter.Engine;
 
 internal sealed class ProjectMetadataIndex
 {
+    private readonly Lazy<SourceFileDependencyIndex> _dependencyIndex;
+
     private ProjectMetadataIndex(
+        ProjectMetadata metadata,
         IReadOnlyDictionary<string, TypeMetadata> typesByFullName,
         IReadOnlyDictionary<string, MethodMetadata> methodsByFullName,
         IReadOnlyDictionary<string, PropertyMetadata> propertiesByFullName)
@@ -12,6 +15,9 @@ internal sealed class ProjectMetadataIndex
         TypesByFullName = typesByFullName;
         MethodsByFullName = methodsByFullName;
         PropertiesByFullName = propertiesByFullName;
+        _dependencyIndex = new Lazy<SourceFileDependencyIndex>(
+            valueFactory: () => SourceFileDependencyIndex.Build(metadata: metadata),
+            mode: LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     public IReadOnlyDictionary<string, TypeMetadata> TypesByFullName { get; }
@@ -25,6 +31,7 @@ internal sealed class ProjectMetadataIndex
         ArgumentNullException.ThrowIfNull(argument: metadata);
 
         return new ProjectMetadataIndex(
+            metadata: metadata,
             typesByFullName: metadata.Types
                 .GroupBy(keySelector: type => type.FullName, comparer: StringComparer.Ordinal)
                 .ToDictionary(keySelector: group => group.Key, elementSelector: group => group.First(), comparer: StringComparer.Ordinal),
@@ -36,5 +43,262 @@ internal sealed class ProjectMetadataIndex
                 .SelectMany(selector: type => type.Properties)
                 .GroupBy(keySelector: property => property.FullName, comparer: StringComparer.Ordinal)
                 .ToDictionary(keySelector: group => group.Key, elementSelector: group => group.First(), comparer: StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// Computes the transitive closure of source files affected by the changed source
+    /// files: every changed file plus every file whose declared types reference a type
+    /// declared in an affected file. Paths not tracked by this project are ignored.
+    /// </summary>
+    /// <param name="changedSourcePaths">The full paths of the changed source files.</param>
+    /// <returns>The full paths of the affected source files (case-insensitive set).</returns>
+    public IReadOnlyCollection<string> GetAffectedSourceFiles(IReadOnlyCollection<string> changedSourcePaths)
+    {
+        ArgumentNullException.ThrowIfNull(argument: changedSourcePaths);
+
+        return _dependencyIndex.Value.GetAffectedSourceFiles(changedSourcePaths: changedSourcePaths);
+    }
+
+    private sealed class SourceFileDependencyIndex
+    {
+        private readonly IReadOnlyDictionary<string, HashSet<string>> _declaredTypesBySourceFile;
+        private readonly IReadOnlyDictionary<string, HashSet<string>> _referencedTypesBySourceFile;
+
+        private SourceFileDependencyIndex(
+            IReadOnlyDictionary<string, HashSet<string>> declaredTypesBySourceFile,
+            IReadOnlyDictionary<string, HashSet<string>> referencedTypesBySourceFile)
+        {
+            _declaredTypesBySourceFile = declaredTypesBySourceFile;
+            _referencedTypesBySourceFile = referencedTypesBySourceFile;
+        }
+
+        public static SourceFileDependencyIndex Build(ProjectMetadata metadata)
+        {
+            var declaredTypesBySourceFile = new Dictionary<string, HashSet<string>>(comparer: StringComparer.OrdinalIgnoreCase);
+            var referencedTypesBySourceFile = new Dictionary<string, HashSet<string>>(comparer: StringComparer.OrdinalIgnoreCase);
+            foreach (var sourceFile in metadata.SourceFiles)
+            {
+                var declaredTypes = new HashSet<string>(comparer: StringComparer.Ordinal);
+                var referencedTypes = new HashSet<string>(comparer: StringComparer.Ordinal);
+                var visitedReferences = new HashSet<object>(comparer: ReferenceEqualityComparer.Instance);
+                foreach (var type in sourceFile.Types)
+                {
+                    CollectType(type: type, declaredTypes: declaredTypes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                }
+
+                foreach (var delegateMetadata in sourceFile.Delegates)
+                {
+                    _ = declaredTypes.Add(item: delegateMetadata.FullName);
+                    CollectDelegate(delegateMetadata: delegateMetadata, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                }
+
+                var sourcePath = sourceFile.Path;
+                declaredTypesBySourceFile[key: sourcePath] = declaredTypes;
+                referencedTypesBySourceFile[key: sourcePath] = referencedTypes;
+            }
+
+            return new SourceFileDependencyIndex(
+                declaredTypesBySourceFile: declaredTypesBySourceFile,
+                referencedTypesBySourceFile: referencedTypesBySourceFile);
+        }
+
+        public IReadOnlyCollection<string> GetAffectedSourceFiles(IReadOnlyCollection<string> changedSourcePaths)
+        {
+            var affectedFiles = new HashSet<string>(comparer: StringComparer.OrdinalIgnoreCase);
+            var dirtyTypes = new HashSet<string>(comparer: StringComparer.Ordinal);
+            foreach (var changedPath in changedSourcePaths)
+            {
+                if (_declaredTypesBySourceFile.TryGetValue(key: changedPath, value: out var declaredTypes)
+                    && affectedFiles.Add(item: changedPath))
+                {
+                    dirtyTypes.UnionWith(other: declaredTypes);
+                }
+            }
+
+            var expanded = affectedFiles.Count > 0;
+            while (expanded)
+            {
+                expanded = false;
+                foreach (var pair in _referencedTypesBySourceFile)
+                {
+                    if (affectedFiles.Contains(item: pair.Key) || !pair.Value.Overlaps(other: dirtyTypes))
+                    {
+                        continue;
+                    }
+
+                    _ = affectedFiles.Add(item: pair.Key);
+                    if (_declaredTypesBySourceFile.TryGetValue(key: pair.Key, value: out var declaredTypes))
+                    {
+                        dirtyTypes.UnionWith(other: declaredTypes);
+                    }
+
+                    expanded = true;
+                }
+            }
+
+            return affectedFiles;
+        }
+
+        private static void CollectType(
+            TypeMetadata type,
+            ISet<string> declaredTypes,
+            ISet<string> referencedTypes,
+            ISet<object> visitedReferences)
+        {
+            _ = declaredTypes.Add(item: type.FullName);
+            CollectReferences(references: type.BaseTypes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            CollectReferences(references: type.TypeArguments, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            CollectAttributes(attributes: type.Attributes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            CollectMembers(type: type, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            foreach (var delegateMetadata in type.Delegates)
+            {
+                _ = declaredTypes.Add(item: delegateMetadata.FullName);
+                CollectDelegate(delegateMetadata: delegateMetadata, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            }
+
+            foreach (var nestedType in EnumerateNestedTypes(type: type))
+            {
+                CollectType(type: nestedType, declaredTypes: declaredTypes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            }
+        }
+
+        private static IEnumerable<TypeMetadata> EnumerateNestedTypes(TypeMetadata type) =>
+            type.NestedClasses
+                .Concat(second: type.NestedRecords)
+                .Concat(second: type.NestedStructs)
+                .Concat(second: type.NestedEnums)
+                .Concat(second: type.NestedInterfaces);
+
+        private static void CollectMembers(
+            TypeMetadata type,
+            ISet<string> referencedTypes,
+            ISet<object> visitedReferences)
+        {
+            foreach (var property in type.Properties)
+            {
+                CollectReference(reference: property.Type, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                CollectAttributes(attributes: property.Attributes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                CollectParameters(parameters: property.Parameters, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            }
+
+            foreach (var method in type.Methods)
+            {
+                CollectReference(reference: method.ReturnType, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                CollectAttributes(attributes: method.Attributes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                CollectParameters(parameters: method.Parameters, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            }
+
+            foreach (var constant in type.Constants)
+            {
+                CollectReference(reference: constant.Type, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                CollectAttributes(attributes: constant.Attributes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            }
+
+            foreach (var field in type.Fields)
+            {
+                CollectReference(reference: field.Type, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                CollectAttributes(attributes: field.Attributes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            }
+
+            foreach (var staticReadOnlyField in type.StaticReadOnlyFields)
+            {
+                CollectReference(reference: staticReadOnlyField.Type, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                CollectAttributes(attributes: staticReadOnlyField.Attributes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            }
+
+            foreach (var @event in type.Events)
+            {
+                CollectReference(reference: @event.Type, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                CollectAttributes(attributes: @event.Attributes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            }
+        }
+
+        private static void CollectDelegate(
+            DelegateMetadata delegateMetadata,
+            ISet<string> referencedTypes,
+            ISet<object> visitedReferences)
+        {
+            CollectReference(reference: delegateMetadata.ReturnType, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            CollectAttributes(attributes: delegateMetadata.Attributes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            CollectParameters(parameters: delegateMetadata.Parameters, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+        }
+
+        private static void CollectParameters(
+            IReadOnlyList<ParameterMetadata> parameters,
+            ISet<string> referencedTypes,
+            ISet<object> visitedReferences)
+        {
+            foreach (var parameter in parameters)
+            {
+                CollectReference(reference: parameter.Type, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                CollectAttributes(attributes: parameter.Attributes, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            }
+        }
+
+        private static void CollectAttributes(
+            IReadOnlyList<AttributeMetadata> attributes,
+            ISet<string> referencedTypes,
+            ISet<object> visitedReferences)
+        {
+            foreach (var attribute in attributes)
+            {
+                _ = referencedTypes.Add(item: attribute.FullName);
+                CollectReference(reference: attribute.Type, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                foreach (var argument in attribute.Arguments)
+                {
+                    CollectReference(reference: argument.Type, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                    CollectReference(reference: argument.TypeValue, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+                }
+            }
+        }
+
+        private static void CollectReferences(
+            IReadOnlyList<TypeMetadataReference> references,
+            ISet<string> referencedTypes,
+            ISet<object> visitedReferences)
+        {
+            foreach (var reference in references)
+            {
+                CollectReference(reference: reference, referencedTypes: referencedTypes, visitedReferences: visitedReferences);
+            }
+        }
+
+        private static void CollectReference(
+            TypeMetadataReference? reference,
+            ISet<string> referencedTypes,
+            ISet<object> visitedReferences)
+        {
+            if (reference is null)
+            {
+                return;
+            }
+
+            var pending = new Stack<TypeMetadataReference>();
+            pending.Push(item: reference);
+            while (pending.Count > 0)
+            {
+                var current = pending.Pop();
+                if (!visitedReferences.Add(item: current))
+                {
+                    continue;
+                }
+
+                _ = referencedTypes.Add(item: current.FullName);
+                if (current.ElementType is not null)
+                {
+                    pending.Push(item: current.ElementType);
+                }
+
+                foreach (var typeArgument in current.TypeArguments)
+                {
+                    pending.Push(item: typeArgument);
+                }
+
+                foreach (var tupleElement in current.TupleElements)
+                {
+                    pending.Push(item: tupleElement.Type);
+                }
+            }
+        }
     }
 }

--- a/src/Typewriter.Engine/TemplateReferenceResolver.cs
+++ b/src/Typewriter.Engine/TemplateReferenceResolver.cs
@@ -387,9 +387,7 @@ internal sealed class TemplateReferenceResolver
         {
             StartInfo = new ProcessStartInfo
             {
-#pragma warning disable S4036
-                FileName = "dotnet",
-#pragma warning restore S4036
+                FileName = dotNetPath,
                 WorkingDirectory = _templateDirectory,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,

--- a/src/Typewriter.Engine/TemplateReferenceResolver.cs
+++ b/src/Typewriter.Engine/TemplateReferenceResolver.cs
@@ -387,7 +387,9 @@ internal sealed class TemplateReferenceResolver
         {
             StartInfo = new ProcessStartInfo
             {
-                FileName = dotNetPath,
+#pragma warning disable S4036
+                FileName = "dotnet",
+#pragma warning restore S4036
                 WorkingDirectory = _templateDirectory,
                 UseShellExecute = false,
                 RedirectStandardOutput = true,

--- a/src/Typewriter.Engine/TypewriterConfigurationLoader.cs
+++ b/src/Typewriter.Engine/TypewriterConfigurationLoader.cs
@@ -127,7 +127,29 @@ public static class TypewriterConfigurationLoader
             {
                 FailOnWarning = loaded.Diagnostics?.FailOnWarning ?? current.Diagnostics.FailOnWarning,
             },
+            Generation = current.Generation with
+            {
+                Incremental = NormalizeIncremental(incremental: loaded.Generation?.Incremental) ?? current.Generation.Incremental,
+            },
         };
+    }
+
+    private static string? NormalizeIncremental(string? incremental)
+    {
+        if (string.IsNullOrWhiteSpace(value: incremental))
+        {
+            return null;
+        }
+
+        var trimmed = incremental.Trim();
+        if (trimmed.Equals(value: GenerationConfiguration.IncrementalOff, comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            return GenerationConfiguration.IncrementalOff;
+        }
+
+        return trimmed.Equals(value: GenerationConfiguration.IncrementalAuto, comparisonType: StringComparison.OrdinalIgnoreCase)
+            ? GenerationConfiguration.IncrementalAuto
+            : null;
     }
 
     private static TypewriterConfiguration ApplyEnvironment(TypewriterConfiguration configuration)
@@ -222,6 +244,8 @@ public static class TypewriterConfigurationLoader
         public OutputConfigurationFile? Output { get; init; }
 
         public DiagnosticsConfigurationFile? Diagnostics { get; init; }
+
+        public GenerationConfigurationFile? Generation { get; init; }
     }
 
     internal sealed record OutputConfigurationFile
@@ -268,5 +292,10 @@ public static class TypewriterConfigurationLoader
     internal sealed record DiagnosticsConfigurationFile
     {
         public bool? FailOnWarning { get; init; }
+    }
+
+    internal sealed record GenerationConfigurationFile
+    {
+        public string? Incremental { get; init; }
     }
 }

--- a/src/Typewriter.Engine/TypewriterGenerator.cs
+++ b/src/Typewriter.Engine/TypewriterGenerator.cs
@@ -70,6 +70,7 @@ public sealed class TypewriterGenerator : ITypewriterGenerator
             configuration: request.Configuration,
             solutionFullName: ResolveSolutionFullName(workspaceRootPath: workspace.RootPath));
         performanceTrace.Add(stage: "Render default resolution", elapsed: defaultsStopwatch.Elapsed);
+        var incrementalChangedSourcePaths = ResolveIncrementalChangedSourcePaths(request: request);
         foreach (var projectPath in projectPaths)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -79,6 +80,7 @@ public sealed class TypewriterGenerator : ITypewriterGenerator
                 templateWorkspace: CreateProjectWorkspace(request: request, workspace: workspace, projectPath: projectPath, projectCount: projectPaths.Count),
                 projectPath: projectPath,
                 renderDefaults: renderDefaults,
+                incrementalChangedSourcePaths: incrementalChangedSourcePaths,
                 diagnostics: diagnostics,
                 generatedFiles: generatedFiles,
                 plannedOutputPaths: plannedOutputPaths,
@@ -141,6 +143,77 @@ public sealed class TypewriterGenerator : ITypewriterGenerator
         return template.OutputPath is null
             && inspection?.IsSingleFileMode != true
             && project.SourceFiles.Any(predicate: sourceFile => sourceFile.Types.Count > 0);
+    }
+
+    /// <summary>
+    /// Resolves the changed source-file paths usable for incremental per-source-file
+    /// rendering. Returns <c>null</c> when a full generation is required: unknown
+    /// provenance, incremental generation disabled, validation mode, deleted or renamed
+    /// inputs, or any changed input that is not a C# source file (templates, project
+    /// files, configuration, and other shape inputs always trigger a full generation).
+    /// </summary>
+    /// <param name="request">The generation request.</param>
+    /// <returns>The full paths of the changed source files, or <c>null</c>.</returns>
+    private static IReadOnlyCollection<string>? ResolveIncrementalChangedSourcePaths(GenerationRequest request)
+    {
+        if (request.ChangedInputs is null
+            || request.ChangedInputs.Count == 0
+            || request.Mode != GenerationMode.Generate
+            || !request.Configuration.Generation.IsIncrementalEnabled)
+        {
+            return null;
+        }
+
+        var changedSourcePaths = new HashSet<string>(comparer: StringComparer.OrdinalIgnoreCase);
+        foreach (var changedInput in request.ChangedInputs)
+        {
+            if (changedInput.Kind is ChangedInputKind.Deleted or ChangedInputKind.Renamed
+                || !Path.GetExtension(path: changedInput.FullPath).Equals(value: ".cs", comparisonType: StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            try
+            {
+                _ = changedSourcePaths.Add(item: Path.GetFullPath(path: changedInput.FullPath));
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+            catch (NotSupportedException)
+            {
+                return null;
+            }
+            catch (PathTooLongException)
+            {
+                return null;
+            }
+        }
+
+        return changedSourcePaths;
+    }
+
+    private static IReadOnlyList<SourceFileRenderContext> FilterSourceFileRenderContexts(
+        IReadOnlyList<SourceFileRenderContext> renderContexts,
+        ProjectMetadataIndex metadataIndex,
+        IReadOnlyCollection<string>? incrementalChangedSourcePaths)
+    {
+        if (incrementalChangedSourcePaths is null || renderContexts.Count == 0)
+        {
+            return renderContexts;
+        }
+
+        var affectedSourceFiles = metadataIndex.GetAffectedSourceFiles(changedSourcePaths: incrementalChangedSourcePaths);
+        if (affectedSourceFiles.Count == 0)
+        {
+            return [];
+        }
+
+        var affectedSourceFileSet = new HashSet<string>(collection: affectedSourceFiles, comparer: StringComparer.OrdinalIgnoreCase);
+        return renderContexts
+            .Where(predicate: renderContext => affectedSourceFileSet.Contains(item: renderContext.SourceFile.Path))
+            .ToArray();
     }
 
     private static bool RequiresSingleFileModeInspection(TemplateDocument template) =>
@@ -376,6 +449,7 @@ public sealed class TypewriterGenerator : ITypewriterGenerator
         WorkspaceContext templateWorkspace,
         string projectPath,
         TemplateRenderDefaults renderDefaults,
+        IReadOnlyCollection<string>? incrementalChangedSourcePaths,
         ICollection<GenerationDiagnostic> diagnostics,
         ICollection<GeneratedFile> generatedFiles,
         IDictionary<string, string> plannedOutputPaths,
@@ -505,6 +579,10 @@ public sealed class TypewriterGenerator : ITypewriterGenerator
                         renderContexts = CreateSourceFileRenderContexts(project: templateProject, metadataIndex: templateIndex);
                     }
 
+                    renderContexts = FilterSourceFileRenderContexts(
+                        renderContexts: renderContexts,
+                        metadataIndex: templateIndex,
+                        incrementalChangedSourcePaths: incrementalChangedSourcePaths);
                     foreach (var sourceContext in renderContexts)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
@@ -762,6 +840,15 @@ public sealed class TypewriterGenerator : ITypewriterGenerator
                             handler: $"{entry.Stage}: {entry.Elapsed.TotalMilliseconds:F1} ms"),
                         Code: "TWPERF"));
             }
+
+            diagnostics.Add(
+                item: new GenerationDiagnostic(
+                    File: file,
+                    Line: null,
+                    Column: null,
+                    Severity: DiagnosticSeverity.Info,
+                    Message: "Metadata cache: " + MetadataCacheMetrics.CreateSummary(),
+                    Code: "TWPERF"));
         }
     }
 

--- a/src/Typewriter.LanguageServer/LanguageServerHost.cs
+++ b/src/Typewriter.LanguageServer/LanguageServerHost.cs
@@ -100,7 +100,7 @@ internal sealed class LanguageServerHost
             serverInfo = new
             {
                 name = "Typewriter Language Server",
-                version = "4.6.1",
+                version = "4.7.0",
             },
         };
 

--- a/src/Typewriter.LanguageServer/WorkspaceChangedInput.cs
+++ b/src/Typewriter.LanguageServer/WorkspaceChangedInput.cs
@@ -1,0 +1,5 @@
+namespace Typewriter.LanguageServer;
+
+internal sealed record WorkspaceChangedInput(
+    string? FullPath,
+    string? Kind);

--- a/src/Typewriter.LanguageServer/WorkspaceGenerationRequest.cs
+++ b/src/Typewriter.LanguageServer/WorkspaceGenerationRequest.cs
@@ -7,4 +7,11 @@ internal sealed record WorkspaceGenerationRequest(
     string? TemplatePath,
     string? Framework,
     bool? AllProjects,
-    string? TemplateSearchPath = null);
+    string? TemplateSearchPath = null)
+{
+    /// <summary>
+    /// Gets the inputs changed since the previous generation, or <c>null</c> when the
+    /// provenance is unknown and a full generation is performed.
+    /// </summary>
+    public IReadOnlyList<WorkspaceChangedInput>? ChangedInputs { get; init; }
+}

--- a/src/Typewriter.LanguageServer/WorkspaceGenerationService.cs
+++ b/src/Typewriter.LanguageServer/WorkspaceGenerationService.cs
@@ -13,8 +13,14 @@ internal sealed class WorkspaceGenerationService : IWorkspaceGenerationService, 
 
     private readonly SemaphoreSlim _generationLock = new(initialCount: 1, maxCount: 1);
 
+    public WorkspaceGenerationService()
+    {
+        MetadataCacheInvalidation.EnableTracking();
+    }
+
     public void Dispose()
     {
+        MetadataCacheInvalidation.Reset();
         _generationLock.Dispose();
     }
 
@@ -47,16 +53,18 @@ internal sealed class WorkspaceGenerationService : IWorkspaceGenerationService, 
                     DryRun = mode == GenerationMode.Validate || configuration.Output.DryRun,
                 },
             };
+            var changedInputs = MapChangedInputs(changedInputs: request.ChangedInputs, basePath: GetPathBase(path: workspacePath));
+            ApplyMetadataInvalidation(changedInputs: changedInputs);
 
             var result = await _generator.GenerateAsync(
-                request: new GenerationRequest(
-                    WorkspacePath: workspacePath,
-                    ProjectPath: projectPath,
-                    TemplatePath: ResolveOptionalPath(value: request.TemplatePath, basePath: GetPathBase(path: workspacePath)),
-                    Mode: mode,
-                    Configuration: configuration,
-                    AllProjects: request.AllProjects ?? settings.AllProjects,
-                    TemplateSearchPath: ResolveOptionalPath(value: request.TemplateSearchPath, basePath: GetPathBase(path: workspacePath))),
+                request: CreateGenerationRequest(
+                    request: request,
+                    settings: settings,
+                    workspacePath: workspacePath,
+                    projectPath: projectPath,
+                    mode: mode,
+                    configuration: configuration,
+                    changedInputs: changedInputs),
                 cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
             return new WorkspaceGenerationResult(
                 Success: result.Success,
@@ -79,6 +87,49 @@ internal sealed class WorkspaceGenerationService : IWorkspaceGenerationService, 
         finally
         {
             _ = _generationLock.Release();
+        }
+    }
+
+    private static GenerationRequest CreateGenerationRequest(
+        WorkspaceGenerationRequest request,
+        LanguageServerSettings settings,
+        string workspacePath,
+        string? projectPath,
+        GenerationMode mode,
+        TypewriterConfiguration configuration,
+        IReadOnlyCollection<ChangedInput>? changedInputs)
+    {
+        var basePath = GetPathBase(path: workspacePath);
+        return new GenerationRequest(
+            WorkspacePath: workspacePath,
+            ProjectPath: projectPath,
+            TemplatePath: ResolveOptionalPath(value: request.TemplatePath, basePath: basePath),
+            Mode: mode,
+            Configuration: configuration,
+            AllProjects: request.AllProjects ?? settings.AllProjects,
+            TemplateSearchPath: ResolveOptionalPath(value: request.TemplateSearchPath, basePath: basePath))
+        {
+            ChangedInputs = changedInputs,
+        };
+    }
+
+    private static void ApplyMetadataInvalidation(IReadOnlyCollection<ChangedInput>? changedInputs)
+    {
+        if (changedInputs is null || changedInputs.Count == 0)
+        {
+            MetadataCacheInvalidation.MarkAllDirty();
+            return;
+        }
+
+        foreach (var changedInput in changedInputs)
+        {
+            if (changedInput.Kind is ChangedInputKind.Deleted or ChangedInputKind.Renamed)
+            {
+                MetadataCacheInvalidation.MarkAllDirty();
+                return;
+            }
+
+            MetadataCacheInvalidation.MarkDirty(fullPath: changedInput.FullPath);
         }
     }
 
@@ -110,6 +161,67 @@ internal sealed class WorkspaceGenerationService : IWorkspaceGenerationService, 
         return Path.IsPathRooted(path: value)
             ? Path.GetFullPath(path: value)
             : Path.GetFullPath(path: Path.Combine(path1: basePath, path2: value));
+    }
+
+    /// <summary>
+    /// Maps the request's changed inputs to engine changed inputs. Returns <c>null</c>
+    /// (unknown provenance, full generation) when no changed inputs were provided or any
+    /// entry cannot be resolved to a path.
+    /// </summary>
+    /// <param name="changedInputs">The changed inputs from the generation request.</param>
+    /// <param name="basePath">The base path used to resolve relative paths.</param>
+    /// <returns>The mapped changed inputs, or <c>null</c>.</returns>
+    private static IReadOnlyCollection<ChangedInput>? MapChangedInputs(
+        IReadOnlyList<WorkspaceChangedInput>? changedInputs,
+        string basePath)
+    {
+        if (changedInputs is null || changedInputs.Count == 0)
+        {
+            return null;
+        }
+
+        var mapped = new List<ChangedInput>(capacity: changedInputs.Count);
+        foreach (var changedInput in changedInputs)
+        {
+            string? fullPath;
+            try
+            {
+                fullPath = ResolveOptionalPath(value: changedInput.FullPath, basePath: basePath);
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+            catch (NotSupportedException)
+            {
+                return null;
+            }
+            catch (PathTooLongException)
+            {
+                return null;
+            }
+
+            if (fullPath is null)
+            {
+                return null;
+            }
+
+            mapped.Add(item: new ChangedInput(FullPath: fullPath, Kind: MapChangedInputKind(kind: changedInput.Kind)));
+        }
+
+        return mapped;
+    }
+
+    private static ChangedInputKind MapChangedInputKind(string? kind)
+    {
+        if (string.IsNullOrWhiteSpace(value: kind))
+        {
+            return ChangedInputKind.Modified;
+        }
+
+        return Enum.TryParse<ChangedInputKind>(value: kind, ignoreCase: true, result: out var parsed)
+            ? parsed
+            : ChangedInputKind.Modified;
     }
 
     private static string GetPathBase(string path)

--- a/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
+++ b/src/Typewriter.Roslyn/CSharpProjectMetadataProvider.cs
@@ -4,8 +4,6 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
-using System.Security.Cryptography;
-using System.Text;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -22,6 +20,11 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
     private static readonly ConcurrentDictionary<ProjectMetadataCacheKey, ProjectMetadataCacheEntry> MetadataCache = [];
     private static readonly ConcurrentBag<HashSet<ITypeSymbol>> TypeReferenceVisitedSymbolSets = [];
     private static readonly ConditionalWeakTable<ISymbol, CachedDocComment> DocCommentCache = [];
+    private static readonly ConditionalWeakTable<ITypeSymbol, TypeReferenceCacheNode> TypeReferenceCache = [];
+    private static readonly ConcurrentDictionary<string, CachedSyntaxTree> SyntaxTreeCache = new(comparer: StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentQueue<string> SyntaxTreeCacheOrder = new();
+    private static readonly ConcurrentDictionary<string, int> SourceParseCounts = new(comparer: StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, string> LastCacheOutcomeByProject = new(comparer: StringComparer.OrdinalIgnoreCase);
     private readonly IProjectWorkspaceLoader _projectLoader;
 
     public CSharpProjectMetadataProvider()
@@ -32,6 +35,13 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
     public CSharpProjectMetadataProvider(IProjectWorkspaceLoader projectLoader)
     {
         _projectLoader = projectLoader;
+    }
+
+    private enum CacheLookupOutcome
+    {
+        Miss,
+        Hit,
+        RebuildFromSources,
     }
 
     public Task<ProjectMetadata> GetMetadataAsync(
@@ -75,6 +85,21 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         return result.Compilation;
     }
 
+    internal static int GetSourceParseCountForTests(string path) =>
+        SourceParseCounts.TryGetValue(key: NormalizeSourceCachePath(path: path), value: out var count) ? count : 0;
+
+    internal static string? GetLastCacheOutcomeForTests(string projectPath) =>
+        LastCacheOutcomeByProject.TryGetValue(key: NormalizeSourceCachePath(path: projectPath), value: out var outcome) ? outcome : null;
+
+    internal static void ClearCachesForTests()
+    {
+        MetadataCache.Clear();
+        SyntaxTreeCache.Clear();
+        SyntaxTreeCacheOrder.Clear();
+        SourceParseCounts.Clear();
+        LastCacheOutcomeByProject.Clear();
+    }
+
     private static async Task<ProjectMetadata> GetMergedMetadataAsync(
         IProjectWorkspaceLoader projectLoader,
         ProjectContext project,
@@ -106,13 +131,16 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
             return cachedResult;
         }
 
+        var validationVersion = MetadataCacheInvalidation.CurrentVersion;
         var metadataCacheKey = new ProjectMetadataCacheKey(
             ProjectPath: projectPath,
             WorkspacePath: Path.GetFullPath(path: project.WorkspacePath),
             TargetFramework: project.TargetFramework ?? string.Empty,
             RunFullDiagnostics: project.RunFullDiagnostics);
-        if (TryGetCachedResult(cacheKey: metadataCacheKey, result: out cachedResult))
+        var cacheLookup = LookupCache(cacheKey: metadataCacheKey);
+        if (cacheLookup.Outcome == CacheLookupOutcome.Hit)
         {
+            cachedResult = cacheLookup.Result!;
             loadedProjects[key: projectPath] = cachedResult;
             return cachedResult;
         }
@@ -125,19 +153,30 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                 CompilationReferences: []);
         }
 
-        if (!File.Exists(path: projectPath))
+        ProjectLoadResult loadedProject;
+        if (cacheLookup.Outcome == CacheLookupOutcome.RebuildFromSources)
         {
-            return CacheResult(
-                projectPath: projectPath,
-                result: new ProjectMetadataBuildResult(
-                    Metadata: CreateProjectFileMissingMetadata(projectPath: projectPath),
-                    Compilation: null,
-                    CompilationReferences: []),
-                loadedProjects: loadedProjects,
-                loadingProjects: loadingProjects);
+            loadedProject = cacheLookup.LoadedProject!;
+            MetadataCacheMetrics.RecordSourceOnlyRebuild();
+        }
+        else
+        {
+            if (!File.Exists(path: projectPath))
+            {
+                return CacheResult(
+                    projectPath: projectPath,
+                    result: new ProjectMetadataBuildResult(
+                        Metadata: CreateProjectFileMissingMetadata(projectPath: projectPath),
+                        Compilation: null,
+                        CompilationReferences: []),
+                    loadedProjects: loadedProjects,
+                    loadingProjects: loadingProjects);
+            }
+
+            loadedProject = await projectLoader.LoadAsync(project: project, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+            MetadataCacheMetrics.RecordFullLoad();
         }
 
-        var loadedProject = await projectLoader.LoadAsync(project: project, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
         if (loadedProject.Diagnostics.Any(predicate: diagnostic => diagnostic.Severity == Typewriter.Abstractions.DiagnosticSeverity.Error))
         {
             return CacheResult(
@@ -189,7 +228,7 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                 projectPath: projectPath,
                 compilation: currentProject.Compilation,
                 referencedProjects: referencedProjects));
-        AddCachedResult(cacheKey: metadataCacheKey, result: result);
+        AddCachedResult(cacheKey: metadataCacheKey, result: result, loadedProject: loadedProject, validatedVersion: validationVersion);
         return CacheResult(
             projectPath: projectPath,
             result: result,
@@ -210,21 +249,44 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         var parseOptions = CSharpParseOptions.Default
             .WithLanguageVersion(version: LanguageVersion.Preview)
             .WithPreprocessorSymbols(preprocessorSymbols: loadedProject.PreprocessorSymbols);
-        var syntaxTrees = new List<SyntaxTree>(capacity: sourcePaths.Length);
-        foreach (var sourcePath in sourcePaths)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
+        var parseOptionsKey = CreateParseOptionsKey(parseOptions: parseOptions);
+        var parsedTrees = new SyntaxTree[sourcePaths.Length];
+        await Parallel.ForAsync(
+            fromInclusive: 0,
+            toExclusive: sourcePaths.Length,
+            cancellationToken: cancellationToken,
+            body: async (index, token) =>
+            {
+                token.ThrowIfCancellationRequested();
+                var sourcePath = sourcePaths[index];
+                var cacheKey = NormalizeSourceCachePath(path: sourcePath);
+                var stamp = FileStamp.Create(path: sourcePath);
+                if (stamp.Exists
+                    && SyntaxTreeCache.TryGetValue(key: cacheKey, value: out var cachedTree)
+                    && cachedTree.Stamp == stamp
+                    && cachedTree.ParseOptionsKey.Equals(value: parseOptionsKey, comparisonType: StringComparison.Ordinal))
+                {
+                    parsedTrees[index] = cachedTree.Tree;
+                    MetadataCacheMetrics.RecordReusedSyntaxTree();
+                    return;
+                }
+
 #pragma warning disable SCS0018 // Potential Path Traversal vulnerability was found where '{0}' in '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.
-            var sourceText = await File.ReadAllTextAsync(path: sourcePath, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+                var sourceText = await File.ReadAllTextAsync(path: sourcePath, cancellationToken: token).ConfigureAwait(continueOnCapturedContext: false);
 #pragma warning restore SCS0018 // Potential Path Traversal vulnerability was found where '{0}' in '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.
-            syntaxTrees.Add(
-                item: CSharpSyntaxTree.ParseText(
+                var parsedTree = CSharpSyntaxTree.ParseText(
                     text: sourceText,
                     options: parseOptions,
                     path: sourcePath,
-                    cancellationToken: cancellationToken));
-        }
+                    cancellationToken: token);
+                parsedTrees[index] = parsedTree;
+                AddCachedSyntaxTree(cacheKey: cacheKey, entry: new CachedSyntaxTree(ParseOptionsKey: parseOptionsKey, Stamp: stamp, Tree: parsedTree));
+                MetadataCacheMetrics.RecordParsedSourceFile();
+                _ = SourceParseCounts.AddOrUpdate(key: cacheKey, addValue: 1, updateValueFactory: static (_, count) => count + 1);
+            }).ConfigureAwait(continueOnCapturedContext: false);
 
+        var syntaxTrees = new List<SyntaxTree>(capacity: sourcePaths.Length + 1);
+        syntaxTrees.AddRange(collection: parsedTrees);
         syntaxTrees.Add(item: CreateDefaultGlobalUsingsTree(globalUsings: loadedProject.GlobalUsings, parseOptions: parseOptions, cancellationToken: cancellationToken));
 
         var compilation = CSharpCompilation.Create(
@@ -373,25 +435,57 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         }
     }
 
-    private static bool TryGetCachedResult(
-        ProjectMetadataCacheKey cacheKey,
-        out ProjectMetadataBuildResult result)
+    private static CacheLookupResult LookupCache(ProjectMetadataCacheKey cacheKey)
     {
-        if (MetadataCache.TryGetValue(key: cacheKey, value: out var entry)
-            && entry.Fingerprint.IsCurrent())
+        if (!MetadataCache.TryGetValue(key: cacheKey, value: out var entry))
         {
-            result = entry.Result;
-            return true;
+            MetadataCacheMetrics.RecordCacheMiss(reason: null);
+            RecordCacheOutcome(projectPath: cacheKey.ProjectPath, outcome: "miss");
+            return CacheLookupResult.Miss;
+        }
+
+        var currentVersion = MetadataCacheInvalidation.CurrentVersion;
+        var dirtyPaths = MetadataCacheInvalidation.GetDirtySince(sinceVersion: entry.LastValidatedVersion);
+        ManifestValidation validation;
+        bool dirtyValidated;
+        if (dirtyPaths is not null)
+        {
+            dirtyValidated = true;
+            validation = dirtyPaths.Count == 0
+                ? ManifestValidation.Valid
+                : entry.Manifest.ValidateDirtyPaths(dirtyPaths: dirtyPaths);
+        }
+        else
+        {
+            dirtyValidated = false;
+            validation = entry.Manifest.Validate();
+        }
+
+        if (validation.IsValid)
+        {
+            entry.LastValidatedVersion = currentVersion;
+            MetadataCacheMetrics.RecordCacheHit(dirtyValidated: dirtyValidated);
+            RecordCacheOutcome(projectPath: cacheKey.ProjectPath, outcome: dirtyValidated ? "hit-dirty-validated" : "hit-stat-validated");
+            return new CacheLookupResult(Outcome: CacheLookupOutcome.Hit, Result: entry.Result, LoadedProject: null);
         }
 
         _ = MetadataCache.TryRemove(key: cacheKey, value: out _);
-        result = null!;
-        return false;
+        MetadataCacheMetrics.RecordCacheMiss(reason: validation.InvalidationReason);
+        if (validation.CanRebuildFromSources && entry.LoadedProject is not null)
+        {
+            RecordCacheOutcome(projectPath: cacheKey.ProjectPath, outcome: "source-rebuild");
+            return new CacheLookupResult(Outcome: CacheLookupOutcome.RebuildFromSources, Result: null, LoadedProject: entry.LoadedProject);
+        }
+
+        RecordCacheOutcome(projectPath: cacheKey.ProjectPath, outcome: "miss");
+        return CacheLookupResult.Miss;
     }
 
     private static void AddCachedResult(
         ProjectMetadataCacheKey cacheKey,
-        ProjectMetadataBuildResult result)
+        ProjectMetadataBuildResult result,
+        ProjectLoadResult loadedProject,
+        long validatedVersion)
     {
         if (result.Metadata.Diagnostics.Any(predicate: diagnostic => diagnostic.Severity == Typewriter.Abstractions.DiagnosticSeverity.Error))
         {
@@ -399,9 +493,66 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         }
 
         MetadataCache[key: cacheKey] = new ProjectMetadataCacheEntry(
-            Result: result,
-            Fingerprint: ProjectMetadataFingerprint.Create(result: result));
+            result: result,
+            manifest: ProjectInputManifest.Create(result: result),
+            loadedProject: loadedProject,
+            validatedVersion: validatedVersion);
         TrimMetadataCache();
+    }
+
+    private static void RecordCacheOutcome(
+        string projectPath,
+        string outcome) =>
+        LastCacheOutcomeByProject[key: projectPath] = outcome;
+
+    private static string NormalizeSourceCachePath(string path)
+    {
+        try
+        {
+            return Path.GetFullPath(path: path);
+        }
+        catch (ArgumentException)
+        {
+            return path;
+        }
+        catch (NotSupportedException)
+        {
+            return path;
+        }
+        catch (PathTooLongException)
+        {
+            return path;
+        }
+    }
+
+    private static string CreateParseOptionsKey(CSharpParseOptions parseOptions) =>
+        string.Join(
+            separator: ';',
+            values: parseOptions.PreprocessorSymbolNames
+                .Order(comparer: StringComparer.Ordinal)
+                .Prepend(element: parseOptions.LanguageVersion.ToString()));
+
+    private static void AddCachedSyntaxTree(
+        string cacheKey,
+        CachedSyntaxTree entry)
+    {
+        if (SyntaxTreeCache.TryAdd(key: cacheKey, value: entry))
+        {
+            SyntaxTreeCacheOrder.Enqueue(item: cacheKey);
+            TrimSyntaxTreeCache();
+            return;
+        }
+
+        SyntaxTreeCache[key: cacheKey] = entry;
+    }
+
+    private static void TrimSyntaxTreeCache()
+    {
+        const int MaxEntries = 8192;
+        while (SyntaxTreeCache.Count > MaxEntries && SyntaxTreeCacheOrder.TryDequeue(result: out var oldest))
+        {
+            _ = SyntaxTreeCache.TryRemove(key: oldest, value: out _);
+        }
     }
 
     private static void TrimMetadataCache()
@@ -1262,10 +1413,23 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         ITypeSymbol symbol,
         NullableAnnotation nullableAnnotation)
     {
+        var annotationIndex = (int)nullableAnnotation;
+        TypeReferenceCacheNode? cacheNode = null;
+        if (annotationIndex >= 0 && annotationIndex < 3)
+        {
+            cacheNode = TypeReferenceCache.GetOrCreateValue(key: symbol);
+            var cached = Volatile.Read(location: ref cacheNode.ByAnnotation[annotationIndex]);
+            if (cached is not null)
+            {
+                return cached;
+            }
+        }
+
         var visitedSymbols = RentVisitedSymbols();
+        TypeMetadataReference reference;
         try
         {
-            return CreateTypeReference(
+            reference = CreateTypeReference(
                 symbol: symbol,
                 nullableAnnotation: nullableAnnotation,
                 visitedSymbols: visitedSymbols);
@@ -1274,6 +1438,13 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         {
             ReturnVisitedSymbols(visitedSymbols: visitedSymbols);
         }
+
+        if (cacheNode is not null)
+        {
+            Volatile.Write(location: ref cacheNode.ByAnnotation[annotationIndex], value: reference);
+        }
+
+        return reference;
     }
 
     private static TypeMetadataReference CreateTypeReference(
@@ -1782,46 +1953,166 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
         string TargetFramework,
         bool RunFullDiagnostics);
 
-    private sealed record ProjectMetadataCacheEntry(
-        ProjectMetadataBuildResult Result,
-        ProjectMetadataFingerprint Fingerprint);
-
-    private sealed record ProjectMetadataFingerprint(
-        IReadOnlyList<string> Paths,
-        IReadOnlyList<string> Directories,
-        string Hash)
+    private sealed record CacheLookupResult(
+        CacheLookupOutcome Outcome,
+        ProjectMetadataBuildResult? Result,
+        ProjectLoadResult? LoadedProject)
     {
-        public static ProjectMetadataFingerprint Create(ProjectMetadataBuildResult result)
+        public static CacheLookupResult Miss { get; } = new(Outcome: CacheLookupOutcome.Miss, Result: null, LoadedProject: null);
+    }
+
+    private sealed class ProjectMetadataCacheEntry
+    {
+        private long _lastValidatedVersion;
+
+        public ProjectMetadataCacheEntry(
+            ProjectMetadataBuildResult result,
+            ProjectInputManifest manifest,
+            ProjectLoadResult? loadedProject,
+            long validatedVersion)
         {
-            var paths = new SortedSet<string>(comparer: StringComparer.OrdinalIgnoreCase);
-            AddPath(paths: paths, path: result.Metadata.ProjectPath);
+            Result = result;
+            Manifest = manifest;
+            LoadedProject = loadedProject;
+            _lastValidatedVersion = validatedVersion;
+        }
+
+        public ProjectMetadataBuildResult Result { get; }
+
+        public ProjectInputManifest Manifest { get; }
+
+        public ProjectLoadResult? LoadedProject { get; }
+
+        public long LastValidatedVersion
+        {
+            get => Interlocked.Read(location: ref _lastValidatedVersion);
+            set => Interlocked.Exchange(location1: ref _lastValidatedVersion, value: value);
+        }
+    }
+
+    private sealed record FileStamp(
+        bool Exists,
+        long Length,
+        long LastWriteTicks)
+    {
+        public static FileStamp Missing { get; } = new(Exists: false, Length: -1, LastWriteTicks: -1);
+
+        public static FileStamp Unreadable { get; } = new(Exists: false, Length: -2, LastWriteTicks: -2);
+
+        public static FileStamp Create(string path)
+        {
+            try
+            {
+#pragma warning disable SCS0018 // Potential Path Traversal vulnerability was found where '{0}' in '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.
+                var info = new FileInfo(fileName: path);
+#pragma warning restore SCS0018 // Potential Path Traversal vulnerability was found where '{0}' in '{1}' may be tainted by user-controlled data from '{2}' in method '{3}'.
+                return info.Exists
+                    ? new FileStamp(Exists: true, Length: info.Length, LastWriteTicks: info.LastWriteTimeUtc.Ticks)
+                    : Missing;
+            }
+            catch (IOException)
+            {
+                return Unreadable;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Unreadable;
+            }
+            catch (ArgumentException)
+            {
+                return Unreadable;
+            }
+            catch (NotSupportedException)
+            {
+                return Unreadable;
+            }
+        }
+    }
+
+    private sealed record CachedSyntaxTree(
+        string ParseOptionsKey,
+        FileStamp Stamp,
+        SyntaxTree Tree);
+
+    private sealed class TypeReferenceCacheNode
+    {
+        public TypeMetadataReference?[] ByAnnotation { get; } = new TypeMetadataReference?[3];
+    }
+
+    private sealed record ManifestValidation(
+        bool IsValid,
+        bool CanRebuildFromSources,
+        IReadOnlyList<string> ChangedSourceFiles,
+        string? InvalidationReason)
+    {
+        public static ManifestValidation Valid { get; } = new(
+            IsValid: true,
+            CanRebuildFromSources: false,
+            ChangedSourceFiles: [],
+            InvalidationReason: null);
+
+        public static ManifestValidation ShapeChanged(string reason) => new(
+            IsValid: false,
+            CanRebuildFromSources: false,
+            ChangedSourceFiles: [],
+            InvalidationReason: reason);
+
+        public static ManifestValidation SourcesChanged(IReadOnlyList<string> changedSourceFiles) => new(
+            IsValid: false,
+            CanRebuildFromSources: true,
+            ChangedSourceFiles: changedSourceFiles,
+            InvalidationReason: $"source changed: {changedSourceFiles[0]}");
+    }
+
+    private sealed class ProjectInputManifest
+    {
+        private readonly Dictionary<string, FileStamp> _sourceFiles;
+        private readonly Dictionary<string, FileStamp> _shapeFiles;
+        private readonly Dictionary<string, long> _directories;
+
+        private ProjectInputManifest(
+            Dictionary<string, FileStamp> sourceFiles,
+            Dictionary<string, FileStamp> shapeFiles,
+            Dictionary<string, long> directories)
+        {
+            _sourceFiles = sourceFiles;
+            _shapeFiles = shapeFiles;
+            _directories = directories;
+        }
+
+        public static ProjectInputManifest Create(ProjectMetadataBuildResult result)
+        {
+            var sourceFiles = new Dictionary<string, FileStamp>(comparer: StringComparer.OrdinalIgnoreCase);
             foreach (var sourceFile in result.Metadata.SourceFiles)
             {
-                AddPath(paths: paths, path: sourceFile.Path);
+                AddStamp(stamps: sourceFiles, path: sourceFile.Path);
             }
 
+            var shapeFiles = new Dictionary<string, FileStamp>(comparer: StringComparer.OrdinalIgnoreCase);
+            AddStamp(stamps: shapeFiles, path: result.Metadata.ProjectPath);
             foreach (var reference in result.CompilationReferences)
             {
-                AddPath(paths: paths, path: reference.ProjectPath);
+                AddStamp(stamps: shapeFiles, path: reference.ProjectPath);
             }
 
             if (result.Compilation is not null)
             {
                 foreach (var referencePath in result.Compilation.References.Select(selector: reference => reference.Display))
                 {
-                    AddPath(paths: paths, path: referencePath);
+                    AddStamp(stamps: shapeFiles, path: referencePath);
                 }
             }
 
-            var directories = new SortedSet<string>(comparer: StringComparer.OrdinalIgnoreCase);
+            var directories = new Dictionary<string, long>(comparer: StringComparer.OrdinalIgnoreCase);
             foreach (var projectPath in result.CompilationReferences.Select(selector: reference => reference.ProjectPath).Append(element: result.Metadata.ProjectPath))
             {
                 var projectDirectory = Path.GetDirectoryName(path: projectPath);
                 if (!string.IsNullOrWhiteSpace(value: projectDirectory) && Directory.Exists(path: projectDirectory))
                 {
-                    foreach (var directory in EnumerateDirectoriesForFingerprint(root: projectDirectory))
+                    foreach (var directory in EnumerateInputDirectories(root: projectDirectory)
+                                 .Where(predicate: directory => !directories.ContainsKey(key: directory)))
                     {
-                        directories.Add(item: directory);
+                        directories[key: directory] = GetDirectoryStamp(directory: directory);
                     }
                 }
             }
@@ -1830,22 +2121,110 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                          .Select(selector: sourceFile => Path.GetDirectoryName(path: sourceFile.Path))
                          .Where(predicate: sourceDirectory => !string.IsNullOrWhiteSpace(value: sourceDirectory)))
             {
-                directories.Add(item: Path.GetFullPath(path: sourceDirectory!));
+                var directory = Path.GetFullPath(path: sourceDirectory!);
+                if (!directories.ContainsKey(key: directory))
+                {
+                    directories[key: directory] = GetDirectoryStamp(directory: directory);
+                }
             }
 
-            var pathList = paths.ToArray();
-            var directoryList = directories.ToArray();
-            return new ProjectMetadataFingerprint(
-                Paths: pathList,
-                Directories: directoryList,
-                Hash: ComputeFingerprintHash(paths: pathList, directories: directoryList));
+            return new ProjectInputManifest(sourceFiles: sourceFiles, shapeFiles: shapeFiles, directories: directories);
         }
 
-        public bool IsCurrent() =>
-            Hash.Equals(value: ComputeFingerprintHash(paths: Paths, directories: Directories), comparisonType: StringComparison.Ordinal);
+        public ManifestValidation Validate()
+        {
+            foreach (var (path, stamp) in _shapeFiles)
+            {
+                if (FileStamp.Create(path: path) != stamp)
+                {
+                    return ManifestValidation.ShapeChanged(reason: $"input changed: {path}");
+                }
+            }
 
-        private static void AddPath(
-            ISet<string> paths,
+            foreach (var (directory, stamp) in _directories)
+            {
+                if (GetDirectoryStamp(directory: directory) != stamp)
+                {
+                    return ManifestValidation.ShapeChanged(reason: $"directory changed: {directory}");
+                }
+            }
+
+            List<string>? changedSources = null;
+            foreach (var (path, stamp) in _sourceFiles)
+            {
+                var current = FileStamp.Create(path: path);
+                if (current == stamp)
+                {
+                    continue;
+                }
+
+                if (!current.Exists)
+                {
+                    return ManifestValidation.ShapeChanged(reason: $"source removed: {path}");
+                }
+
+                (changedSources ??= []).Add(item: path);
+            }
+
+            return changedSources is null
+                ? ManifestValidation.Valid
+                : ManifestValidation.SourcesChanged(changedSourceFiles: changedSources);
+        }
+
+        public ManifestValidation ValidateDirtyPaths(IReadOnlyList<string> dirtyPaths)
+        {
+            List<string>? changedSources = null;
+            var checkedDirectories = new HashSet<string>(comparer: StringComparer.OrdinalIgnoreCase);
+            foreach (var dirtyPath in dirtyPaths)
+            {
+                if (_shapeFiles.TryGetValue(key: dirtyPath, value: out var shapeStamp)
+                    && FileStamp.Create(path: dirtyPath) != shapeStamp)
+                {
+                    return ManifestValidation.ShapeChanged(reason: $"input changed: {dirtyPath}");
+                }
+
+                if (_sourceFiles.TryGetValue(key: dirtyPath, value: out var sourceStamp))
+                {
+                    var current = FileStamp.Create(path: dirtyPath);
+                    if (current != sourceStamp)
+                    {
+                        if (!current.Exists)
+                        {
+                            return ManifestValidation.ShapeChanged(reason: $"source removed: {dirtyPath}");
+                        }
+
+                        (changedSources ??= []).Add(item: dirtyPath);
+                    }
+                }
+
+                if (_directories.TryGetValue(key: dirtyPath, value: out var directoryStamp)
+                    && checkedDirectories.Add(item: dirtyPath)
+                    && GetDirectoryStamp(directory: dirtyPath) != directoryStamp)
+                {
+                    return ManifestValidation.ShapeChanged(reason: $"directory changed: {dirtyPath}");
+                }
+
+                var parent = Path.GetDirectoryName(path: dirtyPath);
+                while (!string.IsNullOrEmpty(value: parent))
+                {
+                    if (_directories.TryGetValue(key: parent, value: out var parentStamp)
+                        && checkedDirectories.Add(item: parent)
+                        && GetDirectoryStamp(directory: parent) != parentStamp)
+                    {
+                        return ManifestValidation.ShapeChanged(reason: $"directory changed: {parent}");
+                    }
+
+                    parent = Path.GetDirectoryName(path: parent);
+                }
+            }
+
+            return changedSources is null
+                ? ManifestValidation.Valid
+                : ManifestValidation.SourcesChanged(changedSourceFiles: changedSources);
+        }
+
+        private static void AddStamp(
+            Dictionary<string, FileStamp> stamps,
             string? path)
         {
             if (string.IsNullOrWhiteSpace(value: path))
@@ -1853,21 +2232,49 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                 return;
             }
 
+            string fullPath;
             try
             {
-                paths.Add(item: Path.GetFullPath(path: path));
+                fullPath = Path.GetFullPath(path: path);
             }
-            catch (ArgumentException ex)
+            catch (ArgumentException)
             {
-                _ = ex;
+                return;
             }
-            catch (NotSupportedException ex)
+            catch (NotSupportedException)
             {
-                _ = ex;
+                return;
+            }
+            catch (PathTooLongException)
+            {
+                return;
+            }
+
+            if (!stamps.ContainsKey(key: fullPath))
+            {
+                stamps[key: fullPath] = FileStamp.Create(path: fullPath);
             }
         }
 
-        private static IEnumerable<string> EnumerateDirectoriesForFingerprint(string root)
+        private static long GetDirectoryStamp(string directory)
+        {
+            try
+            {
+                return Directory.Exists(path: directory)
+                    ? new DirectoryInfo(path: directory).LastWriteTimeUtc.Ticks
+                    : -1L;
+            }
+            catch (IOException)
+            {
+                return -2L;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return -2L;
+            }
+        }
+
+        private static IEnumerable<string> EnumerateInputDirectories(string root)
         {
             var pending = new Stack<string>();
             pending.Push(item: Path.GetFullPath(path: root));
@@ -1876,103 +2283,19 @@ public sealed class CSharpProjectMetadataProvider : IProjectMetadataProvider
                 var directory = pending.Pop();
                 yield return directory;
                 foreach (var childDirectory in Directory.EnumerateDirectories(path: directory)
-                             .Where(predicate: childDirectory => !IsIgnoredDirectoryForFingerprint(name: Path.GetFileName(path: childDirectory))))
+                             .Where(predicate: childDirectory => !IsIgnoredInputDirectory(name: Path.GetFileName(path: childDirectory))))
                 {
                     pending.Push(item: childDirectory);
                 }
             }
         }
 
-        private static bool IsIgnoredDirectoryForFingerprint(string name) =>
+        private static bool IsIgnoredInputDirectory(string name) =>
             name.Equals(value: ".git", comparisonType: StringComparison.OrdinalIgnoreCase)
             || name.Equals(value: "artifacts", comparisonType: StringComparison.OrdinalIgnoreCase)
             || name.Equals(value: "bin", comparisonType: StringComparison.OrdinalIgnoreCase)
             || name.Equals(value: "node_modules", comparisonType: StringComparison.OrdinalIgnoreCase)
             || name.Equals(value: "obj", comparisonType: StringComparison.OrdinalIgnoreCase);
-
-        private static string ComputeFingerprintHash(
-            IEnumerable<string> paths,
-            IEnumerable<string> directories)
-        {
-            using var hash = IncrementalHash.CreateHash(hashAlgorithm: HashAlgorithmName.SHA256);
-            foreach (var path in paths)
-            {
-                AppendHashValue(hash: hash, value: "file");
-                AppendPathFingerprint(hash: hash, path: path);
-            }
-
-            foreach (var directory in directories)
-            {
-                AppendHashValue(hash: hash, value: nameof(directory));
-                AppendDirectoryFingerprint(hash: hash, directory: directory);
-            }
-
-            return Convert.ToHexString(inArray: hash.GetHashAndReset());
-        }
-
-        private static void AppendPathFingerprint(
-            IncrementalHash hash,
-            string path)
-        {
-            AppendHashValue(hash: hash, value: path);
-            try
-            {
-                if (!File.Exists(path: path))
-                {
-                    AppendHashValue(hash: hash, value: "missing");
-                    return;
-                }
-
-#pragma warning disable SCS0018
-                var file = new FileInfo(fileName: path);
-#pragma warning restore SCS0018
-                AppendHashValue(hash: hash, value: file.Length.ToString(provider: CultureInfo.InvariantCulture));
-                AppendHashValue(hash: hash, value: file.LastWriteTimeUtc.Ticks.ToString(provider: CultureInfo.InvariantCulture));
-            }
-            catch (IOException)
-            {
-                AppendHashValue(hash: hash, value: "unreadable");
-            }
-            catch (UnauthorizedAccessException)
-            {
-                AppendHashValue(hash: hash, value: "unreadable");
-            }
-        }
-
-        private static void AppendDirectoryFingerprint(
-            IncrementalHash hash,
-            string directory)
-        {
-            AppendHashValue(hash: hash, value: directory);
-            try
-            {
-                if (!Directory.Exists(path: directory))
-                {
-                    AppendHashValue(hash: hash, value: "missing");
-                    return;
-                }
-
-                var info = new DirectoryInfo(path: directory);
-                AppendHashValue(hash: hash, value: info.LastWriteTimeUtc.Ticks.ToString(provider: CultureInfo.InvariantCulture));
-            }
-            catch (IOException)
-            {
-                AppendHashValue(hash: hash, value: "unreadable");
-            }
-            catch (UnauthorizedAccessException)
-            {
-                AppendHashValue(hash: hash, value: "unreadable");
-            }
-        }
-
-        private static void AppendHashValue(
-            IncrementalHash hash,
-            string value)
-        {
-            var bytes = Encoding.UTF8.GetBytes(s: value);
-            hash.AppendData(data: bytes);
-            hash.AppendData(data: [0]);
-        }
     }
 
     private sealed record CachedDocComment(DocCommentMetadata? Value);

--- a/src/Typewriter.Roslyn/Properties/AssemblyInfo.cs
+++ b/src/Typewriter.Roslyn/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo(assemblyName: "Typewriter.Roslyn.Tests")]

--- a/src/Typewriter.VisualStudio/TypewriterCliModels.cs
+++ b/src/Typewriter.VisualStudio/TypewriterCliModels.cs
@@ -62,6 +62,15 @@ internal sealed class TypewriterGenerationRequest
     public string? Framework { get; set; }
 
     public bool AllProjects { get; set; }
+
+    public List<TypewriterChangedInput>? ChangedInputs { get; set; }
+}
+
+internal sealed class TypewriterChangedInput
+{
+    public string FullPath { get; set; } = string.Empty;
+
+    public string Kind { get; set; } = "modified";
 }
 
 internal sealed class CliGeneratedFile

--- a/src/Typewriter.VisualStudio/TypewriterCommandService.cs
+++ b/src/Typewriter.VisualStudio/TypewriterCommandService.cs
@@ -88,10 +88,11 @@ internal sealed class TypewriterCommandService
 
     public Task GenerateSavedInputAsync(
         string inputPath,
+        IReadOnlyCollection<string>? changedPaths,
         CancellationToken cancellationToken) =>
         RunWithReportingAsync(
             message: "Typewriter generate-on-save failed.",
-            action: () => GenerateAllTemplatesAsync(inputPathOverride: inputPath, cancellationToken: cancellationToken),
+            action: () => GenerateAllTemplatesAsync(inputPathOverride: inputPath, changedPaths: changedPaths, cancellationToken: cancellationToken),
             cancellationToken: cancellationToken);
 
     private void AddCommand(
@@ -218,10 +219,11 @@ internal sealed class TypewriterCommandService
     }
 
     private Task GenerateAllTemplatesAsync(CancellationToken cancellationToken) =>
-        GenerateAllTemplatesAsync(inputPathOverride: null, cancellationToken: cancellationToken);
+        GenerateAllTemplatesAsync(inputPathOverride: null, changedPaths: null, cancellationToken: cancellationToken);
 
     private async Task GenerateAllTemplatesAsync(
         string? inputPathOverride,
+        IReadOnlyCollection<string>? changedPaths,
         CancellationToken cancellationToken)
     {
         var context = await CreateGenerationContextAsync(
@@ -236,7 +238,7 @@ internal sealed class TypewriterCommandService
             return;
         }
 
-        await ExecuteCliAsync(command: "generate", context: context, allTemplates: true, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+        await ExecuteCliAsync(command: "generate", context: context, allTemplates: true, changedPaths: changedPaths, cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
     }
 
     private async Task GenerateSolutionAllTemplatesAsync(CancellationToken cancellationToken)
@@ -327,9 +329,22 @@ internal sealed class TypewriterCommandService
         string command,
         GenerationContext context,
         bool allTemplates,
+        CancellationToken cancellationToken) =>
+        await ExecuteCliAsync(
+            command: command,
+            context: context,
+            allTemplates: allTemplates,
+            changedPaths: null,
+            cancellationToken: cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+
+    private async Task ExecuteCliAsync(
+        string command,
+        GenerationContext context,
+        bool allTemplates,
+        IReadOnlyCollection<string>? changedPaths,
         CancellationToken cancellationToken)
     {
-        var args = BuildTypewriterArguments(command: command, context: context, allTemplates: allTemplates);
+        var args = BuildTypewriterArguments(command: command, context: context, allTemplates: allTemplates, changedPaths: changedPaths);
         await _package.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken: cancellationToken);
         _diagnosticReporter.Clear();
 
@@ -342,6 +357,13 @@ internal sealed class TypewriterCommandService
             TemplateSearchPath = context.TemplateSearchPath,
             Framework = string.IsNullOrWhiteSpace(value: context.Framework) ? null : context.Framework,
             AllProjects = allTemplates && context.AllProjects,
+            ChangedInputs = changedPaths?
+                .Select(selector: changedPath => new TypewriterChangedInput
+                {
+                    FullPath = changedPath,
+                    Kind = File.Exists(path: changedPath) ? "modified" : "deleted",
+                })
+                .ToList(),
         };
         var persistentResult = await TypewriterLanguageClient.TryGenerateAsync(
             request: generationRequest,
@@ -395,7 +417,8 @@ internal sealed class TypewriterCommandService
     private static IReadOnlyList<string> BuildTypewriterArguments(
         string command,
         GenerationContext context,
-        bool allTemplates)
+        bool allTemplates,
+        IReadOnlyCollection<string>? changedPaths)
     {
         var args = new List<string>
         {
@@ -433,6 +456,15 @@ internal sealed class TypewriterCommandService
         if (allTemplates && context.AllProjects)
         {
             args.Add(item: "--all-projects");
+        }
+
+        if (changedPaths is not null)
+        {
+            foreach (var changedPath in changedPaths)
+            {
+                args.Add(item: "--changed");
+                args.Add(item: changedPath);
+            }
         }
 
         return args;

--- a/src/Typewriter.VisualStudio/TypewriterPackage.cs
+++ b/src/Typewriter.VisualStudio/TypewriterPackage.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 namespace Typewriter.VisualStudio;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.6.1")]
+[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.7.0")]
 [ProvideMenuResource(resourceID: "Menus.ctmenu", version: 1)]
 [ProvideOptionPage(pageType: typeof(TypewriterOptions), categoryName: "Typewriter", pageName: "General", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true)]
 [ProvideAutoLoad(cmdUiContextGuid: VSConstants.UICONTEXT.SolutionExists_string, flags: PackageAutoLoadFlags.BackgroundLoad)]

--- a/src/Typewriter.VisualStudio/TypewriterSaveListener.cs
+++ b/src/Typewriter.VisualStudio/TypewriterSaveListener.cs
@@ -275,7 +275,7 @@ internal sealed class TypewriterSaveListener : IVsRunningDocTableEvents3, IDispo
     private Task ExecuteSaveRequestAsync(SaveGenerationRequest request) =>
         request.Scope == SaveGenerationScope.CurrentTemplate
             ? _commandService.GenerateSavedTemplateAsync(templatePath: request.Path, cancellationToken: CancellationToken.None)
-            : _commandService.GenerateSavedInputAsync(inputPath: request.Path, cancellationToken: CancellationToken.None);
+            : _commandService.GenerateSavedInputAsync(inputPath: request.Path, changedPaths: request.ChangedPaths, cancellationToken: CancellationToken.None);
 
     private static SaveGenerationRequest? CreateSaveGenerationRequest(
         string path,
@@ -292,12 +292,10 @@ internal sealed class TypewriterSaveListener : IVsRunningDocTableEvents3, IDispo
             return null;
         }
 
-        if (TemplateExtensions.Contains(item: extension))
-        {
-            return new SaveGenerationRequest(path: path, scope: SaveGenerationScope.CurrentTemplate);
-        }
-
-        return new SaveGenerationRequest(path: path, scope: SaveGenerationScope.AllTemplates);
+        var scope = TemplateExtensions.Contains(item: extension)
+            ? SaveGenerationScope.CurrentTemplate
+            : SaveGenerationScope.AllTemplates;
+        return new SaveGenerationRequest(path: path, scope: scope, changedPaths: [path]);
     }
 
     private static IEnumerable<string> FindConfigurationFiles(string path)
@@ -417,22 +415,36 @@ internal sealed class TypewriterSaveListener : IVsRunningDocTableEvents3, IDispo
     {
         public SaveGenerationRequest(
             string path,
-            SaveGenerationScope scope)
+            SaveGenerationScope scope,
+            IReadOnlyCollection<string> changedPaths)
         {
             Path = path;
             Scope = scope;
+            ChangedPaths = changedPaths;
         }
 
         public string Path { get; }
 
         public SaveGenerationScope Scope { get; }
 
+        public IReadOnlyCollection<string> ChangedPaths { get; }
+
         public static SaveGenerationRequest Merge(
             SaveGenerationRequest? existing,
-            SaveGenerationRequest incoming) =>
-            existing?.Scope == SaveGenerationScope.AllTemplates && incoming.Scope == SaveGenerationScope.CurrentTemplate
+            SaveGenerationRequest incoming)
+        {
+            if (existing is null)
+            {
+                return incoming;
+            }
+
+            var winner = existing.Scope == SaveGenerationScope.AllTemplates && incoming.Scope == SaveGenerationScope.CurrentTemplate
                 ? existing
                 : incoming;
+            var changedPaths = new HashSet<string>(collection: existing.ChangedPaths, comparer: StringComparer.OrdinalIgnoreCase);
+            changedPaths.UnionWith(other: incoming.ChangedPaths);
+            return new SaveGenerationRequest(path: winner.Path, scope: winner.Scope, changedPaths: changedPaths);
+        }
     }
 
     private enum SaveGenerationScope

--- a/src/Typewriter.VisualStudio/source.extension.vsixmanifest
+++ b/src/Typewriter.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.6.1" Language="en-US" Publisher="AdaskoTheBeAsT" />
+    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.7.0" Language="en-US" Publisher="AdaskoTheBeAsT" />
     <DisplayName>Typewriter</DisplayName>
     <Description xml:space="preserve">Generate TypeScript from C# Typewriter templates.</Description>
     <Tags>Typewriter;TypeScript;C#;Code Generation</Tags>

--- a/tests/unit/Typewriter.Cli.Tests/CliCommandLineTests.cs
+++ b/tests/unit/Typewriter.Cli.Tests/CliCommandLineTests.cs
@@ -45,6 +45,56 @@ public sealed class CliCommandLineTests
     }
 
     [Fact]
+    public async Task InvokeAsyncReadsRepeatedChangedOptions()
+    {
+        CliOptions? capturedOptions = null;
+        var command = CliCommandLine.CreateRootCommand(
+            executeAsync: (options, _) =>
+            {
+                capturedOptions = options;
+                return Task.FromResult(result: 0);
+            });
+
+        await command.Parse(
+            args:
+            [
+                "generate",
+                "--project",
+                "sample.csproj",
+                "--changed",
+                "Models/UserDto.cs",
+                "--changed",
+                "Models/OrderDto.cs",
+            ]).InvokeAsync(configuration: null, cancellationToken: CancellationToken.None);
+
+        capturedOptions.Should().NotBeNull();
+        capturedOptions!.ChangedPaths.Should().Equal("Models/UserDto.cs", "Models/OrderDto.cs");
+    }
+
+    [Fact]
+    public async Task InvokeAsyncDefaultsChangedPathsToEmptyWhenOptionIsOmitted()
+    {
+        CliOptions? capturedOptions = null;
+        var command = CliCommandLine.CreateRootCommand(
+            executeAsync: (options, _) =>
+            {
+                capturedOptions = options;
+                return Task.FromResult(result: 0);
+            });
+
+        await command.Parse(
+            args:
+            [
+                "generate",
+                "--project",
+                "sample.csproj",
+            ]).InvokeAsync(configuration: null, cancellationToken: CancellationToken.None);
+
+        capturedOptions.Should().NotBeNull();
+        capturedOptions!.ChangedPaths.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task InvokeAsyncDefaultsToGenerateWhenCommandIsOmitted()
     {
         CliOptions? capturedOptions = null;

--- a/tests/unit/Typewriter.Engine.Tests/TypewriterGeneratorWorkspaceTests.cs
+++ b/tests/unit/Typewriter.Engine.Tests/TypewriterGeneratorWorkspaceTests.cs
@@ -320,6 +320,136 @@ public sealed class TypewriterGeneratorWorkspaceTests
     }
 
     [Fact]
+    public async Task GenerateAsyncRendersOnlyAffectedSourceFilesWhenChangedInputsAreProvided()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var context = await CreateIncrementalGenerationContextAsync(directory: directory);
+
+            var result = await context.Generator.GenerateAsync(
+                request: context.Request with
+                {
+                    ChangedInputs = [new ChangedInput(FullPath: context.UserDtoPath, Kind: ChangedInputKind.Modified)],
+                },
+                cancellationToken: CancellationToken.None);
+
+            result.Success.Should().BeTrue(because: string.Join(separator: Environment.NewLine, values: result.Diagnostics.Select(selector: diagnostic => diagnostic.Message)));
+            result.GeneratedFiles.Select(selector: file => file.Path).Order(comparer: StringComparer.OrdinalIgnoreCase).Should().Equal(
+                Path.Combine(path1: directory, path2: "OrderDto.ts"),
+                Path.Combine(path1: directory, path2: "UserDto.ts"));
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAsyncRendersNothingWhenChangedSourceFileIsNotPartOfTheProject()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var context = await CreateIncrementalGenerationContextAsync(directory: directory);
+
+            var result = await context.Generator.GenerateAsync(
+                request: context.Request with
+                {
+                    ChangedInputs = [new ChangedInput(FullPath: Path.Combine(path1: directory, path2: "Untracked.cs"), Kind: ChangedInputKind.Modified)],
+                },
+                cancellationToken: CancellationToken.None);
+
+            result.Success.Should().BeTrue(because: string.Join(separator: Environment.NewLine, values: result.Diagnostics.Select(selector: diagnostic => diagnostic.Message)));
+            result.GeneratedFiles.Should().BeEmpty();
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAsyncRendersAllSourceFilesWhenChangedInputsContainNonCSharpFile()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var context = await CreateIncrementalGenerationContextAsync(directory: directory);
+
+            var result = await context.Generator.GenerateAsync(
+                request: context.Request with
+                {
+                    ChangedInputs =
+                    [
+                        new ChangedInput(FullPath: context.UserDtoPath, Kind: ChangedInputKind.Modified),
+                        new ChangedInput(FullPath: context.TemplatePath, Kind: ChangedInputKind.Modified),
+                    ],
+                },
+                cancellationToken: CancellationToken.None);
+
+            result.Success.Should().BeTrue(because: string.Join(separator: Environment.NewLine, values: result.Diagnostics.Select(selector: diagnostic => diagnostic.Message)));
+            result.GeneratedFiles.Should().HaveCount(3);
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAsyncRendersAllSourceFilesWhenChangedInputIsDeleted()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var context = await CreateIncrementalGenerationContextAsync(directory: directory);
+
+            var result = await context.Generator.GenerateAsync(
+                request: context.Request with
+                {
+                    ChangedInputs = [new ChangedInput(FullPath: context.UserDtoPath, Kind: ChangedInputKind.Deleted)],
+                },
+                cancellationToken: CancellationToken.None);
+
+            result.Success.Should().BeTrue(because: string.Join(separator: Environment.NewLine, values: result.Diagnostics.Select(selector: diagnostic => diagnostic.Message)));
+            result.GeneratedFiles.Should().HaveCount(3);
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAsyncRendersAllSourceFilesWhenIncrementalGenerationIsDisabled()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            var context = await CreateIncrementalGenerationContextAsync(directory: directory);
+
+            var result = await context.Generator.GenerateAsync(
+                request: context.Request with
+                {
+                    Configuration = TypewriterConfiguration.Default with
+                    {
+                        Generation = new GenerationConfiguration(Incremental: GenerationConfiguration.IncrementalOff),
+                    },
+                    ChangedInputs = [new ChangedInput(FullPath: context.UserDtoPath, Kind: ChangedInputKind.Modified)],
+                },
+                cancellationToken: CancellationToken.None);
+
+            result.Success.Should().BeTrue(because: string.Join(separator: Environment.NewLine, values: result.Diagnostics.Select(selector: diagnostic => diagnostic.Message)));
+            result.GeneratedFiles.Should().HaveCount(3);
+        }
+        finally
+        {
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
+    [Fact]
     public async Task GenerateAsyncResolvesRecordBaseFromFullProjectWhenRenderingPerSourceFile()
     {
         var directory = CreateProjectDirectory();
@@ -890,6 +1020,52 @@ public sealed class TypewriterGeneratorWorkspaceTests
         return projectPath;
     }
 
+    private static async Task<IncrementalGenerationContext> CreateIncrementalGenerationContextAsync(string directory)
+    {
+        var projectPath = Path.Combine(path1: directory, path2: "Sample.csproj");
+        var templatePath = Path.Combine(path1: directory, path2: "Models.tst");
+        await File.WriteAllTextAsync(path: projectPath, contents: "<Project />");
+
+        var userModel = CreateClassMetadata(name: "UserDto");
+        var orderModel = CreateClassMetadata(
+            name: "OrderDto",
+            properties: [CreatePropertyMetadata(declaringTypeName: "OrderDto", name: "Customer", type: userModel)]);
+        var productModel = CreateClassMetadata(name: "ProductDto");
+        var userDtoPath = Path.Combine(path1: directory, path2: "UserDto.cs");
+        var metadataProvider = new CapturingMetadataProvider(
+            types: [userModel, orderModel, productModel],
+            sourceFiles:
+            [
+                new SourceFileMetadata(Path: userDtoPath, Types: [userModel]),
+                new SourceFileMetadata(Path: Path.Combine(path1: directory, path2: "OrderDto.cs"), Types: [orderModel]),
+                new SourceFileMetadata(Path: Path.Combine(path1: directory, path2: "ProductDto.cs"), Types: [productModel]),
+            ]);
+        var generator = new TypewriterGenerator(
+            templateDiscovery: new StaticTemplateDiscovery(
+                templates: new TemplateFile(
+                    Path: templatePath,
+                    Content: """
+                             $Classes[
+                             export class $Name {
+                             }
+                             ]
+                             """)),
+            metadataProvider: metadataProvider,
+            fileWriter: new PassthroughFileWriter());
+        var request = new GenerationRequest(
+            WorkspacePath: directory,
+            ProjectPath: projectPath,
+            TemplatePath: templatePath,
+            Mode: GenerationMode.Generate,
+            Configuration: TypewriterConfiguration.Default);
+
+        return new IncrementalGenerationContext(
+            Generator: generator,
+            Request: request,
+            UserDtoPath: userDtoPath,
+            TemplatePath: templatePath);
+    }
+
     private static TypewriterConfiguration CreateConfiguration(FileNameConvention fileNameConvention) =>
         TypewriterConfiguration.Default with
         {
@@ -899,18 +1075,37 @@ public sealed class TypewriterGeneratorWorkspaceTests
             },
         };
 
-    private static TypeMetadata CreateClassMetadata(string name) =>
+    private static TypeMetadata CreateClassMetadata(
+        string name,
+        IReadOnlyList<PropertyMetadata>? properties = null) =>
         new(
             Name: name,
             FullName: "Sample." + name,
             Namespace: "Sample",
             Kind: TypeMetadataKind.Class,
             Accessibility: MetadataAccessibility.Public,
-            Properties: [],
+            Properties: properties ?? [],
             Attributes: [],
             BaseTypes: [],
             EnumValues: [],
             IsNullableAware: true);
+
+    private static PropertyMetadata CreatePropertyMetadata(
+        string declaringTypeName,
+        string name,
+        TypeMetadata type) =>
+        new(
+            Name: name,
+            FullName: "Sample." + declaringTypeName + "." + name,
+            Type: CreateTypeReference(type: type),
+            Accessibility: MetadataAccessibility.Public,
+            HasGetter: true,
+            HasSetter: true,
+            IsRequired: false,
+            Attributes: [])
+        {
+            ParentTypeFullName = "Sample." + declaringTypeName,
+        };
 
     private static TypeMetadata CreateRecordMetadata(
         string name,
@@ -1043,4 +1238,10 @@ public sealed class TypewriterGeneratorWorkspaceTests
             CancellationToken cancellationToken) =>
             Task.FromResult(result: file);
     }
+
+    private sealed record IncrementalGenerationContext(
+        TypewriterGenerator Generator,
+        GenerationRequest Request,
+        string UserDtoPath,
+        string TemplatePath);
 }

--- a/tests/unit/Typewriter.LanguageServer.Tests/WorkspaceGenerationServiceTests.cs
+++ b/tests/unit/Typewriter.LanguageServer.Tests/WorkspaceGenerationServiceTests.cs
@@ -1,3 +1,4 @@
+using Typewriter.Abstractions;
 using Xunit;
 
 namespace Typewriter.LanguageServer.Tests;
@@ -105,11 +106,21 @@ public sealed class WorkspaceGenerationServiceTests
             await File.WriteAllTextAsync(
                 path: sourcePath,
                 contents: "namespace App; public sealed class Model { public string Name { get; set; } = string.Empty; public int Age { get; set; } }");
-            var second = await service.GenerateAsync(request: request, settings: settings, cancellationToken: CancellationToken.None);
+            var versionBeforeSecondGeneration = MetadataCacheInvalidation.CurrentVersion;
+            var second = await service.GenerateAsync(
+                request: request with
+                {
+                    ChangedInputs = [new WorkspaceChangedInput(FullPath: sourcePath, Kind: "modified")],
+                },
+                settings: settings,
+                cancellationToken: CancellationToken.None);
 
             first.Success.Should().BeTrue();
             second.Success.Should().BeTrue();
             second.GeneratedFiles.Should().ContainSingle().Which.Changed.Should().BeTrue();
+            var dirtyPaths = MetadataCacheInvalidation.GetDirtySince(sinceVersion: versionBeforeSecondGeneration);
+            dirtyPaths.Should().NotBeNull();
+            dirtyPaths!.Should().Contain(Path.GetFullPath(path: sourcePath));
             var output = await File.ReadAllTextAsync(path: outputPath);
             output.Should().Contain("  name: string;");
             output.Should().Contain("  age: number;");

--- a/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
+++ b/tests/unit/Typewriter.Roslyn.Tests/CSharpProjectMetadataProviderTests.cs
@@ -1212,6 +1212,99 @@ public sealed class CSharpProjectMetadataProviderTests
         }
     }
 
+    [Fact]
+    public async Task GetMetadataReusesCacheAndRebuildsFromSourcesOnDirtyPath()
+    {
+        var directory = CreateProjectDirectory();
+        try
+        {
+            CSharpProjectMetadataProvider.ClearCachesForTests();
+            MetadataCacheInvalidation.Reset();
+            MetadataCacheInvalidation.EnableTracking();
+
+            var projectPath = Path.Combine(path1: directory, path2: "Sample.csproj");
+            await File.WriteAllTextAsync(
+                path: projectPath,
+                contents: """
+                          <Project Sdk="Microsoft.NET.Sdk">
+                            <PropertyGroup>
+                              <TargetFramework>net10.0</TargetFramework>
+                              <Nullable>enable</Nullable>
+                              <ImplicitUsings>enable</ImplicitUsings>
+                            </PropertyGroup>
+                          </Project>
+                          """);
+            var modelsPath = Path.Combine(path1: directory, path2: "Models.cs");
+            var servicesPath = Path.Combine(path1: directory, path2: "Services.cs");
+            await File.WriteAllTextAsync(
+                path: modelsPath,
+                contents: """
+                          namespace Sample;
+
+                          public sealed class User
+                          {
+                              public string Name { get; init; } = "";
+                          }
+                          """);
+            await File.WriteAllTextAsync(
+                path: servicesPath,
+                contents: """
+                          namespace Sample;
+
+                          public sealed class UserService
+                          {
+                              public User GetUser() => new();
+                          }
+                          """);
+
+            var provider = new CSharpProjectMetadataProvider();
+            var projectContext = new ProjectContext(ProjectPath: projectPath, WorkspacePath: directory);
+
+            var firstMetadata = await provider.GetMetadataAsync(project: projectContext, cancellationToken: CancellationToken.None);
+            firstMetadata.Diagnostics.Should().NotContain(diagnostic => diagnostic.Severity == Typewriter.Abstractions.DiagnosticSeverity.Error);
+            firstMetadata.Types.Should().Contain(type => type.Name == "User");
+            firstMetadata.Types.Should().Contain(type => type.Name == "UserService");
+            CSharpProjectMetadataProvider.GetLastCacheOutcomeForTests(projectPath: projectPath).Should().Be("miss");
+            var modelsParseCountAfterFirst = CSharpProjectMetadataProvider.GetSourceParseCountForTests(path: modelsPath);
+            var servicesParseCountAfterFirst = CSharpProjectMetadataProvider.GetSourceParseCountForTests(path: servicesPath);
+            modelsParseCountAfterFirst.Should().BePositive();
+            servicesParseCountAfterFirst.Should().BePositive();
+
+            var secondMetadata = await provider.GetMetadataAsync(project: projectContext, cancellationToken: CancellationToken.None);
+            secondMetadata.Types.Should().HaveCount(expected: firstMetadata.Types.Count);
+            CSharpProjectMetadataProvider.GetLastCacheOutcomeForTests(projectPath: projectPath).Should().Be("hit-dirty-validated");
+            CSharpProjectMetadataProvider.GetSourceParseCountForTests(path: modelsPath).Should().Be(modelsParseCountAfterFirst);
+            CSharpProjectMetadataProvider.GetSourceParseCountForTests(path: servicesPath).Should().Be(servicesParseCountAfterFirst);
+
+            await File.WriteAllTextAsync(
+                path: modelsPath,
+                contents: """
+                          namespace Sample;
+
+                          public sealed class User
+                          {
+                              public string Name { get; init; } = "";
+                              public string Email { get; init; } = "";
+                          }
+                          """);
+            MetadataCacheInvalidation.MarkDirty(fullPath: modelsPath);
+
+            var thirdMetadata = await provider.GetMetadataAsync(project: projectContext, cancellationToken: CancellationToken.None);
+            thirdMetadata.Diagnostics.Should().NotContain(diagnostic => diagnostic.Severity == Typewriter.Abstractions.DiagnosticSeverity.Error);
+            var user = thirdMetadata.Types.Should().ContainSingle(type => type.Name == "User").Which;
+            user.Properties.Should().Contain(property => property.Name == "Email");
+            CSharpProjectMetadataProvider.GetLastCacheOutcomeForTests(projectPath: projectPath).Should().Be("source-rebuild");
+            CSharpProjectMetadataProvider.GetSourceParseCountForTests(path: modelsPath).Should().BeGreaterThan(expected: modelsParseCountAfterFirst);
+            CSharpProjectMetadataProvider.GetSourceParseCountForTests(path: servicesPath).Should().Be(servicesParseCountAfterFirst);
+        }
+        finally
+        {
+            MetadataCacheInvalidation.Reset();
+            CSharpProjectMetadataProvider.ClearCachesForTests();
+            await DeleteDirectoryWithRetryAsync(directory: directory);
+        }
+    }
+
     private static string CreateProjectDirectory()
     {
         var directory = Path.Combine(

--- a/typewriter.schema.json
+++ b/typewriter.schema.json
@@ -158,6 +158,19 @@
           "default": false
         }
       }
+    },
+    "generation": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Generation behavior.",
+      "properties": {
+        "incremental": {
+          "type": "string",
+          "enum": ["auto", "off"],
+          "description": "Incremental generation. With 'auto', watch and IDE generate-on-save runs that only changed C# source files re-render only the affected outputs. 'off' always performs a full generation.",
+          "default": "auto"
+        }
+      }
     }
   }
 }

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typewriter-vscode",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typewriter-vscode",
-      "version": "4.6.1",
+      "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^10.0.1"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typewriter-vscode",
   "displayName": "Typewriter",
   "description": "VS Code adapter for Typewriter .tst templates.",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "publisher": "adaskothebeast",
   "license": "MIT",
   "icon": "images/icon.png",

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -216,8 +216,12 @@ function mergeSaveRequests(existing, incoming) {
     const winner = existing.allTemplates && !incoming.allTemplates
         ? existing
         : incoming;
-    const changedPaths = existing.changedPaths && incoming.changedPaths
-        ? Array.from(new Set([...existing.changedPaths, ...incoming.changedPaths]))
+    const changedPathSet = new Set([
+        ...(existing.changedPaths ?? []),
+        ...(incoming.changedPaths ?? []),
+    ]);
+    const changedPaths = changedPathSet.size > 0
+        ? Array.from(changedPathSet)
         : undefined;
     return { ...winner, changedPaths };
 }

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -107,6 +107,7 @@ function createSaveRequest(document) {
                 templatePath: document.uri.fsPath,
                 resourceUri: document.uri,
                 allTemplates: false,
+                changedPaths: [document.uri.fsPath],
             };
         }
 
@@ -116,6 +117,7 @@ function createSaveRequest(document) {
                 templatePath: document.uri.fsPath,
                 resourceUri: document.uri,
                 allTemplates: false,
+                changedPaths: [document.uri.fsPath],
             };
         }
 
@@ -129,6 +131,7 @@ function createSaveRequest(document) {
             allTemplates: true,
             projectPath: findNearestProjectPathForInput(document.uri.fsPath),
             projectScoped: true,
+            changedPaths: [document.uri.fsPath],
         };
     }
 
@@ -139,6 +142,7 @@ function createSaveRequest(document) {
             allTemplates: true,
             projectPath: findNearestProjectPathForInput(document.uri.fsPath),
             projectScoped: true,
+            changedPaths: [document.uri.fsPath],
         };
     }
 
@@ -200,13 +204,22 @@ async function executeSaveRequest(context, request) {
         resourceUri: request.resourceUri,
         projectPath: request.projectPath,
         projectScoped: request.projectScoped,
+        changedPaths: request.changedPaths,
     });
 }
 
 function mergeSaveRequests(existing, incoming) {
-    return existing?.allTemplates && !incoming.allTemplates
+    if (!existing) {
+        return incoming;
+    }
+
+    const winner = existing.allTemplates && !incoming.allTemplates
         ? existing
         : incoming;
+    const changedPaths = existing.changedPaths && incoming.changedPaths
+        ? Array.from(new Set([...existing.changedPaths, ...incoming.changedPaths]))
+        : undefined;
+    return { ...winner, changedPaths };
 }
 
 function delay(milliseconds) {
@@ -376,6 +389,12 @@ function buildTypewriterArguments(command, workspacePath, templatePath, configur
 
     if (options.allTemplates && configuration.get("allProjects", false)) {
         args.push("--all-projects");
+    }
+
+    if (Array.isArray(options.changedPaths)) {
+        for (const changedPath of options.changedPaths) {
+            args.push("--changed", changedPath);
+        }
     }
 
     return args;
@@ -1312,6 +1331,9 @@ function buildGenerationRequest(command, workspacePath, templatePath, configurat
     const projectPath = resolveOptionalPath(configuration.get("projectPath"), getPathBase(workspacePath)) || options.projectPath;
     const templateSearchPath = options.projectScoped ? resolveProjectTemplateSearchPath(projectPath) : undefined;
     const framework = configuration.get("framework");
+    const changedInputs = Array.isArray(options.changedPaths)
+        ? options.changedPaths.map(changedPath => ({ fullPath: changedPath, kind: "modified" }))
+        : undefined;
     return {
         command,
         workspacePath,
@@ -1320,6 +1342,7 @@ function buildGenerationRequest(command, workspacePath, templatePath, configurat
         templateSearchPath,
         framework: typeof framework === "string" && framework.trim() ? framework.trim() : undefined,
         allProjects: Boolean(options.allTemplates && configuration.get("allProjects", false)),
+        changedInputs,
     };
 }
 

--- a/vscode/src/extension.js
+++ b/vscode/src/extension.js
@@ -14,7 +14,7 @@ const defaultInputExtensions = [".cs", ".csproj", ".json", ".props", ".sln", ".s
 const templateExtensions = new Set([".tst"]);
 const ignoredInputDirectories = new Set([".git", ".gradle", ".idea", ".vs", ".vscode", "bin", "obj", "node_modules", "generated"]);
 const saveQueue = {
-    pending: undefined,
+    pending: [],
     timer: undefined,
     running: false,
     lastSaveAt: 0,
@@ -150,8 +150,12 @@ function createSaveRequest(document) {
 }
 
 function scheduleSaveRequest(context, request) {
-    saveQueue.pending = mergeSaveRequests(saveQueue.pending, request);
+    queueSaveRequest(request);
     saveQueue.lastSaveAt = Date.now();
+    scheduleSaveTimer(context);
+}
+
+function scheduleSaveTimer(context) {
     if (saveQueue.timer) {
         clearTimeout(saveQueue.timer);
     }
@@ -160,6 +164,16 @@ function scheduleSaveRequest(context, request) {
         saveQueue.timer = undefined;
         void processSaveQueue(context);
     }, saveDebounceDelayMs);
+}
+
+function queueSaveRequest(request) {
+    const existingIndex = saveQueue.pending.findIndex(candidate => canMergeSaveRequests(candidate, request));
+    if (existingIndex >= 0) {
+        saveQueue.pending[existingIndex] = mergeSaveRequests(saveQueue.pending[existingIndex], request);
+        return;
+    }
+
+    saveQueue.pending.push(request);
 }
 
 async function processSaveQueue(context) {
@@ -171,18 +185,20 @@ async function processSaveQueue(context) {
     try {
         while (true) {
             await waitForSaveQuietPeriod();
-            const request = saveQueue.pending;
-            saveQueue.pending = undefined;
-            if (!request) {
+            const requests = saveQueue.pending;
+            saveQueue.pending = [];
+            if (requests.length === 0) {
                 return;
             }
 
-            await executeSaveRequest(context, request);
+            for (const request of requests) {
+                await executeSaveRequest(context, request);
+            }
         }
     } finally {
         saveQueue.running = false;
-        if (saveQueue.pending && !saveQueue.timer) {
-            scheduleSaveRequest(context, saveQueue.pending);
+        if (saveQueue.pending.length > 0 && !saveQueue.timer) {
+            scheduleSaveTimer(context);
         }
     }
 }
@@ -208,11 +224,16 @@ async function executeSaveRequest(context, request) {
     });
 }
 
-function mergeSaveRequests(existing, incoming) {
-    if (!existing) {
-        return incoming;
-    }
+function canMergeSaveRequests(existing, incoming) {
+    return existing.command === incoming.command
+        && Boolean(existing.allTemplates) === Boolean(incoming.allTemplates)
+        && Boolean(existing.projectScoped) === Boolean(incoming.projectScoped)
+        && getRequestWorkspaceKey(existing) === getRequestWorkspaceKey(incoming)
+        && normalizeRequestPath(existing.projectPath) === normalizeRequestPath(incoming.projectPath)
+        && normalizeRequestPath(existing.templatePath) === normalizeRequestPath(incoming.templatePath);
+}
 
+function mergeSaveRequests(existing, incoming) {
     const winner = existing.allTemplates && !incoming.allTemplates
         ? existing
         : incoming;
@@ -224,6 +245,24 @@ function mergeSaveRequests(existing, incoming) {
         ? Array.from(changedPathSet)
         : undefined;
     return { ...winner, changedPaths };
+}
+
+function getRequestWorkspaceKey(request) {
+    if (request.resourceUri?.fsPath) {
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(request.resourceUri);
+        return normalizeRequestPath(workspaceFolder?.uri?.fsPath ?? path.dirname(request.resourceUri.fsPath));
+    }
+
+    return "";
+}
+
+function normalizeRequestPath(value) {
+    if (typeof value !== "string" || !value) {
+        return "";
+    }
+
+    const normalized = path.normalize(value);
+    return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 
 function delay(milliseconds) {


### PR DESCRIPTION
Fixes #99.

This pull request prepares for the 4.7.0 release and adds comprehensive release, compatibility, and packaging documentation. It updates the version to 4.7.0 across the repository, adjusts CI artifact naming, and documents new features and compatibility status.

**Release versioning and packaging:**

* Bumped the package and artifact version from 4.6.1 to 4.7.0 in `Directory.Build.props` and CI packaging steps, ensuring all built artifacts are correctly versioned. [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL14-R14) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL94-R95)
* Updated the CI workflow to produce editor package artifacts with the 4.7.0 version suffix.

**Documentation updates:**

* Added a detailed 4.7.0 changelog section to `README.md`, describing major new features such as a richer language server, improved incremental generation, new editor integrations, and enhanced performance and compatibility.
* Added a new `docs/compatibility.md` file documenting current compatibility status, completed and pending work, and coverage for old Typewriter templates and features.
* Added a new `docs/packing_plan.md` file detailing the packaging and release process for all supported editors and the CLI, including artifact formats, versioning, platform support, and validation steps.
* Updated the `README.md` table of contents to reference the new 4.7.0 changelog section.