### PR TITLE
additional release to fix release problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Collect editor packages
         shell: pwsh
         run: |
-          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.8.0.vsix
-          Copy-Item rider/build/distributions/typewriter-rider-4.8.0.zip artifacts/packages/Typewriter-Rider-4.8.0.zip
+          Copy-Item src/Typewriter.VisualStudio/bin/Release/net472/Typewriter.VisualStudio.vsix artifacts/packages/Typewriter.VisualStudio-4.9.0.vsix
+          Copy-Item rider/build/distributions/typewriter-rider-4.9.0.zip artifacts/packages/Typewriter-Rider-4.9.0.zip
 
       - name: Upload packages
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ErrorLog>$(MSBuildThisFileDirectory).sarif\$(MSBuildProjectName).json</ErrorLog>
-    <Version>4.8.0</Version>
+    <Version>4.9.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
     - [Top-level settings](#top-level-settings)
     - [`output` settings](#output-settings)
     - [Date and time mapping](#date-and-time-mapping)
+    - [System and NodaTime profile matrix](#system-and-nodatime-profile-matrix)
+    - [Guid mapping](#guid-mapping)
     - [Numeric and decimal mapping](#numeric-and-decimal-mapping)
     - [`diagnostics` settings](#diagnostics-settings)
     - [🔍 Discovery and precedence](#-discovery-and-precedence)
@@ -68,6 +70,7 @@
   - [🔨 Building from Source](#-building-from-source)
   - [🗺 Project Status and Roadmap](#-project-status-and-roadmap)
   - [Changelog](#changelog)
+    - [4.9.0](#490)
     - [4.8.0](#480)
     - [4.7.0](#470)
     - [4.6.1](#461)
@@ -120,7 +123,7 @@ The previous [`AdaskoTheBeAsT/Typewriter`](https://github.com/AdaskoTheBeAsT/Typ
 | Template runtime  | Classic helpers and settings                                                           | Classic helpers plus `#load`, NuGet `#r`, `settings.Log` diagnostics, `Template(Settings, File)`, `OnRenderComplete`, parent/current helper parameters, and richer stack traces |
 | Type mapping      | Mostly template-authored conventions                                                   | Configurable date-time, date-only, time-only, NodaTime, `Guid`, and `decimal` mappings with matching default initializers                                                       |
 | Metadata depth    | Classic type/member surface                                                            | Structs, indexers, member initializer `$Value`, preserved XML doc inline elements, and JSDoc formatting helpers                                                                 |
-| Performance       | Event-driven generation per IDE workflow                                               | Persistent generation, scoped discovery, metadata indexes, cached templates, glob matchers, type mappings, and loaded dependencies                                             |
+| Performance       | Event-driven generation per IDE workflow                                               | Persistent generation, scoped discovery, metadata indexes, cached templates, glob matchers, type mappings, and loaded dependencies                                              |
 | Packaging         | VSIX releases                                                                          | NuGet tool packages, language-server package, VSIX, VS Code VSIX, and Rider plugin artifacts from CI                                                                            |
 
 ### New goodies at a glance
@@ -155,15 +158,15 @@ The classic VS extension offered basic completion inside `.tst` files. This vers
 
 ### IDE support matrix
 
-| Capability                                                            | 💜 VS Code | 🟣 Visual Studio 2026 | 🧠 Rider |
-| --------------------------------------------------------------------- | :--------: | :-------------------: | :------: |
-| Template member completion, hover, and docs (`$BaseClass`, ...)       |     ✅      |    ✅ (LSP client)     |    ✅ (LSP client) |
-| Roslyn IntelliSense in `${ ... }` C# helper blocks (built-in)          |     ✅      |           ✅           |    ✅ (LSP client) |
-| Project-aware IntelliSense (your types in helper blocks)               |     ✅      |           ✅           |    ✅ (LSP client) |
-| Forwarding to installed C# / TypeScript language services              |     ✅      |          🚧           |    🚧     |
-| Semantic highlighting of template / C# / TypeScript regions            |     ✅      |   ✅ (classification)  |    ✅ (LSP) |
-| Live diagnostics in the editor                                        |     ✅      |    ✅ (Error List)     |    ✅ (LSP) |
-| Generate / validate on save                                           |     ✅      |           ✅           |    ✅     |
+| Capability                                                      | 💜 VS Code | 🟣 Visual Studio 2026 |    🧠 Rider     |
+| --------------------------------------------------------------- | :-------: | :------------------: | :------------: |
+| Template member completion, hover, and docs (`$BaseClass`, ...) |     ✅     |    ✅ (LSP client)    | ✅ (LSP client) |
+| Roslyn IntelliSense in `${ ... }` C# helper blocks (built-in)   |     ✅     |          ✅           | ✅ (LSP client) |
+| Project-aware IntelliSense (your types in helper blocks)        |     ✅     |          ✅           | ✅ (LSP client) |
+| Forwarding to installed C# / TypeScript language services       |     ✅     |          🚧           |       🚧        |
+| Semantic highlighting of template / C# / TypeScript regions     |     ✅     |  ✅ (classification)  |    ✅ (LSP)     |
+| Live diagnostics in the editor                                  |     ✅     |    ✅ (Error List)    |    ✅ (LSP)     |
+| Generate / validate on save                                     |     ✅     |          ✅           |       ✅        |
 
 **Will this work in VS, VS Code, and Rider?** Yes. All three IDEs now share the same language server, so template member IntelliSense (documented completions and hover for `$BaseClass`, `$Properties`, ...), real Roslyn IntelliSense inside `${ ... }` C# helper blocks (with XML doc tooltips and project-aware type completions), live diagnostics, and go-to-definition work identically in VS Code, Visual Studio 2026, and Rider. VS Code additionally forwards to the installed C# extension and built-in TypeScript service through virtual documents (`typewriter.embeddedLanguages.forwarding`), which is VS Code client-side code that could be replicated in VS and Rider later. Rider enables the LSP client via the built-in IntelliJ Platform LSP API; toggle it in Settings under Typewriter.
 
@@ -375,30 +378,30 @@ Generated by `typewriter init`. The generated file includes a `$schema` referenc
 
 ### `output` settings
 
-| Key                      | Default      | Description                                                                                                                                              |
-| ------------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `newline`                | `"lf"`       | `lf` or `crlf` line endings in generated files                                                                                                           |
-| `encoding`               | `"utf-8"`    | `utf-8` (no BOM) or `utf-8-bom` ⚠️ the original Typewriter emitted a BOM by default — set `utf-8-bom` for byte-identical output                           |
-| `writeOnlyWhenChanged`   | `true`       | Skip disk writes when content is unchanged (keeps file watchers and HMR calm)                                                                            |
-| `dryRun`                 | `false`      | Render without writing files                                                                                                                             |
-| `fileNameConvention`     | `"preserve"` | Output file naming: `preserve`, `kebab`, `pascal`, `camel`, `snake`                                                                                      |
-| `strictNull`             | `true`       | Render nullable types as `T \| null`; templates can override via `settings.DisableStrictNullGeneration()`                                                |
-| `indentStyle`            | `"preserve"` | Re-indent generated output: `preserve`, `space`, or `tab` (the rendered indent unit is detected automatically)                                           |
-| `indentSize`             | `4`          | Target indent width used when `indentStyle` is `space`                                                                                                   |
-| `insertFinalNewline`     | `false`      | Ensure generated files end with a single trailing newline                                                                                                |
-| `trimTrailingWhitespace` | `false`      | Strip trailing spaces and tabs from every generated line                                                                                                 |
-| `quoteStyle`             | `"double"`   | Default string literal character for generated defaults: `double`, `single`, or `backtick`; `settings.UseStringLiteralCharacter(...)` in a template wins |
-| `dateLibrary`            | `"legacy"`   | Coherent semantic profile: `legacy`, `nativeDate`, `temporal`, `moment`, `luxon`, `dateFns`, `dayJs`, or `jsJoda`; `settings.UseDateLibrary(...)` wins |
-| `dateType`               | `"Date"`     | TypeScript type used for `DateTime`, `DateTimeOffset`, and date-time-like NodaTime values; `settings.UseDateType(...)` wins                             |
-| `dateInitializer`        | `"new Date()"` | TypeScript initializer used for non-null date-time defaults; `settings.UseDateInitializer(...)` wins                                                    |
-| `dateOnlyType`           | `"Date"`     | TypeScript type used for `DateOnly`, `NodaTime.LocalDate`, and `NodaTime.OffsetDate`; `settings.UseDateOnlyType(...)` wins                              |
-| `dateOnlyInitializer`    | `"new Date()"` | TypeScript initializer used for non-null date-only defaults; `settings.UseDateOnlyInitializer(...)` wins                                                |
-| `timeOnlyType`           | `"string"`   | TypeScript type used for `TimeOnly`, `NodaTime.LocalTime`, and `NodaTime.OffsetTime`; `settings.UseTimeOnlyType(...)` wins                              |
-| `timeOnlyInitializer`    | `"\"00:00:00\""` | TypeScript initializer used for non-null time-only defaults; default literal follows `quoteStyle`, and `settings.UseTimeOnlyInitializer(...)` wins   |
-| `guidType`               | `"string"`   | TypeScript type used for C# `Guid`; set to `uuid`, `UUID`, or a branded alias with `settings.UseGuidType(...)` or config                                |
-| `guidInitializer`        | `"auto"`     | Non-null `Guid` initializer; `auto` emits the empty GUID string, or `new Uint8Array(16)` for `Uint8Array`; `settings.UseGuidInitializer(...)` wins      |
-| `decimalType`            | `"number"`   | TypeScript type used for C# `decimal`; `settings.UseDecimalType(...)` in a template wins                                                                 |
-| `decimalInitializer`     | `"auto"`     | Non-null `decimal` initializer; `auto` emits `0`, or `new <decimalType>(0)` for a custom type; `settings.UseDecimalInitializer(...)` wins               |
+| Key                      | Default          | Description                                                                                                                                              |
+| ------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `newline`                | `"lf"`           | `lf` or `crlf` line endings in generated files                                                                                                           |
+| `encoding`               | `"utf-8"`        | `utf-8` (no BOM) or `utf-8-bom` ⚠️ the original Typewriter emitted a BOM by default — set `utf-8-bom` for byte-identical output                           |
+| `writeOnlyWhenChanged`   | `true`           | Skip disk writes when content is unchanged (keeps file watchers and HMR calm)                                                                            |
+| `dryRun`                 | `false`          | Render without writing files                                                                                                                             |
+| `fileNameConvention`     | `"preserve"`     | Output file naming: `preserve`, `kebab`, `pascal`, `camel`, `snake`                                                                                      |
+| `strictNull`             | `true`           | Render nullable types as `T \| null`; templates can override via `settings.DisableStrictNullGeneration()`                                                |
+| `indentStyle`            | `"preserve"`     | Re-indent generated output: `preserve`, `space`, or `tab` (the rendered indent unit is detected automatically)                                           |
+| `indentSize`             | `4`              | Target indent width used when `indentStyle` is `space`                                                                                                   |
+| `insertFinalNewline`     | `false`          | Ensure generated files end with a single trailing newline                                                                                                |
+| `trimTrailingWhitespace` | `false`          | Strip trailing spaces and tabs from every generated line                                                                                                 |
+| `quoteStyle`             | `"double"`       | Default string literal character for generated defaults: `double`, `single`, or `backtick`; `settings.UseStringLiteralCharacter(...)` in a template wins |
+| `dateLibrary`            | `"legacy"`       | Coherent semantic profile: `legacy`, `nativeDate`, `temporal`, `moment`, `luxon`, `dateFns`, `dayJs`, or `jsJoda`; `settings.UseDateLibrary(...)` wins   |
+| `dateType`               | `"Date"`         | TypeScript type used for `DateTime`, `DateTimeOffset`, and date-time-like NodaTime values; `settings.UseDateType(...)` wins                              |
+| `dateInitializer`        | `"new Date()"`   | TypeScript initializer used for non-null date-time defaults; `settings.UseDateInitializer(...)` wins                                                     |
+| `dateOnlyType`           | `"Date"`         | TypeScript type used for `DateOnly`, `NodaTime.LocalDate`, and `NodaTime.OffsetDate`; `settings.UseDateOnlyType(...)` wins                               |
+| `dateOnlyInitializer`    | `"new Date()"`   | TypeScript initializer used for non-null date-only defaults; `settings.UseDateOnlyInitializer(...)` wins                                                 |
+| `timeOnlyType`           | `"string"`       | TypeScript type used for `TimeOnly`, `NodaTime.LocalTime`, and `NodaTime.OffsetTime`; `settings.UseTimeOnlyType(...)` wins                               |
+| `timeOnlyInitializer`    | `"\"00:00:00\""` | TypeScript initializer used for non-null time-only defaults; default literal follows `quoteStyle`, and `settings.UseTimeOnlyInitializer(...)` wins       |
+| `guidType`               | `"string"`       | TypeScript type used for C# `Guid`; set to `uuid`, `UUID`, or a branded alias with `settings.UseGuidType(...)` or config                                 |
+| `guidInitializer`        | `"auto"`         | Non-null `Guid` initializer; `auto` emits the empty GUID string, or `new Uint8Array(16)` for `Uint8Array`; `settings.UseGuidInitializer(...)` wins       |
+| `decimalType`            | `"number"`       | TypeScript type used for C# `decimal`; `settings.UseDecimalType(...)` in a template wins                                                                 |
+| `decimalInitializer`     | `"auto"`         | Non-null `decimal` initializer; `auto` emits `0`, or `new <decimalType>(0)` for a custom type; `settings.UseDecimalInitializer(...)` wins                |
 
 ### Date and time mapping
 
@@ -440,16 +443,16 @@ ${
 
 All supported values are:
 
-| `output.dateLibrary` value | Template API equivalent | Profile |
-| --- | --- | --- |
-| `"legacy"` | `settings.UseDateLibrary(DateLibrary.Legacy)` | Preserves the legacy `dateType`, `dateOnlyType`, `timeOnlyType`, and initializer settings |
-| `"nativeDate"` | `settings.UseDateLibrary(DateLibrary.NativeDate)` | Native JavaScript `Date` where it can represent the semantic type; otherwise `string` |
-| `"temporal"` | `settings.UseDateLibrary(DateLibrary.Temporal)` | Temporal types from `@js-temporal/polyfill` |
-| `"moment"` | `settings.UseDateLibrary(DateLibrary.Moment)` | Moment and Moment Duration types |
-| `"luxon"` | `settings.UseDateLibrary(DateLibrary.Luxon)` | Luxon `DateTime` and `Duration` types |
-| `"dateFns"` | `settings.UseDateLibrary(DateLibrary.DateFns)` | Native `Date` plus the date-fns `Duration` type |
-| `"dayJs"` | `settings.UseDateLibrary(DateLibrary.DayJs)` | Day.js types with its duration plugin |
-| `"jsJoda"` | `settings.UseDateLibrary(DateLibrary.JsJoda)` | js-joda semantic date/time types plus `@js-joda/timezone` |
+| `output.dateLibrary` value | Template API equivalent                           | Profile                                                                                   |
+| -------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `"legacy"`                 | `settings.UseDateLibrary(DateLibrary.Legacy)`     | Preserves the legacy `dateType`, `dateOnlyType`, `timeOnlyType`, and initializer settings |
+| `"nativeDate"`             | `settings.UseDateLibrary(DateLibrary.NativeDate)` | Native JavaScript `Date` where it can represent the semantic type; otherwise `string`     |
+| `"temporal"`               | `settings.UseDateLibrary(DateLibrary.Temporal)`   | Temporal types from `@js-temporal/polyfill`                                               |
+| `"moment"`                 | `settings.UseDateLibrary(DateLibrary.Moment)`     | Moment and Moment Duration types                                                          |
+| `"luxon"`                  | `settings.UseDateLibrary(DateLibrary.Luxon)`      | Luxon `DateTime` and `Duration` types                                                     |
+| `"dateFns"`                | `settings.UseDateLibrary(DateLibrary.DateFns)`    | Native `Date` plus the date-fns `Duration` type                                           |
+| `"dayJs"`                  | `settings.UseDateLibrary(DateLibrary.DayJs)`      | Day.js types with its duration plugin                                                     |
+| `"jsJoda"`                 | `settings.UseDateLibrary(DateLibrary.JsJoda)`     | js-joda semantic date/time types plus `@js-joda/timezone`                                 |
 
 The JSON values above show the canonical camel-case spellings accepted by `output.dateLibrary`. `legacy` is the default.
 
@@ -457,25 +460,25 @@ The profile supplies semantic TypeScript types, non-null initializers, and `sett
 
 ### System and NodaTime profile matrix
 
-| C# type | Semantic kind | Native `Date` | Temporal | Moment | Luxon | date-fns | Day.js | js-joda |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `DateTime` | plain date-time | `Date` | `Temporal.PlainDateTime` | `moment.Moment` | `DateTime` | `Date` | `Dayjs` | `LocalDateTime` |
-| `DateTimeOffset` | instant | `Date` | `Temporal.Instant` | `moment.Moment` | `DateTime` | `Date` | `Dayjs` | `Instant` |
-| `DateOnly` | plain date | `Date` | `Temporal.PlainDate` | `moment.Moment` | `DateTime` | `Date` | `Dayjs` | `LocalDate` |
-| `TimeOnly` | plain time | `string` | `Temporal.PlainTime` | `string` | `DateTime` | `string` | `string` | `LocalTime` |
-| `TimeSpan` | elapsed duration | `string` | `Temporal.Duration` | `moment.Duration` | `Duration` | `Duration` | `ReturnType<typeof dayjs.duration>` | `Duration` |
-| `NodaTime.Instant` | instant | `Date` | `Temporal.Instant` | `moment.Moment` | `DateTime` | `Date` | `Dayjs` | `Instant` |
-| `NodaTime.LocalDate` | plain date | `Date` | `Temporal.PlainDate` | `moment.Moment` | `DateTime` | `Date` | `Dayjs` | `LocalDate` |
-| `NodaTime.OffsetDate` | plain date | `Date` | `Temporal.PlainDate` | `moment.Moment` | `DateTime` | `Date` | `Dayjs` | `LocalDate` |
-| `NodaTime.LocalTime` | plain time | `string` | `Temporal.PlainTime` | `string` | `DateTime` | `string` | `string` | `LocalTime` |
-| `NodaTime.OffsetTime` | plain time | `string` | `Temporal.PlainTime` | `string` | `DateTime` | `string` | `string` | `LocalTime` |
-| `NodaTime.LocalDateTime` | plain date-time | `Date` | `Temporal.PlainDateTime` | `moment.Moment` | `DateTime` | `Date` | `Dayjs` | `LocalDateTime` |
-| `NodaTime.OffsetDateTime` | instant | `Date` | `Temporal.Instant` | `moment.Moment` | `DateTime` | `Date` | `Dayjs` | `Instant` |
-| `NodaTime.ZonedDateTime` | zoned date-time | `string` | `Temporal.ZonedDateTime` | `string` | `DateTime` | `string` | `string` | `ZonedDateTime` |
-| `NodaTime.Duration` | elapsed duration | `string` | `Temporal.Duration` | `moment.Duration` | `Duration` | `Duration` | `ReturnType<typeof dayjs.duration>` | `Duration` |
-| `NodaTime.Period` | calendar period | `string` | `Temporal.Duration` | `moment.Duration` | `Duration` | `Duration` | `ReturnType<typeof dayjs.duration>` | `Period` |
-| `NodaTime.YearMonth` | plain year-month | `string` | `Temporal.PlainYearMonth` | `string` | `DateTime` | `string` | `string` | `YearMonth` |
-| `NodaTime.AnnualDate` | plain month-day | `string` | `Temporal.PlainMonthDay` | `string` | `DateTime` | `string` | `string` | `MonthDay` |
+| C# type                   | Semantic kind    | Native `Date` | Temporal                  | Moment            | Luxon      | date-fns   | Day.js                              | js-joda         |
+| ------------------------- | ---------------- | ------------- | ------------------------- | ----------------- | ---------- | ---------- | ----------------------------------- | --------------- |
+| `DateTime`                | plain date-time  | `Date`        | `Temporal.PlainDateTime`  | `moment.Moment`   | `DateTime` | `Date`     | `Dayjs`                             | `LocalDateTime` |
+| `DateTimeOffset`          | instant          | `Date`        | `Temporal.Instant`        | `moment.Moment`   | `DateTime` | `Date`     | `Dayjs`                             | `Instant`       |
+| `DateOnly`                | plain date       | `Date`        | `Temporal.PlainDate`      | `moment.Moment`   | `DateTime` | `Date`     | `Dayjs`                             | `LocalDate`     |
+| `TimeOnly`                | plain time       | `string`      | `Temporal.PlainTime`      | `string`          | `DateTime` | `string`   | `string`                            | `LocalTime`     |
+| `TimeSpan`                | elapsed duration | `string`      | `Temporal.Duration`       | `moment.Duration` | `Duration` | `Duration` | `ReturnType<typeof dayjs.duration>` | `Duration`      |
+| `NodaTime.Instant`        | instant          | `Date`        | `Temporal.Instant`        | `moment.Moment`   | `DateTime` | `Date`     | `Dayjs`                             | `Instant`       |
+| `NodaTime.LocalDate`      | plain date       | `Date`        | `Temporal.PlainDate`      | `moment.Moment`   | `DateTime` | `Date`     | `Dayjs`                             | `LocalDate`     |
+| `NodaTime.OffsetDate`     | plain date       | `Date`        | `Temporal.PlainDate`      | `moment.Moment`   | `DateTime` | `Date`     | `Dayjs`                             | `LocalDate`     |
+| `NodaTime.LocalTime`      | plain time       | `string`      | `Temporal.PlainTime`      | `string`          | `DateTime` | `string`   | `string`                            | `LocalTime`     |
+| `NodaTime.OffsetTime`     | plain time       | `string`      | `Temporal.PlainTime`      | `string`          | `DateTime` | `string`   | `string`                            | `LocalTime`     |
+| `NodaTime.LocalDateTime`  | plain date-time  | `Date`        | `Temporal.PlainDateTime`  | `moment.Moment`   | `DateTime` | `Date`     | `Dayjs`                             | `LocalDateTime` |
+| `NodaTime.OffsetDateTime` | instant          | `Date`        | `Temporal.Instant`        | `moment.Moment`   | `DateTime` | `Date`     | `Dayjs`                             | `Instant`       |
+| `NodaTime.ZonedDateTime`  | zoned date-time  | `string`      | `Temporal.ZonedDateTime`  | `string`          | `DateTime` | `string`   | `string`                            | `ZonedDateTime` |
+| `NodaTime.Duration`       | elapsed duration | `string`      | `Temporal.Duration`       | `moment.Duration` | `Duration` | `Duration` | `ReturnType<typeof dayjs.duration>` | `Duration`      |
+| `NodaTime.Period`         | calendar period  | `string`      | `Temporal.Duration`       | `moment.Duration` | `Duration` | `Duration` | `ReturnType<typeof dayjs.duration>` | `Period`        |
+| `NodaTime.YearMonth`      | plain year-month | `string`      | `Temporal.PlainYearMonth` | `string`          | `DateTime` | `string`   | `string`                            | `YearMonth`     |
+| `NodaTime.AnnualDate`     | plain month-day  | `string`      | `Temporal.PlainMonthDay`  | `string`          | `DateTime` | `string`   | `string`                            | `MonthDay`      |
 
 `Duration` means elapsed time, while `Period` means calendar-relative units such as years and months. They remain separate schema kinds even when a frontend library represents both with the same runtime class. A `string` entry means that the selected library backend cannot faithfully represent that semantic kind.
 
@@ -497,14 +500,14 @@ The neutral annotation values include `Instant`, `PlainDate`, `PlainTime`, `Plai
 
 The `AdaskoTheBeAsT.Typewriter.Annotations` package also includes source-level attributes that recipes and templates recognise by simple name:
 
-| Attribute | Applies to | Purpose |
-|---|---|---|
+| Attribute                       | Applies to                     | Purpose                                                                                                                       |
+| ------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
 | `GenerateFrontendTypeAttribute` | Class, interface, enum, method | Marks a type or method for inclusion in frontend generation; optional `DllName` routes the type to a specific output assembly |
-| `FrontendRuntimeTypeAttribute` | Property, field, parameter | Overrides the semantic runtime type for a single member |
-| `FrontendNoTransformAttribute` | Property, field, parameter | Emits the value as a plain passthrough, skipping runtime transformation |
-| `AsStringAttribute` | Enum | Emits enum values as strings instead of numbers |
-| `LabelForEnumAttribute` | Field (enum member) | Attaches a human-readable label to an enum value |
-| `CustomNameAttribute` | Method | Overrides the generated frontend method name |
+| `FrontendRuntimeTypeAttribute`  | Property, field, parameter     | Overrides the semantic runtime type for a single member                                                                       |
+| `FrontendNoTransformAttribute`  | Property, field, parameter     | Emits the value as a plain passthrough, skipping runtime transformation                                                       |
+| `AsStringAttribute`             | Enum                           | Emits enum values as strings instead of numbers                                                                               |
+| `LabelForEnumAttribute`         | Field (enum member)            | Attaches a human-readable label to an enum value                                                                              |
+| `CustomNameAttribute`           | Method                         | Overrides the generated frontend method name                                                                                  |
 
 Typewriter matches these by simple name, so user-defined attributes with the same name in any namespace continue to work without the package.
 
@@ -541,15 +544,15 @@ If the selected date type is not global, update your template to emit the requir
 
 If your API returns ISO strings for `DateTime`, `DateTimeOffset`, `DateOnly`, or NodaTime values, pair generated models with [date-interceptors](https://github.com/adaskothebeast/date-interceptors) for runtime conversion. This is required when generated TypeScript uses `Date`, Day.js, Moment.js, Luxon, js-joda, Temporal, or another runtime date type, because JSON still arrives as strings and must be translated to the corresponding object type.
 
-| Target runtime | Date-time config | Date-only config | Time-only config | Type imports | Converter |
-| -------------- | ---------------- | ---------------- | ---------------- | ------------ | --------- |
-| Native `Date` | `dateType: "Date"`, `dateInitializer: "new Date()"` | `dateOnlyType: "Date"`, `dateOnlyInitializer: "new Date()"` | `timeOnlyType: "string"`, `timeOnlyInitializer: "\"00:00:00\""` | none | `@adaskothebeast/hierarchical-convert-to-date` |
-| date-fns | same as native `Date` | same as native `Date` | ISO `string` | none | `@adaskothebeast/hierarchical-convert-to-date-fns` |
-| Day.js | `Dayjs`, `dayjs()` | `Dayjs`, `dayjs()` | ISO `string` | `import type { Dayjs } from 'dayjs';` | `@adaskothebeast/hierarchical-convert-to-dayjs` |
-| Moment.js | `Moment`, `moment()` | `Moment`, `moment()` | ISO `string` | `import type { Moment } from 'moment';` | `@adaskothebeast/hierarchical-convert-to-moment` |
-| Luxon | `DateTime`, `DateTime.now()` | `DateTime`, `DateTime.now().startOf('day')` | ISO `string` | `import type { DateTime } from 'luxon';` | `@adaskothebeast/hierarchical-convert-to-luxon` |
-| js-joda | `ZonedDateTime`, `ZonedDateTime.now()` or `LocalDateTime`, `LocalDateTime.now()` | `LocalDate`, `LocalDate.now()` | `LocalTime`, `LocalTime.now()` | `import type { LocalDate, LocalTime, ZonedDateTime } from '@js-joda/core';` | `@adaskothebeast/hierarchical-convert-to-js-joda` |
-| Temporal | `Temporal.Instant`, `Temporal.Now.instant()` or `Temporal.PlainDateTime`, `Temporal.Now.plainDateTimeISO()` | `Temporal.PlainDate`, `Temporal.Now.plainDateISO()` | `Temporal.PlainTime`, `Temporal.Now.plainTimeISO()` | `import { Temporal } from '@js-temporal/polyfill';` | `@adaskothebeast/hierarchical-convert-to-temporal` |
+| Target runtime | Date-time config                                                                                            | Date-only config                                            | Time-only config                                                | Type imports                                                                | Converter                                          |
+| -------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------- |
+| Native `Date`  | `dateType: "Date"`, `dateInitializer: "new Date()"`                                                         | `dateOnlyType: "Date"`, `dateOnlyInitializer: "new Date()"` | `timeOnlyType: "string"`, `timeOnlyInitializer: "\"00:00:00\""` | none                                                                        | `@adaskothebeast/hierarchical-convert-to-date`     |
+| date-fns       | same as native `Date`                                                                                       | same as native `Date`                                       | ISO `string`                                                    | none                                                                        | `@adaskothebeast/hierarchical-convert-to-date-fns` |
+| Day.js         | `Dayjs`, `dayjs()`                                                                                          | `Dayjs`, `dayjs()`                                          | ISO `string`                                                    | `import type { Dayjs } from 'dayjs';`                                       | `@adaskothebeast/hierarchical-convert-to-dayjs`    |
+| Moment.js      | `Moment`, `moment()`                                                                                        | `Moment`, `moment()`                                        | ISO `string`                                                    | `import type { Moment } from 'moment';`                                     | `@adaskothebeast/hierarchical-convert-to-moment`   |
+| Luxon          | `DateTime`, `DateTime.now()`                                                                                | `DateTime`, `DateTime.now().startOf('day')`                 | ISO `string`                                                    | `import type { DateTime } from 'luxon';`                                    | `@adaskothebeast/hierarchical-convert-to-luxon`    |
+| js-joda        | `ZonedDateTime`, `ZonedDateTime.now()` or `LocalDateTime`, `LocalDateTime.now()`                            | `LocalDate`, `LocalDate.now()`                              | `LocalTime`, `LocalTime.now()`                                  | `import type { LocalDate, LocalTime, ZonedDateTime } from '@js-joda/core';` | `@adaskothebeast/hierarchical-convert-to-js-joda`  |
+| Temporal       | `Temporal.Instant`, `Temporal.Now.instant()` or `Temporal.PlainDateTime`, `Temporal.Now.plainDateTimeISO()` | `Temporal.PlainDate`, `Temporal.Now.plainDateISO()`         | `Temporal.PlainTime`, `Temporal.Now.plainTimeISO()`             | `import { Temporal } from '@js-temporal/polyfill';`                         | `@adaskothebeast/hierarchical-convert-to-temporal` |
 
 ```bash
 # Native Date
@@ -628,14 +631,14 @@ approvedAt: ZonedDateTime | null;
 
 Recommended semantic mappings:
 
-| C# or NodaTime type | Recommended TypeScript shape | Notes |
-| ------------------- | ---------------------------- | ----- |
-| `DateTime`, `DateTimeOffset`, `NodaTime.Instant`, `NodaTime.OffsetDateTime`, `NodaTime.ZonedDateTime` | `Date`, `Temporal.Instant`, Luxon `DateTime`, Day.js `Dayjs`, or js-joda `Instant`/`ZonedDateTime` | Use a real date-time object when clients compare, format, or calculate with the value. Use [date-interceptors](https://github.com/adaskothebeast/date-interceptors) to convert JSON strings at runtime. |
-| `DateOnly`, `NodaTime.LocalDate`, `NodaTime.OffsetDate` | ISO `string`, `Temporal.PlainDate`, or js-joda `LocalDate` | Avoid native `Date` for pure dates if timezone shifts matter. |
-| `TimeOnly`, `NodaTime.LocalTime`, `NodaTime.OffsetTime` | ISO `string`, `Temporal.PlainTime`, or js-joda `LocalTime` | JavaScript has no native time-only type. |
-| `NodaTime.LocalDateTime` | `Temporal.PlainDateTime`, Luxon `DateTime`, js-joda `LocalDateTime`, or ISO `string` | Use `output.dateType` for this local date-time type. |
-| `TimeSpan`, `NodaTime.Duration` | ISO duration `string`, `Temporal.Duration`, js-joda `Duration`, or a numeric convention such as milliseconds | Pick one wire format and document it. `Duration` means elapsed time. |
-| `NodaTime.Period` | ISO period `string`, `Temporal.Duration`, js-joda `Period`, or date-fns `Duration` | `Period` is calendar-based, such as 1 month and 3 days, so keep it distinct from elapsed `Duration`. |
+| C# or NodaTime type                                                                                   | Recommended TypeScript shape                                                                                 | Notes                                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DateTime`, `DateTimeOffset`, `NodaTime.Instant`, `NodaTime.OffsetDateTime`, `NodaTime.ZonedDateTime` | `Date`, `Temporal.Instant`, Luxon `DateTime`, Day.js `Dayjs`, or js-joda `Instant`/`ZonedDateTime`           | Use a real date-time object when clients compare, format, or calculate with the value. Use [date-interceptors](https://github.com/adaskothebeast/date-interceptors) to convert JSON strings at runtime. |
+| `DateOnly`, `NodaTime.LocalDate`, `NodaTime.OffsetDate`                                               | ISO `string`, `Temporal.PlainDate`, or js-joda `LocalDate`                                                   | Avoid native `Date` for pure dates if timezone shifts matter.                                                                                                                                           |
+| `TimeOnly`, `NodaTime.LocalTime`, `NodaTime.OffsetTime`                                               | ISO `string`, `Temporal.PlainTime`, or js-joda `LocalTime`                                                   | JavaScript has no native time-only type.                                                                                                                                                                |
+| `NodaTime.LocalDateTime`                                                                              | `Temporal.PlainDateTime`, Luxon `DateTime`, js-joda `LocalDateTime`, or ISO `string`                         | Use `output.dateType` for this local date-time type.                                                                                                                                                    |
+| `TimeSpan`, `NodaTime.Duration`                                                                       | ISO duration `string`, `Temporal.Duration`, js-joda `Duration`, or a numeric convention such as milliseconds | Pick one wire format and document it. `Duration` means elapsed time.                                                                                                                                    |
+| `NodaTime.Period`                                                                                     | ISO period `string`, `Temporal.Duration`, js-joda `Period`, or date-fns `Duration`                           | `Period` is calendar-based, such as 1 month and 3 days, so keep it distinct from elapsed `Duration`.                                                                                                    |
 
 For date types that need an import, emit the import only when the current class actually has date fields or properties:
 
@@ -871,23 +874,23 @@ For lossless high-precision values, the API must serialize the decimal as a JSON
 
 ### 🌱 Environment variables
 
-| Variable                              | Overrides                                      |
-| ------------------------------------- | ---------------------------------------------- |
-| `TYPEWRITER_INPUT_EXTENSIONS`         | `inputExtensions` (comma/semicolon/space list) |
-| `TYPEWRITER_DEFAULT_TARGET_FRAMEWORK` | `defaultTargetFramework`                       |
-| `TYPEWRITER_OUTPUT_NEWLINE`           | `output.newline`                               |
-| `TYPEWRITER_OUTPUT_DATE_LIBRARY`      | `output.dateLibrary`                           |
-| `TYPEWRITER_OUTPUT_DATE_TYPE`         | `output.dateType`                              |
-| `TYPEWRITER_OUTPUT_DATE_INITIALIZER`  | `output.dateInitializer`                       |
-| `TYPEWRITER_OUTPUT_DATE_ONLY_TYPE`    | `output.dateOnlyType`                          |
-| `TYPEWRITER_OUTPUT_DATE_ONLY_INITIALIZER` | `output.dateOnlyInitializer`               |
-| `TYPEWRITER_OUTPUT_TIME_ONLY_TYPE`    | `output.timeOnlyType`                          |
-| `TYPEWRITER_OUTPUT_TIME_ONLY_INITIALIZER` | `output.timeOnlyInitializer`               |
-| `TYPEWRITER_OUTPUT_GUID_TYPE`         | `output.guidType`                              |
-| `TYPEWRITER_OUTPUT_GUID_INITIALIZER`  | `output.guidInitializer`                       |
-| `TYPEWRITER_OUTPUT_DECIMAL_TYPE`      | `output.decimalType`                           |
-| `TYPEWRITER_OUTPUT_DECIMAL_INITIALIZER` | `output.decimalInitializer`                   |
-| `TYPEWRITER_FAIL_ON_WARNING`          | `diagnostics.failOnWarning` (`true`/`1`/`yes`) |
+| Variable                                  | Overrides                                      |
+| ----------------------------------------- | ---------------------------------------------- |
+| `TYPEWRITER_INPUT_EXTENSIONS`             | `inputExtensions` (comma/semicolon/space list) |
+| `TYPEWRITER_DEFAULT_TARGET_FRAMEWORK`     | `defaultTargetFramework`                       |
+| `TYPEWRITER_OUTPUT_NEWLINE`               | `output.newline`                               |
+| `TYPEWRITER_OUTPUT_DATE_LIBRARY`          | `output.dateLibrary`                           |
+| `TYPEWRITER_OUTPUT_DATE_TYPE`             | `output.dateType`                              |
+| `TYPEWRITER_OUTPUT_DATE_INITIALIZER`      | `output.dateInitializer`                       |
+| `TYPEWRITER_OUTPUT_DATE_ONLY_TYPE`        | `output.dateOnlyType`                          |
+| `TYPEWRITER_OUTPUT_DATE_ONLY_INITIALIZER` | `output.dateOnlyInitializer`                   |
+| `TYPEWRITER_OUTPUT_TIME_ONLY_TYPE`        | `output.timeOnlyType`                          |
+| `TYPEWRITER_OUTPUT_TIME_ONLY_INITIALIZER` | `output.timeOnlyInitializer`                   |
+| `TYPEWRITER_OUTPUT_GUID_TYPE`             | `output.guidType`                              |
+| `TYPEWRITER_OUTPUT_GUID_INITIALIZER`      | `output.guidInitializer`                       |
+| `TYPEWRITER_OUTPUT_DECIMAL_TYPE`          | `output.decimalType`                           |
+| `TYPEWRITER_OUTPUT_DECIMAL_INITIALIZER`   | `output.decimalInitializer`                    |
+| `TYPEWRITER_FAIL_ON_WARNING`              | `diagnostics.failOnWarning` (`true`/`1`/`yes`) |
 
 ---
 
@@ -1158,33 +1161,33 @@ The built-in Web API helpers parse `Route` and `RoutePrefix` attribute values, i
 
 The `Settings` object passed to the template constructor keeps the original API so old templates compile unchanged. Current wiring status:
 
-| Setting                                                                                                     | Status | Notes                                                                                                           |
-| ----------------------------------------------------------------------------------------------------------- | :----: | --------------------------------------------------------------------------------------------------------------- |
-| `OutputExtension`                                                                                           |   ✅    | Default `.ts`                                                                                                   |
-| `OutputFilenameFactory`                                                                                     |   ✅    | Per-source fan-out and no-match suppression supported                                                           |
-| `OutputDirectory`                                                                                           |   ✅    | Relative paths resolve against the template location                                                            |
-| `SingleFileMode("name.ts")`                                                                                 |   ✅    | Renders the whole template into one file                                                                        |
-| `UseStringLiteralCharacter('\'')`                                                                           |   ✅    | Affects generated string literals and defaults; defaults from `output.quoteStyle` in `typewriter.json`          |
-| `UseDateLibrary(DateLibrary.Temporal)`                                                                      |   ✅    | Selects one coherent semantic type, initializer, and import profile; inspect `DateLibraryImportsGeneration` for imports |
-| `UseDateType("Date")`                                                                                       |   ✅    | Overrides date-time types such as `DateTime`, `DateTimeOffset`, and NodaTime `Instant`                          |
-| `UseDateInitializer("new Date()")`                                                                          |   ✅    | Overrides the generated TypeScript initializer for non-null date-time defaults                                   |
-| `UseDateOnlyType("Date")`                                                                                   |   ✅    | Overrides date-only types such as `DateOnly` and NodaTime `LocalDate`                                           |
-| `UseDateOnlyInitializer("new Date()")`                                                                      |   ✅    | Overrides the generated TypeScript initializer for non-null date-only defaults                                   |
-| `UseTimeOnlyType("string")`                                                                                 |   ✅    | Overrides time-only types such as `TimeOnly` and NodaTime `LocalTime`                                           |
-| `UseTimeOnlyInitializer("\"00:00:00\"")`                                                                    |   ✅    | Overrides the generated TypeScript initializer for non-null time-only defaults                                   |
-| `UseGuidType("string")`                                                                                     |   ✅    | Overrides the generated TypeScript type for C# `Guid`, for example `uuid` or `UUID`                             |
-| `UseGuidInitializer("auto")`                                                                                |   ✅    | Overrides non-null `Guid` defaults; `auto` understands string and `Uint8Array` mappings                          |
-| `UseDecimalType("number")`                                                                                  |   ✅    | Overrides the generated TypeScript type for C# `decimal`, for example `Decimal` from `decimal.js`               |
-| `UseDecimalInitializer("auto")`                                                                             |   ✅    | Overrides non-null decimal defaults; `auto` emits `0` or constructs the configured decimal type                 |
-| `TemplatePath`                                                                                              |   ✅    | Full path of the executing template                                                                             |
-| `Log` (`ILog`)                                                                                              |   ✅    | Messages surface as `TW0007` diagnostics in CLI output and editors                                              |
-| `IncludeProject(name)`                                                                                      |   ✅    | Merges the named workspace project (and its references) into the template's code model, in addition to the current project; unknown names raise `TW0009` |
-| `IncludeCurrentProject()` / `IncludeReferencedProjects()` / `IncludeAllProjects()`                          |   ♻️    | Accepted for compatibility; the current project and its references are always included, `--all-projects` controls full workspace scope |
-| `DisableStrictNullGeneration()`                                                                             |   ✅    | Defaults from `output.strictNull` in `typewriter.json`; calling this in the template overrides it               |
-| `DisableUtf8BomGeneration()` / `Utf8BomGeneration`                                                          |   ✅    | Defaults from `output.encoding` in `typewriter.json`; the template override wins per file                       |
-| `PartialRenderingMode`                                                                                      |   🚧    | Accepted but not wired yet                                                                                      |
-| `SolutionFullName`                                                                                          |   ✅    | Populated from the resolved workspace (solution or folder path)                                                 |
-| `SkipAddingGeneratedFilesToProject`                                                                         |   ➖    | Obsolete — SDK-style projects include files automatically                                                       |
+| Setting                                                                            | Status | Notes                                                                                                                                                    |
+| ---------------------------------------------------------------------------------- | :----: | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OutputExtension`                                                                  |   ✅    | Default `.ts`                                                                                                                                            |
+| `OutputFilenameFactory`                                                            |   ✅    | Per-source fan-out and no-match suppression supported                                                                                                    |
+| `OutputDirectory`                                                                  |   ✅    | Relative paths resolve against the template location                                                                                                     |
+| `SingleFileMode("name.ts")`                                                        |   ✅    | Renders the whole template into one file                                                                                                                 |
+| `UseStringLiteralCharacter('\'')`                                                  |   ✅    | Affects generated string literals and defaults; defaults from `output.quoteStyle` in `typewriter.json`                                                   |
+| `UseDateLibrary(DateLibrary.Temporal)`                                             |   ✅    | Selects one coherent semantic type, initializer, and import profile; inspect `DateLibraryImportsGeneration` for imports                                  |
+| `UseDateType("Date")`                                                              |   ✅    | Overrides date-time types such as `DateTime`, `DateTimeOffset`, and NodaTime `Instant`                                                                   |
+| `UseDateInitializer("new Date()")`                                                 |   ✅    | Overrides the generated TypeScript initializer for non-null date-time defaults                                                                           |
+| `UseDateOnlyType("Date")`                                                          |   ✅    | Overrides date-only types such as `DateOnly` and NodaTime `LocalDate`                                                                                    |
+| `UseDateOnlyInitializer("new Date()")`                                             |   ✅    | Overrides the generated TypeScript initializer for non-null date-only defaults                                                                           |
+| `UseTimeOnlyType("string")`                                                        |   ✅    | Overrides time-only types such as `TimeOnly` and NodaTime `LocalTime`                                                                                    |
+| `UseTimeOnlyInitializer("\"00:00:00\"")`                                           |   ✅    | Overrides the generated TypeScript initializer for non-null time-only defaults                                                                           |
+| `UseGuidType("string")`                                                            |   ✅    | Overrides the generated TypeScript type for C# `Guid`, for example `uuid` or `UUID`                                                                      |
+| `UseGuidInitializer("auto")`                                                       |   ✅    | Overrides non-null `Guid` defaults; `auto` understands string and `Uint8Array` mappings                                                                  |
+| `UseDecimalType("number")`                                                         |   ✅    | Overrides the generated TypeScript type for C# `decimal`, for example `Decimal` from `decimal.js`                                                        |
+| `UseDecimalInitializer("auto")`                                                    |   ✅    | Overrides non-null decimal defaults; `auto` emits `0` or constructs the configured decimal type                                                          |
+| `TemplatePath`                                                                     |   ✅    | Full path of the executing template                                                                                                                      |
+| `Log` (`ILog`)                                                                     |   ✅    | Messages surface as `TW0007` diagnostics in CLI output and editors                                                                                       |
+| `IncludeProject(name)`                                                             |   ✅    | Merges the named workspace project (and its references) into the template's code model, in addition to the current project; unknown names raise `TW0009` |
+| `IncludeCurrentProject()` / `IncludeReferencedProjects()` / `IncludeAllProjects()` |   ♻️    | Accepted for compatibility; the current project and its references are always included, `--all-projects` controls full workspace scope                   |
+| `DisableStrictNullGeneration()`                                                    |   ✅    | Defaults from `output.strictNull` in `typewriter.json`; calling this in the template overrides it                                                        |
+| `DisableUtf8BomGeneration()` / `Utf8BomGeneration`                                 |   ✅    | Defaults from `output.encoding` in `typewriter.json`; the template override wins per file                                                                |
+| `PartialRenderingMode`                                                             |   🚧    | Accepted but not wired yet                                                                                                                               |
+| `SolutionFullName`                                                                 |   ✅    | Populated from the resolved workspace (solution or folder path)                                                                                          |
+| `SkipAddingGeneratedFilesToProject`                                                |   ➖    | Obsolete — SDK-style projects include files automatically                                                                                                |
 
 Legend: ✅ working · ♻️ superseded by CLI/config · 🚧 accepted no-op (tracked) · ➖ intentionally dropped
 
@@ -1270,18 +1273,18 @@ Feature samples and issue regressions in [`samples/`](samples) ship with checked
 
 Issue regression samples:
 
-| Sample                                   | Regression covered                                                       |
-| ---------------------------------------- | ------------------------------------------------------------------------ |
-| [`issue66`](samples/issue66)             | Conflicting versions of the same referenced package                      |
-| [`issue67`](samples/issue67)             | Projects that use source generators                                      |
-| [`issue68`](samples/issue68)             | Implicit-using isolation across referenced projects                      |
-| [`issue69`](samples/issue69)             | Old-style non-SDK .NET Framework project loading                          |
-| [`issue69v2`](samples/issue69v2)         | Legacy imported project shapes and captured design-time build failures   |
-| [`issue74`](samples/issue74)             | Types from transitively referenced projects                              |
-| [`issue75`](samples/issue75)             | Localized resources and satellite assemblies                             |
-| [`issue81`](samples/issue81)             | Cyclic metadata graphs without stack overflow                            |
-| [`issue90`](samples/issue90)             | Closed generic arguments in properties and collections                   |
-| [`issue96`](samples/issue96)             | Cross-file record inheritance                                            |
+| Sample                           | Regression covered                                                     |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| [`issue66`](samples/issue66)     | Conflicting versions of the same referenced package                    |
+| [`issue67`](samples/issue67)     | Projects that use source generators                                    |
+| [`issue68`](samples/issue68)     | Implicit-using isolation across referenced projects                    |
+| [`issue69`](samples/issue69)     | Old-style non-SDK .NET Framework project loading                       |
+| [`issue69v2`](samples/issue69v2) | Legacy imported project shapes and captured design-time build failures |
+| [`issue74`](samples/issue74)     | Types from transitively referenced projects                            |
+| [`issue75`](samples/issue75)     | Localized resources and satellite assemblies                           |
+| [`issue81`](samples/issue81)     | Cyclic metadata graphs without stack overflow                          |
+| [`issue90`](samples/issue90)     | Closed generic arguments in properties and collections                 |
+| [`issue96`](samples/issue96)     | Cross-file record inheritance                                          |
 
 ---
 
@@ -1394,9 +1397,9 @@ dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj --config
 | Visual Studio 2026 VSIX (AMD64 + ARM64)                              |     ✅     |
 | JetBrains Rider frontend plugin                                      |     ✅     |
 | Old-template compatibility hardening                                 | 🚧 ongoing |
-| NuGet publishing for CLI and language-server tools                    |     ✅     |
-| GitHub release assets for VS Code, Visual Studio, and Rider           |     ✅     |
-| Visual Studio / VS Code / JetBrains Marketplace publishing            | 📋 planned |
+| NuGet publishing for CLI and language-server tools                   |     ✅     |
+| GitHub release assets for VS Code, Visual Studio, and Rider          |     ✅     |
+| Visual Studio / VS Code / JetBrains Marketplace publishing           | 📋 planned |
 
 - 📗 [`implemented.md`](implemented.md) — everything that is done, in detail
 - 📙 [`to_implement.md`](to_implement.md) — roadmap and backlog
@@ -1405,6 +1408,10 @@ dotnet build src/Typewriter.VisualStudio/Typewriter.VisualStudio.csproj --config
 ---
 
 ## Changelog
+
+### 4.9.0
+
+- additional release to fix publish error
 
 ### 4.8.0
 

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.adaskothebeast.typewriter
 pluginName=Typewriter
-pluginVersion=4.8.0
+pluginVersion=4.9.0
 pluginSinceBuild=261
 platformVersion=2026.1.2
 

--- a/src/Typewriter.LanguageServer/LanguageServerHost.cs
+++ b/src/Typewriter.LanguageServer/LanguageServerHost.cs
@@ -100,7 +100,7 @@ internal sealed class LanguageServerHost
             serverInfo = new
             {
                 name = "Typewriter Language Server",
-                version = "4.8.0",
+                version = "4.9.0",
             },
         };
 

--- a/src/Typewriter.VisualStudio/TypewriterPackage.cs
+++ b/src/Typewriter.VisualStudio/TypewriterPackage.cs
@@ -10,7 +10,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 namespace Typewriter.VisualStudio;
 
 [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.8.0")]
+[InstalledProductRegistration(productName: "Typewriter", productDetails: "Generates TypeScript from C# Typewriter templates.", productId: "4.9.0")]
 [ProvideMenuResource(resourceID: "Menus.ctmenu", version: 1)]
 [ProvideOptionPage(pageType: typeof(TypewriterOptions), categoryName: "Typewriter", pageName: "General", categoryResourceID: 0, pageNameResourceID: 0, supportsAutomation: true)]
 [ProvideAutoLoad(cmdUiContextGuid: VSConstants.UICONTEXT.SolutionExists_string, flags: PackageAutoLoadFlags.BackgroundLoad)]

--- a/src/Typewriter.VisualStudio/source.extension.vsixmanifest
+++ b/src/Typewriter.VisualStudio/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.8.0" Language="en-US" Publisher="AdaskoTheBeAsT" />
+    <Identity Id="AdaskoTheBeAsT.Typewriter.VisualStudio" Version="4.9.0" Language="en-US" Publisher="AdaskoTheBeAsT" />
     <DisplayName>Typewriter</DisplayName>
     <Description xml:space="preserve">Generate TypeScript from C# Typewriter templates.</Description>
     <Tags>Typewriter;TypeScript;C#;Code Generation</Tags>

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typewriter-vscode",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typewriter-vscode",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^10.0.1"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "typewriter-vscode",
   "displayName": "Typewriter",
   "description": "VS Code adapter for Typewriter .tst templates.",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "publisher": "adaskothebeast",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
This pull request updates the Typewriter project to version 4.9.0 across all relevant packages and documentation. The main purpose of this release is to fix a publish error encountered in the previous version. The version bump is reflected in the build configuration, package manifests, and CI workflow. Additionally, the changelog and related documentation are updated to reference the new version.

Most important changes:

**Version Bump and Packaging**

* Updated all version numbers from `4.8.0` to `4.9.0` in build configuration files (`Directory.Build.props`, `rider/gradle.properties`, `.github/workflows/ci.yml`, `src/Typewriter.VisualStudio/source.extension.vsixmanifest`, `src/Typewriter.VisualStudio/TypewriterPackage.cs`, `vscode/package.json`, `vscode/package-lock.json`, `src/Typewriter.LanguageServer/LanguageServerHost.cs`). [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL14-R14) [[2]](diffhunk://#diff-9a9ceaffbadf59cdb679b33f9b046dc11f5547bdd75a197dad5b74030dc25966L3-R3) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL97-R98) [[4]](diffhunk://#diff-e51f2f3de5be31955cb798c4ba2db57f3de15f96ce94f80efb7c5747ef3974dfL4-R4) [[5]](diffhunk://#diff-0fe60420e46f2d750c12fb98ec460ddaa6982b52270f65451e0e4943223ebc4aL13-R13) [[6]](diffhunk://#diff-99d7a3c2c2975fcaf8184c4639922f5ef6c915610b6f8e15ffa8fb8b329828d8L5-R5) [[7]](diffhunk://#diff-a80e103c30d6e330f516b0e27b1072a48509d32373887ecbc9768fd09eb7b9b7L3-R9) [[8]](diffhunk://#diff-35017bf2deb6f8fcfcad9110fc8c9a9402caddc668c2d3e352290ab57cb65521L103-R103)
* Updated CI workflow to collect and package the new versioned artifacts.

**Documentation Updates**

* Added a new changelog entry for version 4.9.0 in `README.md`, noting it as a release to fix a publish error. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1412-R1415)
* Updated all references and tables in `README.md` to ensure consistency and clarity, including minor formatting adjustments. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R47) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L159-R162) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L379-R382) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L444-R447) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L461-R464) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L501-R504) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L545-R548) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L632-R635) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L875-R878) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1162-R1165) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1274-R1277)

No functional code changes are included; this is a maintenance release to ensure proper publishing and version consistency.